### PR TITLE
fixed the endLineNumber for Cpd-Warnings

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/dry/cpd/CpdParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/dry/cpd/CpdParser.java
@@ -62,7 +62,7 @@ public class CpdParser extends AbstractDryParser<Duplication> {
             for (SourceFile file : duplication.getFiles()) {
                 IssueBuilder builder = new IssueBuilder().setPriority(getPriority(duplication.getLines()))
                         .setLineStart(file.getLine())
-                        .setLineEnd(file.getLine() + duplication.getLines())
+                        .setLineEnd(file.getLine() + duplication.getLines() -1)
                         .setFileName(file.getPath());
                 issues.add(new CodeDuplication(builder.build(), group));
             }

--- a/src/test/java/edu/hm/hafner/analysis/parser/dry/cpd/CpdParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/dry/cpd/CpdParserTest.java
@@ -82,11 +82,11 @@ class CpdParserTest extends AbstractParserTest<CodeDuplication> {
         CodeDuplication reporterSecond = issues.get(2);
         CodeDuplication publisherSecond = issues.get(3);
         softly.assertThat(reporterSecond)
-                .hasLineStart(274).hasLineEnd(274 + 95)
+                .hasLineStart(274).hasLineEnd(274 + 94)
                 .hasFileName(FILE_NAME_REPORTER)
                 .hasPriority(Priority.HIGH);
         softly.assertThat(publisherSecond)
-                .hasLineStart(202).hasLineEnd(202 + 95)
+                .hasLineStart(202).hasLineEnd(202 + 94)
                 .hasFileName(FILE_NAME_PUBLISHER)
                 .hasPriority(Priority.HIGH);
         softly.assertThat(publisherSecond.getDescription()).isNotEmpty();
@@ -134,13 +134,13 @@ class CpdParserTest extends AbstractParserTest<CodeDuplication> {
         assertThat(issues).hasSize(2);
         CodeDuplication first = issues.get(0);
         assertThat(first)
-                .hasLineStart(19).hasLineEnd(19 + 68)
+                .hasLineStart(19).hasLineEnd(19 + 67)
                 .hasFileName("csci07/csc60/remote_copy.sh")
                 .hasDescription(CODE_FRAGMENT)
                 .hasPriority(Priority.HIGH);
         CodeDuplication second = issues.get(1);
         assertThat(second)
-                .hasLineStart(19).hasLineEnd(19 + 68)
+                .hasLineStart(19).hasLineEnd(19 + 67)
                 .hasFileName("csci08/csc90/remote_copy.sh")
                 .hasDescription(CODE_FRAGMENT)
                 .hasPriority(Priority.HIGH);
@@ -179,11 +179,11 @@ class CpdParserTest extends AbstractParserTest<CodeDuplication> {
     private void assertThatReporterAndPublisherDuplicationsAreCorrectlyLinked(final CodeDuplication reporterFirst,
             final CodeDuplication publisherFirst) {
         assertThat(reporterFirst)
-                .hasLineStart(76).hasLineEnd(76 + 36)
+                .hasLineStart(76).hasLineEnd(76 + 35)
                 .hasFileName(FILE_NAME_REPORTER)
                 .hasPriority(Priority.NORMAL);
         assertThat(publisherFirst)
-                .hasLineStart(69).hasLineEnd(69 + 36)
+                .hasLineStart(69).hasLineEnd(69 + 35)
                 .hasFileName(FILE_NAME_PUBLISHER)
                 .hasPriority(Priority.NORMAL);
         assertThat(reporterFirst.getDescription()).isNotEmpty();


### PR DESCRIPTION
The endline was not calculated the right way, which lead to displaying in the wrong number of duplicate lines in the frontend.