### PR TITLE
Parser tests now implement AbstractParserTest

### DIFF
--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -2,46 +2,51 @@ package edu.hm.hafner.analysis.parser;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Iterator;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
+import edu.hm.hafner.analysis.AbstractParser;
+import edu.hm.hafner.analysis.AbstractParserTest;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
 import static edu.hm.hafner.analysis.assertj.Assertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
 import static edu.hm.hafner.analysis.assertj.SoftAssertions.*;
 
 /**
  * Tests the class {@link MsBuildParser}.
  */
-@SuppressWarnings("ReuseOfLocalVariable")
-public class MsBuildParserTest extends ParserTester {
+public class MsBuildParserTest extends AbstractParserTest {
+    MsBuildParserTest() {
+        super("msbuild.txt");
+    }
+
     /**
      * MSBuildParser should make relative paths absolute, based on the project name listed in the message.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-38215">Issue 38215</a>
      */
     @Test
-    public void issue38215() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue38215.txt"));
+    void issue38215() {
+        Issues<Issue> warnings = parse("issue38215.txt");
 
-        assertThat(warnings).hasSize(1).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings.get(0))
-                    .hasFileName("C:/J/workspace/ci_windows/ws/build/rmw/test/test_error_handling.vcxproj")
-                    .hasCategory("D9002")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("ignoring unknown option '-std=c++11'")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("C:/J/workspace/ci_windows/ws/build/rmw/test/test_error_handling.vcxproj")
+                .hasCategory("D9002")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("ignoring unknown option '-std=c++11'")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
@@ -50,16 +55,15 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-22386">Issue 22386</a>
      */
     @Test
-    public void issue22386() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue22386.txt"));
+    void issue22386() {
+        Issues<Issue> warnings = parse("issue22386.txt");
 
-        assertThat(warnings).hasSize(2).hasNormalPrioritySize(2);
+        assertThat(warnings)
+                .hasSize(2)
+                .hasNormalPrioritySize(2);
 
         assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("c:/solutiondir/projectdir/src/main.cpp")
                     .hasCategory("C4996")
                     .hasPriority(Priority.NORMAL)
@@ -71,8 +75,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("c:/solutiondir/projectdir/src/main.cpp")
                     .hasCategory("C4996")
                     .hasPriority(Priority.NORMAL)
@@ -93,16 +96,15 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-27914">Issue 27914</a>
      */
     @Test
-    public void issue27914() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue27914.txt"));
+    void issue27914() {
+        Issues<Issue> warnings = parse("issue27914.txt");
 
-        assertThat(warnings).hasSize(3).hasNormalPrioritySize(3);
+        assertThat(warnings)
+                .hasSize(3)
+                .hasNormalPrioritySize(3);
 
         assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("E:/workspace/TreeSize release nightly/DelphiLib/Jam.UI.Dialogs.pas")
                     .hasCategory("H2164")
                     .hasPriority(Priority.NORMAL)
@@ -114,8 +116,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("E:/workspace/TreeSize release nightly/DelphiLib/Jam.UI.Dialogs.pas")
                     .hasCategory("H2164")
                     .hasPriority(Priority.NORMAL)
@@ -127,8 +128,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(2))
                     .hasFileName("E:/workspace/TreeSize release nightly/DelphiLib/Jam.UI.Dialogs.pas")
                     .hasCategory("H2164")
                     .hasPriority(Priority.NORMAL)
@@ -148,8 +148,8 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-26441">Issue 26441</a>
      */
     @Test
-    public void issue26441() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue26441.txt"));
+    void issue26441() {
+        Issues<Issue> warnings = parse("issue26441.txt");
 
         assertThat(warnings).isEmpty();
     }
@@ -160,8 +160,8 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-20544">Issue 20544</a>
      */
     @Test
-    public void issue20544() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue20544.txt"));
+    void issue20544() {
+        Issues<Issue> warnings = parse("issue20544.txt");
 
         assertThat(warnings).isEmpty();
     }
@@ -172,18 +172,16 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-20154">Issue 20154</a>
      */
     @Test
-    public void issue20154() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue20154.txt"));
+    void issue20154() {
+        Issues<Issue> warnings = parse("issue20154.txt");
 
-        assertThat(warnings).hasSize(3)
+        assertThat(warnings)
+                .hasSize(3)
                 .hasDuplicatesSize(5)
                 .hasNormalPrioritySize(3);
 
         assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("MSBUILD")
                     .hasCategory("CA2210")
                     .hasType("Microsoft.Design")
@@ -196,8 +194,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("i:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
                     .hasCategory("CA1801")
                     .hasType("Microsoft.Usage")
@@ -209,6 +206,19 @@ public class MsBuildParserTest extends ParserTester {
                     .hasLineEnd(12)
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
+
+            softly.assertThat(warnings.get(2))
+                    .hasFileName("i:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
+                    .hasCategory("CA1801")
+                    .hasType("Microsoft.Usage")
+                    .hasPriority(Priority.NORMAL)
+                    .hasMessage("Parameter 'args' of 'Program.Main(string[])' is never used. Remove the parameter or use it in the method body.")
+                    .hasDescription("")
+                    .hasPackageName("-")
+                    .hasLineStart(13)
+                    .hasLineEnd(13)
+                    .hasColumnStart(0)
+                    .hasColumnEnd(0);
         });
     }
 
@@ -218,17 +228,15 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-14888">Issue 14888</a>
      */
     @Test
-    public void issue14888() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue14888.txt"));
+    void issue14888() {
+        Issues<Issue> warnings = parse("issue14888.txt");
+
+        assertThat(warnings)
+                .hasSize(4)
+                .hasHighPrioritySize(4);
 
         assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(4);
-            softly.assertThat(warnings).hasHighPrioritySize(4);
-
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("F:/AC_working/new-wlanac/ac/np/capwap/source/capwap_data.c")
                     .hasCategory("40")
                     .hasPriority(Priority.HIGH)
@@ -240,8 +248,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("F:/AC_working/new-wlanac/ac/np/capwap/source/capwap_data.c")
                     .hasCategory("63")
                     .hasPriority(Priority.HIGH)
@@ -253,8 +260,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(2))
                     .hasFileName("F:/AC_working/new-wlanac/ac/np/capwap/source/capwap_data.c")
                     .hasCategory("40")
                     .hasPriority(Priority.HIGH)
@@ -266,8 +272,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(3))
                     .hasFileName("F:/AC_working/new-wlanac/ac/np/capwap/source/capwap_data.c")
                     .hasCategory("10")
                     .hasPriority(Priority.HIGH)
@@ -287,24 +292,24 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-10566">Issue 10566</a>
      */
     @Test
-    public void issue10566() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue10566.txt"));
+    void issue10566() {
+        Issues<Issue> warnings = parse("issue10566.txt");
 
-        assertThat(warnings).hasSize(1).hasHighPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasHighPrioritySize(1);
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings.get(0))
-                    .hasFileName("..//..//..//xx_Source//file.c")
-                    .hasCategory("c1083")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("cannot open include file: 'Header.h': No such file or directory")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(54)
-                    .hasLineEnd(54)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("..//..//..//xx_Source//file.c")
+                .hasCategory("c1083")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("cannot open include file: 'Header.h': No such file or directory")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(54)
+                .hasLineEnd(54)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
@@ -313,24 +318,24 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-3582">Issue 3582</a>
      */
     @Test
-    public void issue3582() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue3582.txt"));
+    void issue3582() {
+        Issues<Issue> warnings = parse("issue3582.txt");
 
-        assertThat(warnings).hasSize(1).hasHighPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasHighPrioritySize(1);
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings.get(0))
-                    .hasFileName("TestLib.lib")
-                    .hasCategory("LNK1181")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("cannot open input file 'TestLib.lib'")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("TestLib.lib")
+                .hasCategory("LNK1181")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("cannot open input file 'TestLib.lib'")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
@@ -339,16 +344,15 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-8347">Issue 8347</a>
      */
     @Test
-    public void issue8347() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue8347.txt"));
+    void issue8347() {
+        Issues<Issue> warnings = parse("issue8347.txt");
 
-        assertThat(warnings).hasSize(5).hasNormalPrioritySize(5);
+        assertThat(warnings)
+                .hasSize(5)
+                .hasNormalPrioritySize(5);
 
         assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("C:/hudsonSlave/workspace/MyProject/Source/MoqExtensions.cs")
                     .hasCategory("SA1210")
                     .hasPriority(Priority.NORMAL)
@@ -360,8 +364,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(1)
                     .hasColumnEnd(1);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("C:/hudsonSlave/workspace/MyProject/Source/MoqExtensions.cs")
                     .hasCategory("SA1210")
                     .hasPriority(Priority.NORMAL)
@@ -373,8 +376,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(1)
                     .hasColumnEnd(1);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(2))
                     .hasFileName("C:/hudsonSlave/workspace/MyProject/Source/MoqExtensions.cs")
                     .hasCategory("SA1210")
                     .hasPriority(Priority.NORMAL)
@@ -386,8 +388,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(1)
                     .hasColumnEnd(1);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(3))
                     .hasFileName("C:/hudsonSlave/workspace/MyProject/Source/MoqExtensions.cs")
                     .hasCategory("SA1208")
                     .hasPriority(Priority.NORMAL)
@@ -399,8 +400,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(1)
                     .hasColumnEnd(1);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(4))
                     .hasFileName("C:/hudsonSlave/workspace/MyProject/Source/MoqExtensions.cs")
                     .hasCategory("SA1402")
                     .hasPriority(Priority.NORMAL)
@@ -420,24 +420,24 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-3582">Issue 3582</a>
      */
     @Test
-    public void issue6709() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue6709.txt"));
+    void issue6709() {
+        Issues<Issue> warnings = parse("issue6709.txt");
 
-        assertThat(warnings).hasSize(1).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings.get(0))
-                    .hasFileName("Rules/TaskRules.cs")
-                    .hasCategory("CS0168")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("The variable 'ex' is declared but never used")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1145)
-                    .hasLineEnd(1145)
-                    .hasColumnStart(49)
-                    .hasColumnEnd(49);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("Rules/TaskRules.cs")
+                .hasCategory("CS0168")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("The variable 'ex' is declared but never used")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1145)
+                .hasLineEnd(1145)
+                .hasColumnStart(49)
+                .hasColumnEnd(49));
     }
 
     /**
@@ -446,24 +446,24 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-9926">Issue 9926</a>
      */
     @Test
-    public void issue9926() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue9926.txt"));
+    void issue9926() {
+        Issues<Issue> warnings = parse("issue9926.txt");
 
-        assertThat(warnings).hasSize(1).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings.get(0))
-                    .hasFileName("c:/jci/jobs/external_nvtristrip/workspace/compiler/cl/config/debug/platform/win32/tfields/live/external/nvtristrip/nvtristrip.cpp")
-                    .hasCategory("C4706")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("assignment within conditional expression")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(125)
-                    .hasLineEnd(125)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("c:/jci/jobs/external_nvtristrip/workspace/compiler/cl/config/debug/platform/win32/tfields/live/external/nvtristrip/nvtristrip.cpp")
+                .hasCategory("C4706")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("assignment within conditional expression")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(125)
+                .hasLineEnd(125)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
@@ -472,15 +472,15 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-4932">Issue 4932</a>
      */
     @Test
-    public void issue4932() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue4932.txt"));
+    void issue4932() {
+        Issues<Issue> warnings = parse("issue4932.txt");
 
-        assertThat(warnings).hasSize(2).hasHighPrioritySize(2);
+        assertThat(warnings)
+                .hasSize(2)
+                .hasHighPrioritySize(2);
 
         assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("SynchronisationHeure.obj")
                     .hasCategory("LNK2001")
                     .hasPriority(Priority.HIGH)
@@ -492,8 +492,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("Release/Navineo.exe")
                     .hasCategory("LNK1120")
                     .hasPriority(Priority.HIGH)
@@ -513,17 +512,16 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-4731">Issue 4731</a>
      */
     @Test
-    public void issue4731() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile("issue4731.txt"));
-        assertThat(warnings).hasSize(11)
+    void issue4731() {
+        Issues<Issue> warnings = parse("issue4731.txt");
+
+        assertThat(warnings)
+                .hasSize(11)
                 .hasDuplicatesSize(1)
                 .hasNormalPrioritySize(11);
 
         assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("c:/playpens/Catalyst/Platform/src/Ptc.Platform.Web/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasPriority(Priority.NORMAL)
@@ -535,8 +533,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("c:/playpens/Catalyst/Platform/src/Ptc.Platform.Web/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasPriority(Priority.NORMAL)
@@ -548,8 +545,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(2))
                     .hasFileName("c:/playpens/Catalyst/Platform/src/Ptc.Platform.ShowcaseSiteTemplate/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasPriority(Priority.NORMAL)
@@ -561,8 +557,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(3))
                     .hasFileName("c:/playpens/Catalyst/Platform/src/Ptc.Platform.ShowcaseSiteTemplate/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasPriority(Priority.NORMAL)
@@ -576,101 +571,6 @@ public class MsBuildParserTest extends ParserTester {
         });
     }
 
-    /**
-     * Parses a file with warnings of the MS Build tools.
-     */
-    @Test
-    public void parseWarnings() {
-        Issues<Issue> warnings = new MsBuildParser().parse(openFile());
-
-        assertThat(warnings)
-                .hasSize(6)
-                .hasHighPrioritySize(2)
-                .hasNormalPrioritySize(3)
-                .hasLowPrioritySize(1);
-
-        assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
-                    .hasFileName("Src/Parser/CSharp/cs.ATG")
-                    .hasCategory("CS0168")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("The variable 'type' is declared but never used")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(2242)
-                    .hasLineEnd(2242)
-                    .hasColumnStart(17)
-                    .hasColumnEnd(17);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("C:/Src/Parser/CSharp/file.cs")
-                    .hasCategory("XXX")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("An error occurred")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(10)
-                    .hasLineEnd(10)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("Controls/MozItem.cs")
-                    .hasCategory("CS0618")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("System.ComponentModel.Design.ComponentDesigner.OnSetComponentDefaults() : This method has been deprecated. Use InitializeNewComponent instead. http://go.microsoft.com/fwlink/?linkid=14202")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1338)
-                    .hasLineEnd(1338)
-                    .hasColumnStart(4)
-                    .hasColumnEnd(4);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("MediaPortal.cs")
-                    .hasCategory("CS0162")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Hier kommt der Warnings Text")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(3001)
-                    .hasLineEnd(3001)
-                    .hasColumnStart(5)
-                    .hasColumnEnd(5);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("x/a/b/include/abc.h")
-                    .hasCategory("C1083")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("Cannot open include file: xyz.h:...")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(18)
-                    .hasLineEnd(18)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("foo.h")
-                    .hasCategory("701")
-                    .hasPriority(Priority.LOW)
-                    .hasMessage("This is an info message from PcLint")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
-    }
 
     /**
      * MSBuildParser should also detect keywords 'Warning' and 'Error', as they are produced by the .NET-2.0 compiler of
@@ -679,20 +579,22 @@ public class MsBuildParserTest extends ParserTester {
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-2383">Issue 2383</a>
      */
     @Test
-    public void shouldDetectKeywordsInRegexCaseInsensitive() throws IOException {
-        String containsErrorAndWarningKeywords = "Src\\Parser\\CSharp\\cs.ATG (2242,17):  Warning CS0168: The variable 'type' is declared but never used\r\nC:\\Src\\Parser\\CSharp\\file.cs (10): Error XXX: An error occurred";
+    void shouldDetectKeywordsInRegexCaseInsensitive() throws IOException {
+        String containsErrorAndWarningKeywords = "Src\\Parser\\CSharp\\cs.ATG (2242,17):  Warning"
+                + " CS0168: The variable 'type' is declared but never used\r\nC:\\Src\\Parser\\CSharp\\file.cs"
+                + " (10): Error XXX: An error occurred";
 
-        Issues<Issue> warnings = new MsBuildParser().parse(new InputStreamReader(
+        Issues<Issue> warnings = createParser().parse(new InputStreamReader(
                 IOUtils.toInputStream(containsErrorAndWarningKeywords, "UTF-8")
         ));
 
-        assertThat(warnings).hasSize(2).hasHighPrioritySize(1).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(2)
+                .hasHighPrioritySize(1)
+                .hasNormalPrioritySize(1);
 
         assertSoftly(softly -> {
-            Iterator<Issue> iterator = warnings.iterator();
-            Issue warning = iterator.next();
-
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(0))
                     .hasFileName("Src/Parser/CSharp/cs.ATG")
                     .hasCategory("CS0168")
                     .hasPriority(Priority.NORMAL)
@@ -704,8 +606,7 @@ public class MsBuildParserTest extends ParserTester {
                     .hasColumnStart(17)
                     .hasColumnEnd(17);
 
-            warning = iterator.next();
-            softly.assertThat(warning)
+            softly.assertThat(warnings.get(1))
                     .hasFileName("C:/Src/Parser/CSharp/file.cs")
                     .hasCategory("XXX")
                     .hasPriority(Priority.HIGH)
@@ -720,8 +621,89 @@ public class MsBuildParserTest extends ParserTester {
     }
 
     @Override
-    protected String getWarningsFile() {
-        return "msbuild.txt";
+    protected void assertThatIssuesArePresent(final Issues<Issue> issues, final SoftAssertions softly) {
+        softly.assertThat(issues)
+                .hasSize(6)
+                .hasHighPrioritySize(2)
+                .hasNormalPrioritySize(3)
+                .hasLowPrioritySize(1);
+
+        softly.assertThat(issues.get(0))
+                .hasFileName("Src/Parser/CSharp/cs.ATG")
+                .hasCategory("CS0168")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("The variable 'type' is declared but never used")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(2242)
+                .hasLineEnd(2242)
+                .hasColumnStart(17)
+                .hasColumnEnd(17);
+
+        softly.assertThat(issues.get(1))
+                .hasFileName("C:/Src/Parser/CSharp/file.cs")
+                .hasCategory("XXX")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("An error occurred")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(10)
+                .hasLineEnd(10)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(2))
+                .hasFileName("Controls/MozItem.cs")
+                .hasCategory("CS0618")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("System.ComponentModel.Design.ComponentDesigner.OnSetComponentDefaults() : This method has been deprecated. Use InitializeNewComponent instead. http://go.microsoft.com/fwlink/?linkid=14202")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1338)
+                .hasLineEnd(1338)
+                .hasColumnStart(4)
+                .hasColumnEnd(4);
+
+        softly.assertThat(issues.get(3))
+                .hasFileName("MediaPortal.cs")
+                .hasCategory("CS0162")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Hier kommt der Warnings Text")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(3001)
+                .hasLineEnd(3001)
+                .hasColumnStart(5)
+                .hasColumnEnd(5);
+
+        softly.assertThat(issues.get(4))
+                .hasFileName("x/a/b/include/abc.h")
+                .hasCategory("C1083")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("Cannot open include file: xyz.h:...")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(18)
+                .hasLineEnd(18)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(5))
+                .hasFileName("foo.h")
+                .hasCategory("701")
+                .hasPriority(Priority.LOW)
+                .hasMessage("This is an info message from PcLint")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+    }
+
+    @Override
+    protected AbstractParser createParser() {
+        return new MsBuildParser();
     }
 }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/NagFortranParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/NagFortranParserTest.java
@@ -1,430 +1,395 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.util.Iterator;
-
 import org.junit.jupiter.api.Test;
 
+import edu.hm.hafner.analysis.AbstractParser;
+import edu.hm.hafner.analysis.AbstractParserTest;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
+import static edu.hm.hafner.analysis.assertj.Assertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
 import static edu.hm.hafner.analysis.assertj.SoftAssertions.*;
 
 /**
  * Tests the class {@link NagFortranParser}.
  */
-@SuppressWarnings("ReuseOfLocalVariable")
-public class NagFortranParserTest extends ParserTester {
+public class NagFortranParserTest extends AbstractParserTest {
+    NagFortranParserTest() {
+        super("NagFortran.txt");
+    }
+
     /**
      * Test parsing of a file containing an Info message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testInfoParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranInfo.txt"));
+    void testInfoParser() {
+        Issues<Issue> warnings = parse("NagFortranInfo.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasLowPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasLowPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("C:/file1.inc")
-                    .hasCategory("Info")
-                    .hasPriority(Priority.LOW)
-                    .hasMessage("Unterminated last line of INCLUDE file")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("C:/file1.inc")
+                .hasCategory("Info")
+                .hasPriority(Priority.LOW)
+                .hasMessage("Unterminated last line of INCLUDE file")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1)
+                .hasLineEnd(1)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing a Warning message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testWarningParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranWarning.txt"));
+    void testWarningParser() {
+        Issues<Issue> warnings = parse("NagFortranWarning.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("C:/file2.f90")
-                    .hasCategory("Warning")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Procedure pointer F pointer-assigned but otherwise unused")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("C:/file2.f90")
+                .hasCategory("Warning")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Procedure pointer F pointer-assigned but otherwise unused")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing a Questionable message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testQuestionableParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranQuestionable.txt"));
+    void testQuestionableParser() {
+        Issues<Issue> warnings = parse("NagFortranQuestionable.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("/file3.f90")
-                    .hasCategory("Questionable")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Array constructor has polymorphic element P(5) (but the constructor value will not be polymorphic)")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(12)
-                    .hasLineEnd(12)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("/file3.f90")
+                .hasCategory("Questionable")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Array constructor has polymorphic element P(5) (but the constructor value will not be polymorphic)")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(12)
+                .hasLineEnd(12)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing an Extension message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testExtensionParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranExtension.txt"));
+    void testExtensionParser() {
+        Issues<Issue> warnings = parse("NagFortranExtension.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("file4.f90")
-                    .hasCategory("Extension")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Left-hand side of intrinsic assignment is allocatable polymorphic variable X")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(9)
-                    .hasLineEnd(9)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("file4.f90")
+                .hasCategory("Extension")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Left-hand side of intrinsic assignment is allocatable polymorphic variable X")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(9)
+                .hasLineEnd(9)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing an Obsolescent message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testObsolescentParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranObsolescent.txt"));
+    void testObsolescentParser() {
+        Issues<Issue> warnings = parse("NagFortranObsolescent.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("file5.f")
-                    .hasCategory("Obsolescent")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Fixed source form")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("file5.f")
+                .hasCategory("Obsolescent")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Fixed source form")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1)
+                .hasLineEnd(1)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing a Deleted fature used message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testDeletedFeatureUsedParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranDeletedFeatureUsed.txt"));
+    void testDeletedFeatureUsedParser() {
+        Issues<Issue> warnings = parse("NagFortranDeletedFeatureUsed.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasNormalPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasNormalPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("file6.f90")
-                    .hasCategory("Deleted feature used")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("assigned GOTO statement")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(4)
-                    .hasLineEnd(4)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("file6.f90")
+                .hasCategory("Deleted feature used")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("assigned GOTO statement")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(4)
+                .hasLineEnd(4)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing an Error message, with no line number, output by the NAG Fortran Compiler.
      */
     @Test
-    public void testErrorParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranError.txt"));
+    void testErrorParser() {
+        Issues<Issue> warnings = parse("NagFortranError.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasHighPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasHighPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("file7.f90")
-                    .hasCategory("Error")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("Character function length 7 is not same as argument F (no. 1) in reference to SUB from O8K (expected length 6)")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("file7.f90")
+                .hasCategory("Error")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("Character function length 7 is not same as argument F (no. 1) in reference to SUB from O8K (expected length 6)")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing a Runtime Error message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testRuntimeErrorParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranRuntimeError.txt"));
+    void testRuntimeErrorParser() {
+        Issues<Issue> warnings = parse("NagFortranRuntimeError.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasHighPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasHighPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("file8.f90")
-                    .hasCategory("Runtime Error")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("Reference to undefined POINTER P")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(7)
-                    .hasLineEnd(7)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("file8.f90")
+                .hasCategory("Runtime Error")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("Reference to undefined POINTER P")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(7)
+                .hasLineEnd(7)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing a Fatal Error message, on multiple lines, output by the NAG Fortran Compiler.
      */
     @Test
-    public void testFatalErrorParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranFatalError.txt"));
+    void testFatalErrorParser() {
+        Issues<Issue> warnings = parse("NagFortranFatalError.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasHighPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasHighPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("file9.f90")
-                    .hasCategory("Fatal Error")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("SAME_NAME is not a derived type\n             detected at ::@N")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("file9.f90")
+                .hasCategory("Fatal Error")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("SAME_NAME is not a derived type\n             detected at ::@N")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     /**
      * Test parsing of a file containing a Panic message output by the NAG Fortran Compiler.
      */
     @Test
-    public void testPanicParser() {
-        Issues<Issue> warnings = new NagFortranParser().parse(openFile("NagFortranPanic.txt"));
+    void testPanicParser() {
+        Issues<Issue> warnings = parse("NagFortranPanic.txt");
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(1);
-            softly.assertThat(warnings).hasHighPrioritySize(1);
+        assertThat(warnings)
+                .hasSize(1)
+                .hasHighPrioritySize(1);
 
-            Issue warning = warnings.get(0);
-            softly.assertThat(warning)
-                    .hasFileName("file10.f90")
-                    .hasCategory("Panic")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("User requested panic")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
-    }
-
-    /**
-     * Test parsing of a file containing all categories of message output by the NAG Fortran Compiler.
-     */
-    @Test
-    public void testMessageParser() {
-        Issues<Issue> warnings =
-                new NagFortranParser().parse(openFile());
-
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(10);
-            softly.assertThat(warnings).hasHighPrioritySize(4);
-            softly.assertThat(warnings).hasNormalPrioritySize(5);
-            softly.assertThat(warnings).hasLowPrioritySize(1);
-
-            Iterator<Issue> iterator = warnings.iterator();
-
-            Issue warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("C:/file1.inc")
-                    .hasCategory("Info")
-                    .hasPriority(Priority.LOW)
-                    .hasMessage("Unterminated last line of INCLUDE file")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("C:/file2.f90")
-                    .hasCategory("Warning")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Procedure pointer F pointer-assigned but otherwise unused")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("/file3.f90")
-                    .hasCategory("Questionable")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Array constructor has polymorphic element P(5) (but the constructor value will not be polymorphic)")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(12)
-                    .hasLineEnd(12)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("file4.f90")
-                    .hasCategory("Extension")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Left-hand side of intrinsic assignment is allocatable polymorphic variable X")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(9)
-                    .hasLineEnd(9)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("file5.f")
-                    .hasCategory("Obsolescent")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("Fixed source form")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("file6.f90")
-                    .hasCategory("Deleted feature used")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("assigned GOTO statement")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(4)
-                    .hasLineEnd(4)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("file7.f90")
-                    .hasCategory("Error")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("Character function length 7 is not same as argument F (no. 1) in reference to SUB from O8K (expected length 6)")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("file8.f90")
-                    .hasCategory("Runtime Error")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("Reference to undefined POINTER P")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(7)
-                    .hasLineEnd(7)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("file9.f90")
-                    .hasCategory("Fatal Error")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("SAME_NAME is not a derived type\n             detected at ::@N")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("file10.f90")
-                    .hasCategory("Panic")
-                    .hasPriority(Priority.HIGH)
-                    .hasMessage("User requested panic")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("file10.f90")
+                .hasCategory("Panic")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("User requested panic")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1)
+                .hasLineEnd(1)
+                .hasColumnStart(0)
+                .hasColumnEnd(0));
     }
 
     @Override
-    protected String getWarningsFile() {
-        return "NagFortran.txt";
+    protected void assertThatIssuesArePresent(final Issues<Issue> issues, final SoftAssertions softly) {
+        softly.assertThat(issues)
+                .hasSize(10)
+                .hasHighPrioritySize(4)
+                .hasNormalPrioritySize(5)
+                .hasLowPrioritySize(1);
+
+        softly.assertThat(issues.get(0))
+                .hasFileName("C:/file1.inc")
+                .hasCategory("Info")
+                .hasPriority(Priority.LOW)
+                .hasMessage("Unterminated last line of INCLUDE file")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1)
+                .hasLineEnd(1)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(1))
+                .hasFileName("C:/file2.f90")
+                .hasCategory("Warning")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Procedure pointer F pointer-assigned but otherwise unused")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(2))
+                .hasFileName("/file3.f90")
+                .hasCategory("Questionable")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Array constructor has polymorphic element P(5) (but the constructor value will not be polymorphic)")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(12)
+                .hasLineEnd(12)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(3))
+                .hasFileName("file4.f90")
+                .hasCategory("Extension")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Left-hand side of intrinsic assignment is allocatable polymorphic variable X")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(9)
+                .hasLineEnd(9)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(4))
+                .hasFileName("file5.f")
+                .hasCategory("Obsolescent")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("Fixed source form")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1)
+                .hasLineEnd(1)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(5))
+                .hasFileName("file6.f90")
+                .hasCategory("Deleted feature used")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("assigned GOTO statement")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(4)
+                .hasLineEnd(4)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(6))
+                .hasFileName("file7.f90")
+                .hasCategory("Error")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("Character function length 7 is not same as argument F (no. 1) in reference to SUB from O8K (expected length 6)")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(7))
+                .hasFileName("file8.f90")
+                .hasCategory("Runtime Error")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("Reference to undefined POINTER P")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(7)
+                .hasLineEnd(7)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(8))
+                .hasFileName("file9.f90")
+                .hasCategory("Fatal Error")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("SAME_NAME is not a derived type\n             detected at ::@N")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(9))
+                .hasFileName("file10.f90")
+                .hasCategory("Panic")
+                .hasPriority(Priority.HIGH)
+                .hasMessage("User requested panic")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(1)
+                .hasLineEnd(1)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
     }
 
+    @Override
+    protected AbstractParser createParser() {
+        return new NagFortranParser();
+    }
 }

--- a/src/test/java/edu/hm/hafner/analysis/parser/P4ParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/P4ParserTest.java
@@ -1,90 +1,79 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.util.Iterator;
-
-import org.junit.jupiter.api.Test;
-
+import edu.hm.hafner.analysis.AbstractParser;
+import edu.hm.hafner.analysis.AbstractParserTest;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
-import static edu.hm.hafner.analysis.assertj.SoftAssertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
 
 /**
  * Tests the class {@link P4Parser}.
  */
-@SuppressWarnings("ReuseOfLocalVariable")
-public class P4ParserTest extends ParserTester {
-    /**
-     * Parses a file with four Perforce warnings.
-     */
-    @Test
-    public void testWarningsParser() {
-        Issues<Issue> warnings = new P4Parser().parse(openFile());
-
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(4);
-            softly.assertThat(warnings).hasNormalPrioritySize(2);
-            softly.assertThat(warnings).hasLowPrioritySize(2);
-
-            Iterator<Issue> iterator = warnings.iterator();
-
-            Issue warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/.owner")
-                    .hasCategory("can't add existing file")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/.owner")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/jobs/EASW-FIFA DailyTasks/config.xml")
-                    .hasCategory("warning: add of existing file")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/jobs/EASW-FIFA DailyTasks/config.xml")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/jobs/BFBC2-DailyTasksEurope/config.xml")
-                    .hasCategory("can't add (already opened for edit)")
-                    .hasPriority(Priority.LOW)
-                    .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/jobs/BFBC2-DailyTasksEurope/config.xml")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/config.xml#8")
-                    .hasCategory("nothing changed")
-                    .hasPriority(Priority.LOW)
-                    .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/config.xml#8")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-        });
+public class P4ParserTest extends AbstractParserTest {
+    P4ParserTest() {
+        super("perforce.txt");
     }
 
     @Override
-    protected String getWarningsFile() {
-        return "perforce.txt";
+    protected void assertThatIssuesArePresent(final Issues<Issue> issues, final SoftAssertions softly) {
+        softly.assertThat(issues)
+                .hasSize(4)
+                .hasNormalPrioritySize(2)
+                .hasLowPrioritySize(2);
+
+        softly.assertThat(issues.get(0))
+                .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/.owner")
+                .hasCategory("can't add existing file")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/.owner")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(1))
+                .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/jobs/EASW-FIFA DailyTasks/config.xml")
+                .hasCategory("warning: add of existing file")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/jobs/EASW-FIFA DailyTasks/config.xml")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(2))
+                .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/jobs/BFBC2-DailyTasksEurope/config.xml")
+                .hasCategory("can't add (already opened for edit)")
+                .hasPriority(Priority.LOW)
+                .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/jobs/BFBC2-DailyTasksEurope/config.xml")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(issues.get(3))
+                .hasFileName("//eng/Tools/Hudson/instances/PCFARM08/config.xml#8")
+                .hasCategory("nothing changed")
+                .hasPriority(Priority.LOW)
+                .hasMessage("//eng/Tools/Hudson/instances/PCFARM08/config.xml#8")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+    }
+
+    @Override
+    protected AbstractParser createParser() {
+        return new P4Parser();
     }
 }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/Pep8ParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/Pep8ParserTest.java
@@ -1,143 +1,128 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.util.Iterator;
-
-import org.junit.jupiter.api.Test;
-
+import edu.hm.hafner.analysis.AbstractParser;
+import edu.hm.hafner.analysis.AbstractParserTest;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Issues;
 import edu.hm.hafner.analysis.Priority;
-import static edu.hm.hafner.analysis.assertj.SoftAssertions.*;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
 
 /**
  * Tests the class {@link Pep8Parser}.
  *
  * @author Marvin Schütz, J. Behrmann
  */
-@SuppressWarnings("ReuseOfLocalVariable")
-public class Pep8ParserTest extends ParserTester {
-    /**
-     * Parses a file with W and E warnings.
-     */
-    @Test
-    public void testParseSimpleAndComplexMessage() {
-        Issues<Issue> warnings = new Pep8Parser().parse(openFile());
-
-        assertSoftly(softly -> {
-            softly.assertThat(warnings).hasSize(8);
-            softly.assertThat(warnings).hasNormalPrioritySize(6);
-            softly.assertThat(warnings).hasLowPrioritySize(2);
-
-            Iterator<Issue> iterator = warnings.iterator();
-
-            Issue warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("E401")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("multiple imports on one line")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(69)
-                    .hasLineEnd(69)
-                    .hasColumnStart(11)
-                    .hasColumnEnd(11);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("E302")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("expected 2 blank lines, found 1")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(77)
-                    .hasLineEnd(77)
-                    .hasColumnStart(1)
-                    .hasColumnEnd(1);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("E301")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("expected 1 blank line, found 0")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(88)
-                    .hasLineEnd(88)
-                    .hasColumnStart(5)
-                    .hasColumnEnd(5);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("W602")
-                    .hasPriority(Priority.LOW)
-                    .hasMessage("deprecated form of raising exception")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(222)
-                    .hasLineEnd(222)
-                    .hasColumnStart(34)
-                    .hasColumnEnd(34);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("E211")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("whitespace before '('")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(347)
-                    .hasLineEnd(347)
-                    .hasColumnStart(31)
-                    .hasColumnEnd(31);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("E201")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("whitespace after '{'")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(357)
-                    .hasLineEnd(357)
-                    .hasColumnStart(17)
-                    .hasColumnEnd(17);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("E221")
-                    .hasPriority(Priority.NORMAL)
-                    .hasMessage("multiple spaces before operator")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(472)
-                    .hasLineEnd(472)
-                    .hasColumnStart(29)
-                    .hasColumnEnd(29);
-
-            warning = iterator.next();
-            softly.assertThat(warning)
-                    .hasFileName("optparse.py")
-                    .hasCategory("W601")
-                    .hasPriority(Priority.LOW)
-                    .hasMessage(".has_key() is deprecated, use 'in'")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(544)
-                    .hasLineEnd(544)
-                    .hasColumnStart(21)
-                    .hasColumnEnd(21);
-        });
+public class Pep8ParserTest extends AbstractParserTest {
+    Pep8ParserTest() {
+        super("pep8Test.txt");
     }
 
     @Override
-    protected String getWarningsFile() {
-        return "pep8Test.txt";
+    protected void assertThatIssuesArePresent(final Issues<Issue> issues, final SoftAssertions softly) {
+        softly.assertThat(issues)
+                .hasSize(8)
+                .hasNormalPrioritySize(6)
+                .hasLowPrioritySize(2);
+
+        softly.assertThat(issues.get(0))
+                .hasFileName("optparse.py")
+                .hasCategory("E401")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("multiple imports on one line")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(69)
+                .hasLineEnd(69)
+                .hasColumnStart(11)
+                .hasColumnEnd(11);
+
+        softly.assertThat(issues.get(1))
+                .hasFileName("optparse.py")
+                .hasCategory("E302")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("expected 2 blank lines, found 1")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(77)
+                .hasLineEnd(77)
+                .hasColumnStart(1)
+                .hasColumnEnd(1);
+
+        softly.assertThat(issues.get(2))
+                .hasFileName("optparse.py")
+                .hasCategory("E301")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("expected 1 blank line, found 0")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(88)
+                .hasLineEnd(88)
+                .hasColumnStart(5)
+                .hasColumnEnd(5);
+
+        softly.assertThat(issues.get(3))
+                .hasFileName("optparse.py")
+                .hasCategory("W602")
+                .hasPriority(Priority.LOW)
+                .hasMessage("deprecated form of raising exception")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(222)
+                .hasLineEnd(222)
+                .hasColumnStart(34)
+                .hasColumnEnd(34);
+
+        softly.assertThat(issues.get(4))
+                .hasFileName("optparse.py")
+                .hasCategory("E211")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("whitespace before '('")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(347)
+                .hasLineEnd(347)
+                .hasColumnStart(31)
+                .hasColumnEnd(31);
+
+        softly.assertThat(issues.get(5))
+                .hasFileName("optparse.py")
+                .hasCategory("E201")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("whitespace after '{'")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(357)
+                .hasLineEnd(357)
+                .hasColumnStart(17)
+                .hasColumnEnd(17);
+
+        softly.assertThat(issues.get(6))
+                .hasFileName("optparse.py")
+                .hasCategory("E221")
+                .hasPriority(Priority.NORMAL)
+                .hasMessage("multiple spaces before operator")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(472)
+                .hasLineEnd(472)
+                .hasColumnStart(29)
+                .hasColumnEnd(29);
+
+        softly.assertThat(issues.get(7))
+                .hasFileName("optparse.py")
+                .hasCategory("W601")
+                .hasPriority(Priority.LOW)
+                .hasMessage(".has_key() is deprecated, use 'in'")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(544)
+                .hasLineEnd(544)
+                .hasColumnStart(21)
+                .hasColumnEnd(21);
+    }
+
+    @Override
+    protected AbstractParser createParser() {
+        return new Pep8Parser();
     }
 }


### PR DESCRIPTION
Changes for **MsBuildParserTest**, **NagFortranParserTest**, **P4ParserTest** & **Pep8ParserTest**:
- Now implement AbstractParserTest and necessary methods
- Code cleanup where it made sense
- Changed test-cases to use junit5 (removed public modifier from methods)