### PR TITLE
Refactor parser tests to use assertj

### DIFF
--- a/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
-import static org.junit.jupiter.api.Assertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
+import edu.hm.hafner.analysis.assertj.IssuesAssert;
 
 /**
  * Tests the class {@link GhsMultiParser}.
@@ -24,25 +25,40 @@ public class GhsMultiParserTest extends ParserTester {
     @Test
     public void parseMultiLine() throws IOException {
         Issues warnings = new GhsMultiParser().parse(openFile());
-
-        assertEquals(3, warnings.size());
+        IssuesAssert.assertThat(warnings).hasSize(3);
 
         Iterator<Issue> iterator = warnings.iterator();
-        Issue annotation = iterator.next();
-        checkWarning(annotation, 37,
-                "transfer of control bypasses initialization of:\n            variable \"CF_TRY_FLAG\" (declared at line 42)\n            variable \"CF_EXCEPTION_NOT_CAUGHT\" (declared at line 42)\n        CF_TRY_CHECK_EX(ex2);",
-                "/maindir/tests/TestCase_0101.cpp\"", TYPE, "#546-D",
-                Priority.NORMAL);
-        annotation = iterator.next();
-        checkWarning(annotation, 29,
-                "label\n          \"CF_TRY_LABELex1\" was declared but never referenced\n     CF_TRY_EX(ex1)",
-                "/maindir/tests/TestCase_0101.cpp\"", TYPE, "#177-D",
-                Priority.NORMAL);
-        annotation = iterator.next();
-        checkWarning(annotation, 9,
-                "extra\n          \";\" ignored\n  TEST_DSS( CHECK_4TH_CONFIG_DATA, 18, 142, 'F');",
-                "/maindir/tests/TestCase_1601.cpp\"", TYPE, "#381-D",
-                Priority.NORMAL);
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory("#546-D")
+                .hasLineStart(37)
+                .hasLineEnd(37)
+                .hasMessage("transfer of control bypasses initialization of:\n            variable \"CF_TRY_FLAG\" (declared at line 42)\n            variable \"CF_EXCEPTION_NOT_CAUGHT\" (declared at line 42)\n        CF_TRY_CHECK_EX(ex2);")
+                .hasFileName("/maindir/tests/TestCase_0101.cpp\"")
+                .hasType(TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory("#177-D")
+                .hasLineStart(29)
+                .hasLineEnd(29)
+                .hasMessage("label\n          \"CF_TRY_LABELex1\" was declared but never referenced\n     CF_TRY_EX(ex1)")
+                .hasFileName("/maindir/tests/TestCase_0101.cpp\"")
+                .hasType(TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory("#381-D")
+                .hasLineStart(9)
+                .hasLineEnd(9)
+                .hasMessage("extra\n          \";\" ignored\n  TEST_DSS( CHECK_4TH_CONFIG_DATA, 18, 142, 'F');")
+                .hasFileName("/maindir/tests/TestCase_1601.cpp\"")
+                .hasType(TYPE);
+        softly.assertAll();
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
@@ -38,7 +38,6 @@ public class GhsMultiParserTest extends ParserTester {
                 .hasMessage("transfer of control bypasses initialization of:\n            variable \"CF_TRY_FLAG\" (declared at line 42)\n            variable \"CF_EXCEPTION_NOT_CAUGHT\" (declared at line 42)\n        CF_TRY_CHECK_EX(ex2);")
                 .hasFileName("/maindir/tests/TestCase_0101.cpp\"")
                 .hasType(TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -48,7 +47,6 @@ public class GhsMultiParserTest extends ParserTester {
                 .hasMessage("label\n          \"CF_TRY_LABELex1\" was declared but never referenced\n     CF_TRY_EX(ex1)")
                 .hasFileName("/maindir/tests/TestCase_0101.cpp\"")
                 .hasType(TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)

--- a/src/test/java/edu/hm/hafner/analysis/parser/GnatParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GnatParserTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
-import static org.junit.jupiter.api.Assertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
+import edu.hm.hafner.analysis.assertj.IssuesAssert;
 
 /**
  * Tests the class {@link GnatParser}.
@@ -25,101 +26,120 @@ public class GnatParserTest extends ParserTester {
     @Test
     public void testWarningsParser() throws IOException {
         Issues warnings = new GnatParser().parse(openFile());
-
-        assertEquals(9, warnings.size());
+        IssuesAssert.assertThat(warnings).hasSize(9);
 
         Iterator<Issue> iterator = warnings.iterator();
-        Issue annotation = iterator.next();
+        SoftAssertions softly = new SoftAssertions();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/class_utilities.adb:402:23:
         // warning: call to obsolescent procedure "Very_Verbose" declared at
         // debug.ads:59
-        checkWarning(
-                annotation,
-                402,
-                "call to obsolescent procedure \"Very_Verbose\" declared at debug.ads:59",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/class_utilities.adb",
-                TYPE, GNAT_WARNING, Priority.NORMAL);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(GNAT_WARNING)
+                .hasLineStart(402)
+                .hasLineEnd(402)
+                .hasMessage("call to obsolescent procedure \"Very_Verbose\" declared at debug.ads:59")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/class_utilities.adb")
+                .hasType(TYPE);
+        softly.assertAll();
+
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/iml-interfaces-cfg.adb:63:14:
         // warning: variable "E" is not referenced
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                63,
-                "variable \"E\" is not referenced",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/iml-interfaces-cfg.adb",
-                TYPE, GNAT_WARNING, Priority.NORMAL);
+       softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(GNAT_WARNING)
+                .hasLineStart(63)
+                .hasLineEnd(63)
+                .hasMessage("variable \"E\" is not referenced")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/iml-interfaces-cfg.adb")
+                .hasType(TYPE);
+        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/pointsto/andersen_results.adb:96:80:
         // (style) this line is too long
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                96,
-                "this line is too long",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/pointsto/andersen_results.adb",
-                TYPE, "GNAT style", Priority.LOW);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.LOW)
+                .hasCategory("GNAT style")
+                .hasLineStart(96)
+                .hasLineEnd(96)
+                .hasMessage("this line is too long")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/pointsto/andersen_results.adb")
+                .hasType(TYPE);
+        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/generated/ada_delta_constraints.adb:3:06:
         // warning: redundant with clause in body
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                3,
-                "redundant with clause in body",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/generated/ada_delta_constraints.adb",
-                TYPE, GNAT_WARNING, Priority.NORMAL);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(GNAT_WARNING)
+                .hasLineStart(3)
+                .hasLineEnd(3)
+                .hasMessage("redundant with clause in body")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/generated/ada_delta_constraints.adb")
+                .hasType(TYPE);
+        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/array_tables.adb:97:07:
         // warning: variable "Dummy_Empty_Array_Item" is read but never assigned
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                97,
-                "variable \"Dummy_Empty_Array_Item\" is read but never assigned",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/array_tables.adb",
-                TYPE, GNAT_WARNING, Priority.NORMAL);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(GNAT_WARNING)
+                .hasLineStart(97)
+                .hasLineEnd(97)
+                .hasMessage("variable \"Dummy_Empty_Array_Item\" is read but never assigned")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/array_tables.adb")
+                .hasType(TYPE);
+        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/graph_algorithms-generic_explorers.adb:63:14:
         // warning: "C" is not modified, could be declared constant
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                63,
-                "\"C\" is not modified, could be declared constant",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/graph_algorithms-generic_explorers.adb",
-                TYPE, GNAT_WARNING, Priority.NORMAL);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(GNAT_WARNING)
+                .hasLineStart(63)
+                .hasLineEnd(63)
+                .hasMessage("\"C\" is not modified, could be declared constant")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/graph_algorithms-generic_explorers.adb")
+                .hasType(TYPE);
+        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/process_data.adb:257:49:
         // (style) bad casing of "False" declared in Standard
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                257,
-                "bad casing of \"False\" declared in Standard",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/process_data.adb",
-                TYPE, "GNAT style", Priority.LOW);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.LOW)
+                .hasCategory("GNAT style")
+                .hasLineStart(257)
+                .hasLineEnd(257)
+                .hasMessage("bad casing of \"False\" declared in Standard")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/process_data.adb")
+                .hasType(TYPE);
+        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb:23:35:
         // error: binary operator expected
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                23,
-                "binary operator expected",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb",
-                TYPE, "GNAT error", Priority.HIGH);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("GNAT error")
+                .hasLineStart(23)
+                .hasLineEnd(23)
+                .hasMessage("binary operator expected")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb")
+                .hasType(TYPE);
+        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb:23:36:
         // error: identifier cannot start with underline
-        annotation = iterator.next();
-        checkWarning(
-                annotation,
-                23,
-                "identifier cannot start with underline",
-                "/home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb",
-                TYPE, "GNAT error", Priority.HIGH);
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("GNAT error")
+                .hasLineStart(23)
+                .hasLineEnd(23)
+                .hasMessage("identifier cannot start with underline")
+                .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb")
+                .hasType(TYPE);
+        softly.assertAll();
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/GnatParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GnatParserTest.java
@@ -42,7 +42,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("call to obsolescent procedure \"Very_Verbose\" declared at debug.ads:59")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/class_utilities.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/iml-interfaces-cfg.adb:63:14:
@@ -55,7 +54,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("variable \"E\" is not referenced")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/utilities/iml-interfaces-cfg.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/pointsto/andersen_results.adb:96:80:
         // (style) this line is too long
@@ -67,7 +65,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("this line is too long")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/pointsto/andersen_results.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/generated/ada_delta_constraints.adb:3:06:
         // warning: redundant with clause in body
@@ -79,7 +76,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("redundant with clause in body")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/generated/ada_delta_constraints.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/array_tables.adb:97:07:
         // warning: variable "Dummy_Empty_Array_Item" is read but never assigned
@@ -91,7 +87,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("variable \"Dummy_Empty_Array_Item\" is read but never assigned")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/array_tables.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/graph_algorithms-generic_explorers.adb:63:14:
         // warning: "C" is not modified, could be declared constant
@@ -103,7 +98,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("\"C\" is not modified, could be declared constant")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/graph_algorithms-generic_explorers.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/process_data.adb:257:49:
         // (style) bad casing of "False" declared in Standard
@@ -115,7 +109,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("bad casing of \"False\" declared in Standard")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/libs/reuse/src/process_data.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb:23:35:
         // error: binary operator expected
@@ -127,7 +120,6 @@ public class GnatParserTest extends ParserTester {
                 .hasMessage("binary operator expected")
                 .hasFileName("/home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // /home/bergerbd/.hudson/jobs/Test/workspace/projects/tools/scangen/src/scangen.adb:23:36:
         // error: identifier cannot start with underline

--- a/src/test/java/edu/hm/hafner/analysis/parser/GnuFortranParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GnuFortranParserTest.java
@@ -145,7 +145,6 @@ public class GnuFortranParserTest extends ParserTester {
                 .hasMessage("Inequality comparison for REAL(8)")
                 .hasFileName("C:/zlaror.f")
                 .hasType(TYPE);
-        softly.assertAll();
 
         // NOCHECKSTYLE
         softly.assertThat(iterator.next())
@@ -157,7 +156,6 @@ public class GnuFortranParserTest extends ParserTester {
                 .hasFileName("/path/to/file.f90")
                 .hasColumnStart(10)
                 .hasType(TYPE);
-        softly.assertAll();
 
         // NOCHECKSTYLE
         softly.assertThat(iterator.next())
@@ -169,7 +167,6 @@ public class GnuFortranParserTest extends ParserTester {
                 .hasFileName("generic2.f90")
                 .hasColumnStart(24)
                 .hasType(TYPE);
-        softly.assertAll();
 
         // NOCHECKSTYLE
         softly.assertThat(iterator.next())

--- a/src/test/java/edu/hm/hafner/analysis/parser/GnuFortranParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GnuFortranParserTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
-import static org.junit.jupiter.api.Assertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
+import edu.hm.hafner.analysis.assertj.IssuesAssert;
 
 /**
  * Tests the class {@link GnuFortranParser}.
@@ -24,18 +25,19 @@ public class GnuFortranParserTest extends ParserTester {
     @Test
     public void testWarningParser() throws IOException {
         Issues warnings = new GnuFortranParser().parse(openFile("GnuFortranWarning.txt"));
+        IssuesAssert.assertThat(warnings).hasSize(1);
 
-        assertEquals(1, warnings.size());
+        SoftAssertions softly = new SoftAssertions();
 
-        Iterator<Issue> iterator = warnings.iterator();
-
-        checkWarning(iterator.next(),
-                318,
-                "Inequality comparison for REAL(8)",
-                "C:/zlaror.f",
-                TYPE,
-                "Warning",
-                Priority.NORMAL);
+        softly.assertThat(warnings.iterator().next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory("Warning")
+                .hasLineStart(318)
+                .hasLineEnd(318)
+                .hasMessage("Inequality comparison for REAL(8)")
+                .hasFileName("C:/zlaror.f")
+                .hasType(TYPE);
+        softly.assertAll();
     }
 
     /**
@@ -48,17 +50,21 @@ public class GnuFortranParserTest extends ParserTester {
         Issues warnings =
                 new GnuFortranParser().parse(openFile("GnuFortranError.txt"));
 
-        assertEquals(1, warnings.size());
+        IssuesAssert.assertThat(warnings).hasSize(1);
 
-        Iterator<Issue> iterator = warnings.iterator();
+        // NOCHECKSTYLE
+        SoftAssertions softly = new SoftAssertions();
 
-        checkWarning(iterator.next(),
-                81, 24,
-                "Interface mismatch in dummy procedure 'f': Shape mismatch in dimension 1 of argument 'y'",
-                "generic2.f90",
-                TYPE,
-                "Error",
-                Priority.HIGH);
+        softly.assertThat(warnings.iterator().next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("Error")
+                .hasLineStart(81)
+                .hasLineEnd(81)
+                .hasMessage("Interface mismatch in dummy procedure 'f': Shape mismatch in dimension 1 of argument 'y'")
+                .hasFileName("generic2.f90")
+                .hasColumnStart(24)
+                .hasType(TYPE);
+        softly.assertAll();
     }
 
     /**
@@ -71,17 +77,21 @@ public class GnuFortranParserTest extends ParserTester {
         Issues warnings =
                 new GnuFortranParser().parse(openFile("GnuFortranFatalError.txt"));
 
-        assertEquals(1, warnings.size());
+        IssuesAssert.assertThat(warnings).hasSize(1);
 
-        Iterator<Issue> iterator = warnings.iterator();
+        // NOCHECKSTYLE
+        SoftAssertions softly = new SoftAssertions();
 
-        checkWarning(iterator.next(),
-                7, 10,
-                "Can't open module file 'ieee_arithmetic.mod' for reading: No such file or directory",
-                "/path/to/file.f90",
-                TYPE,
-                "Fatal Error",
-                Priority.HIGH);
+        softly.assertThat(warnings.iterator().next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("Fatal Error")
+                .hasLineStart(7)
+                .hasLineEnd(7)
+                .hasMessage("Can't open module file 'ieee_arithmetic.mod' for reading: No such file or directory")
+                .hasFileName("/path/to/file.f90")
+                .hasColumnStart(10)
+                .hasType(TYPE);
+        softly.assertAll();
     }
 
     /**
@@ -94,17 +104,21 @@ public class GnuFortranParserTest extends ParserTester {
         Issues warnings =
                 new GnuFortranParser().parse(openFile("GnuFortranInternalError.txt"));
 
-        assertEquals(1, warnings.size());
+        IssuesAssert.assertThat(warnings).hasSize(1);
 
-        Iterator<Issue> iterator = warnings.iterator();
+        // NOCHECKSTYLE
+        SoftAssertions softly = new SoftAssertions();
 
-        checkWarning(iterator.next(),
-                5, 8,
-                "free_pi_tree(): Unresolved fixup",
-                "linear_algebra_mod.f90",
-                TYPE,
-                "Internal Error",
-                Priority.HIGH);
+        softly.assertThat(warnings.iterator().next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("Internal Error")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasMessage("free_pi_tree(): Unresolved fixup")
+                .hasFileName("linear_algebra_mod.f90")
+                .hasColumnStart(8)
+                .hasType(TYPE);
+        softly.assertAll();
     }
 
     /**
@@ -117,38 +131,57 @@ public class GnuFortranParserTest extends ParserTester {
         Issues warnings =
                 new GnuFortranParser().parse(openFile());
 
-        assertEquals(4, warnings.size());
+        IssuesAssert.assertThat(warnings).hasSize(4);
 
         Iterator<Issue> iterator = warnings.iterator();
 
-        checkWarning(iterator.next(),
-                318,
-                "Inequality comparison for REAL(8)",
-                "C:/zlaror.f",
-                TYPE,
-                "Warning",
-                Priority.NORMAL);
-        checkWarning(iterator.next(),
-                7, 10,
-                "Can't open module file 'ieee_arithmetic.mod' for reading: No such file or directory",
-                "/path/to/file.f90",
-                TYPE,
-                "Fatal Error",
-                Priority.HIGH);
-        checkWarning(iterator.next(),
-                81, 24,
-                "Interface mismatch in dummy procedure 'f': Shape mismatch in dimension 1 of argument 'y'",
-                "generic2.f90",
-                TYPE,
-                "Error",
-                Priority.HIGH);
-        checkWarning(iterator.next(),
-                5, 8,
-                "free_pi_tree(): Unresolved fixup",
-                "linear_algebra_mod.f90",
-                TYPE,
-                "Internal Error",
-                Priority.HIGH);
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory("Warning")
+                .hasLineStart(318)
+                .hasLineEnd(318)
+                .hasMessage("Inequality comparison for REAL(8)")
+                .hasFileName("C:/zlaror.f")
+                .hasType(TYPE);
+        softly.assertAll();
+
+        // NOCHECKSTYLE
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("Fatal Error")
+                .hasLineStart(7)
+                .hasLineEnd(7)
+                .hasMessage("Can't open module file 'ieee_arithmetic.mod' for reading: No such file or directory")
+                .hasFileName("/path/to/file.f90")
+                .hasColumnStart(10)
+                .hasType(TYPE);
+        softly.assertAll();
+
+        // NOCHECKSTYLE
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("Error")
+                .hasLineStart(81)
+                .hasLineEnd(81)
+                .hasMessage("Interface mismatch in dummy procedure 'f': Shape mismatch in dimension 1 of argument 'y'")
+                .hasFileName("generic2.f90")
+                .hasColumnStart(24)
+                .hasType(TYPE);
+        softly.assertAll();
+
+        // NOCHECKSTYLE
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory("Internal Error")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasMessage("free_pi_tree(): Unresolved fixup")
+                .hasFileName("linear_algebra_mod.f90")
+                .hasColumnStart(8)
+                .hasType(TYPE);
+        softly.assertAll();
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/GnuMakeGccParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GnuMakeGccParserTest.java
@@ -8,13 +8,15 @@ import org.junit.jupiter.api.Test;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
-import static org.junit.jupiter.api.Assertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
+import edu.hm.hafner.analysis.assertj.IssuesAssert;
 
 /**
  * Tests the class {@link GnuMakeGccParser}.
  *
  * @author vichak
  */
+@SuppressWarnings("NonBooleanMethodNameMayNotStartWithQuestion")
 public class GnuMakeGccParserTest extends ParserTester {
     private static final String WARNING_CATEGORY = "Warning";
     private static final String ERROR_CATEGORY = "Error";
@@ -29,81 +31,151 @@ public class GnuMakeGccParserTest extends ParserTester {
     @Test
     public void testCreateWarning() throws IOException {
         Issues warnings = new GnuMakeGccParser().parse(openFile());
-
-        assertEquals(NUMBER_OF_TESTS, warnings.size());
+        IssuesAssert.assertThat(warnings).hasSize(NUMBER_OF_TESTS);
 
         Iterator<Issue> iterator = warnings.iterator();
 
-        checkWarning(iterator.next(),
-                451,
-                "'void yyunput(int, char*)' defined but not used",
-                "/dir1/testhist.l",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                73,
-                "implicit typename is deprecated, please see the documentation for details",
-                "/u1/drjohn/bfdist/packages/RegrTest/V00-03-01/RgtAddressLineScan.cc",
-                WARNING_TYPE, ERROR_CATEGORY, Priority.HIGH);
-        checkWarning(iterator.next(),
-                4,
-                "foo.h: No such file or directory",
-                "/dir1/foo.cc",
-                WARNING_TYPE, ERROR_CATEGORY, Priority.HIGH);
-        checkWarning(iterator.next(),
-                678,
-                "missing initializer for member sigaltstack::ss_sp",
-                "/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                678,
-                "missing initializer for member sigaltstack::ss_flags",
-                "/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                678,
-                "missing initializer for member sigaltstack::ss_size",
-                "/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                52,
-                "large integer implicitly truncated to unsigned type",
-                "/dir1/src/test_simple_sgs_message.cxx",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                352,
-                "'s2.mepSector2::lubrications' may be used uninitialized in this function",
-                "/dir1/dir2/main/mep.cpp",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                6,
-                "passing 'Test' chooses 'int' over 'unsigned int'",
-                "/dir1/dir2/warnings.cc",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                6,
-                "in call to 'std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char, _Traits = std::char_traits<char>]'",
-                "/dir1/dir2/warnings.cc",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                33,
-                "#warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated.",
-                "/usr/include/c++/4.3/backward/backward_warning.h",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
-        checkWarning(iterator.next(),
-                8,
-                "'bar' was not declared in this scope",
-                "/dir1/dir2/dir3/fo:oo.cpp",
-                WARNING_TYPE, ERROR_CATEGORY, Priority.HIGH);
-        checkWarning(iterator.next(),
-                12,
-                "expected ';' before 'return'",
-                "/dir1/dir2/dir3/fo:oo.cpp",
-                WARNING_TYPE, ERROR_CATEGORY, Priority.HIGH);
-        checkWarning(iterator.next(),
-                5,
-                "Your code is bad, and you should feel bad!",
-                "/dir4/zoidberg.c",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(451)
+                .hasLineEnd(451)
+                .hasMessage("'void yyunput(int, char*)' defined but not used")
+                .hasFileName("/dir1/testhist.l")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory(ERROR_CATEGORY)
+                .hasLineStart(73)
+                .hasLineEnd(73)
+                .hasMessage("implicit typename is deprecated, please see the documentation for details")
+                .hasFileName("/u1/drjohn/bfdist/packages/RegrTest/V00-03-01/RgtAddressLineScan.cc")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory(ERROR_CATEGORY)
+                .hasLineStart(4)
+                .hasLineEnd(4)
+                .hasMessage("foo.h: No such file or directory")
+                .hasFileName("/dir1/foo.cc")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(678)
+                .hasLineEnd(678)
+                .hasMessage("missing initializer for member sigaltstack::ss_sp")
+                .hasFileName("/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(678)
+                .hasLineEnd(678)
+                .hasMessage("missing initializer for member sigaltstack::ss_flags")
+                .hasFileName("/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(678)
+                .hasLineEnd(678)
+                .hasMessage("missing initializer for member sigaltstack::ss_size")
+                .hasFileName("/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(52)
+                .hasLineEnd(52)
+                .hasMessage("large integer implicitly truncated to unsigned type")
+                .hasFileName("/dir1/src/test_simple_sgs_message.cxx")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(352)
+                .hasLineEnd(352)
+                .hasMessage("'s2.mepSector2::lubrications' may be used uninitialized in this function")
+                .hasFileName("/dir1/dir2/main/mep.cpp")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(6)
+                .hasLineEnd(6)
+                .hasMessage("passing 'Test' chooses 'int' over 'unsigned int'")
+                .hasFileName("/dir1/dir2/warnings.cc")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(6)
+                .hasLineEnd(6)
+                .hasMessage("in call to 'std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char, _Traits = std::char_traits<char>]'")
+                .hasFileName("/dir1/dir2/warnings.cc")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(33)
+                .hasLineEnd(33)
+                .hasMessage("#warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated.")
+                .hasFileName("/usr/include/c++/4.3/backward/backward_warning.h")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory(ERROR_CATEGORY)
+                .hasLineStart(8)
+                .hasLineEnd(8)
+                .hasMessage("'bar' was not declared in this scope")
+                .hasFileName("/dir1/dir2/dir3/fo:oo.cpp")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.HIGH)
+                .hasCategory(ERROR_CATEGORY)
+                .hasLineStart(12)
+                .hasLineEnd(12)
+                .hasMessage("expected ';' before 'return'")
+                .hasFileName("/dir1/dir2/dir3/fo:oo.cpp")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
+
+        softly.assertThat(iterator.next())
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasMessage("Your code is bad, and you should feel bad!")
+                .hasFileName("/dir4/zoidberg.c")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
         //Next test is OS-specific, so just skip it
         iterator.next();
         //Place new tests after this line
@@ -132,20 +204,20 @@ public class GnuMakeGccParserTest extends ParserTester {
     /**
      * Checks that paths of the type "/c/anything" are changed to "c:/anything" on windows but no other OS
      */
-    private void checkOsSpecificPath(String os, String rootDir) throws IOException {
+    private void checkOsSpecificPath(final String os, final String rootDir) {
 
         Issues warnings = new GnuMakeGccParser(os).parse(openFile());
-        Iterator<Issue> iterator = warnings.iterator();
-        for (int i = 0; i < 14; i++) //Skip the first 14 warnings, we are only interested in the 15th one
-        {
-            iterator.next();
-        }
+        SoftAssertions softly = new SoftAssertions();
 
-        checkWarning(iterator.next(),
-                20,
-                "I'm warning you! He's got huge, sharp... er... He can leap about.",
-                rootDir + "/dir5/grail.cpp",
-                WARNING_TYPE, WARNING_CATEGORY, Priority.NORMAL);
+        softly.assertThat(warnings.get(14))
+                .hasPriority(Priority.NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(20)
+                .hasLineEnd(20)
+                .hasMessage("I'm warning you! He's got huge, sharp... er... He can leap about.")
+                .hasFileName(rootDir + "/dir5/grail.cpp")
+                .hasType(WARNING_TYPE);
+        softly.assertAll();
 
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/GnuMakeGccParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GnuMakeGccParserTest.java
@@ -45,7 +45,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("'void yyunput(int, char*)' defined but not used")
                 .hasFileName("/dir1/testhist.l")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.HIGH)
@@ -55,7 +54,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("implicit typename is deprecated, please see the documentation for details")
                 .hasFileName("/u1/drjohn/bfdist/packages/RegrTest/V00-03-01/RgtAddressLineScan.cc")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.HIGH)
@@ -65,7 +63,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("foo.h: No such file or directory")
                 .hasFileName("/dir1/foo.cc")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -75,7 +72,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("missing initializer for member sigaltstack::ss_sp")
                 .hasFileName("/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -85,7 +81,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("missing initializer for member sigaltstack::ss_flags")
                 .hasFileName("/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -95,7 +90,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("missing initializer for member sigaltstack::ss_size")
                 .hasFileName("/dir1/../../lib/linux-i686/include/boost/test/impl/execution_monitor.ipp")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -105,7 +99,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("large integer implicitly truncated to unsigned type")
                 .hasFileName("/dir1/src/test_simple_sgs_message.cxx")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -115,7 +108,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("'s2.mepSector2::lubrications' may be used uninitialized in this function")
                 .hasFileName("/dir1/dir2/main/mep.cpp")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -125,7 +117,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("passing 'Test' chooses 'int' over 'unsigned int'")
                 .hasFileName("/dir1/dir2/warnings.cc")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -135,7 +126,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("in call to 'std::basic_ostream<_CharT, _Traits>& std::basic_ostream<_CharT, _Traits>::operator<<(int) [with _CharT = char, _Traits = std::char_traits<char>]'")
                 .hasFileName("/dir1/dir2/warnings.cc")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)
@@ -145,7 +135,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("#warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated.")
                 .hasFileName("/usr/include/c++/4.3/backward/backward_warning.h")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.HIGH)
@@ -155,7 +144,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("'bar' was not declared in this scope")
                 .hasFileName("/dir1/dir2/dir3/fo:oo.cpp")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.HIGH)
@@ -165,7 +153,6 @@ public class GnuMakeGccParserTest extends ParserTester {
                 .hasMessage("expected ';' before 'return'")
                 .hasFileName("/dir1/dir2/dir3/fo:oo.cpp")
                 .hasType(WARNING_TYPE);
-        softly.assertAll();
 
         softly.assertThat(iterator.next())
                 .hasPriority(Priority.NORMAL)


### PR DESCRIPTION
Refactor  GhsMultiParserTest, GnatParserTest, GnuFortranParserTest and GnuMakeGccParserTest to use custom assertions instead of the JUnit assertions.