### PR TITLE
Updates to Eclipse Compiler output parsing

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/EclipseParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/EclipseParser.java
@@ -57,9 +57,9 @@ public class EclipseParser extends RegexpDocumentParser {
                 break;
         }
 
-        // Columns are start index to after last index, 1 based index.
+        // Columns are a closed range, 1 based index.
         int columnStart = StringUtils.defaultString(matcher.group(5)).length() + 1;
-        int columnEnd = columnStart + matcher.group(6).length();
+        int columnEnd = columnStart + matcher.group(6).length() - 1;
 
         return builder
                 .setFileName(matcher.group(2))

--- a/src/main/java/edu/hm/hafner/analysis/parser/EclipseParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/EclipseParser.java
@@ -14,23 +14,25 @@ import edu.hm.hafner.util.VisibleForTesting;
  * A parser for Eclipse compiler warnings.
  *
  * @author Ullrich Hafner
+ * @author Jason Faust
  */
 public class EclipseParser extends RegexpDocumentParser {
     private static final long serialVersionUID = 425883472788422955L;
 
     /** Pattern for eclipse warnings. */
     @VisibleForTesting
-    public static final String ANT_ECLIPSE_WARNING_PATTERN = "\\[?(WARNING|ERROR)\\]?" +      // group 1 'type':
-            // WARNING or ERROR in optional []
-            "\\s*(?:in)?" +                  // optional " in"
-            "\\s*(.*)" +                     // group 2 'filename'
-            "(?:\\(at line\\s*(\\d+)\\)|" +  // either group 3 'lineNumber': at line dd
-            ":\\[(\\d+)).*" +                // or group 4 'rowNumber': eg :[row,col] - col ignored
-            "(?:\\r?\\n[^\\^\\n]*){1,3}" +   // 1 or 3 ignored lines (no column pointer) eg source excerpt
-            "\\r?\\n([^\\^]*)" +             // newline then group 5 (indent for column pointers)
-            "([\\^]+).*" +                   // group 6 column pointers (^^^^^)
-            "\\r?\\n(?:\\s*\\[.*\\]\\s*)?" + // newline then optional ignored text in [] (eg [javac])
-            "(.*)";                          // group 7 'message'
+    public static final String ANT_ECLIPSE_WARNING_PATTERN =
+            "(?:\\[?(?:INFO|WARNING|ERROR)\\]?.*)?" + // Ignore leading type (output embedded in output)
+            "\\[?(INFO|WARNING|ERROR)\\]?" +          // group 1 'type': INFO, WARNING or ERROR in optional []
+            "\\s*(?:in)?" +                           // optional " in"
+            "\\s*(.*)" +                              // group 2 'filename'
+            "(?:\\(at line\\s*(\\d+)\\)|" +           // either group 3 'lineNumber': at line dd
+            ":\\[(\\d+)).*" +                         // or group 4 'rowNumber': eg :[row,col] - col ignored
+            "(?:\\r?\\n[^\\^\\n]*)+?" +               // 1+ ignored lines (no column pointer) eg source excerpt
+            "\\r?\\n.*\\t([^\\^]*)" +                 // newline then group 5 (indent for column pointers)
+            "([\\^]+).*" +                            // group 6 column pointers (^^^^^)
+            "\\r?\\n(?:\\s*\\[.*\\]\\s*)?" +          // newline then optional ignored text in [] (eg [javac])
+            "(.*)";                                   // group 7 'message'
 
     /**
      * Creates a new instance of {@link EclipseParser}.
@@ -43,13 +45,19 @@ public class EclipseParser extends RegexpDocumentParser {
     protected Issue createIssue(final Matcher matcher, final IssueBuilder builder) {
         String type = StringUtils.capitalize(matcher.group(1));
         Severity priority;
-        if ("warning".equalsIgnoreCase(type)) {
-            priority = Severity.WARNING_NORMAL;
-        }
-        else {
-            priority = Severity.WARNING_HIGH;
+        switch (type) {
+            case "ERROR":
+                priority = Severity.ERROR;
+                break;
+            case "INFO":
+                priority = Severity.WARNING_LOW;
+                break;
+            default:
+                priority = Severity.WARNING_NORMAL;
+                break;
         }
 
+        // Columns are start index to after last index, 1 based index.
         int columnStart = StringUtils.defaultString(matcher.group(5)).length() + 1;
         int columnEnd = columnStart + matcher.group(6).length();
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/EclipseParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/EclipseParserTest.java
@@ -58,8 +58,8 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasLineStart(13)
                     .hasLineEnd(13)
-                    .hasColumnStart(15)
-                    .hasColumnEnd(15 + 13)
+                    .hasColumnStart(11)
+                    .hasColumnEnd(11 + 13)
                     .hasMessage("The method getOldValue() from the type SomeType is deprecated")
                     .hasFileName("/path/to/job/job-name/module/src/main/java/com/example/Example.java");
         });
@@ -174,5 +174,73 @@ public class EclipseParserTest extends AbstractIssueParserTest {
             number++;
         }
     }
+
+    /**
+     * Test for the info log level for the eclipse compiler.
+     */
+    @Test
+    void infoLogLevel() {
+        Report report = parse("eclipse-withinfo.txt");
+
+        assertThat(report).hasSize(6);
+
+        assertSoftly(softly -> {
+            softly.assertThat(report.get(0))
+                    .hasSeverity(Severity.ERROR)
+                    .hasLineStart(8)
+                    .hasLineEnd(8)
+                    .hasColumnStart(13)
+                    .hasColumnEnd(17)
+                    .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
+                    .hasMessage("Type mismatch: cannot convert from float to Integer");
+
+            softly.assertThat(report.get(1))
+                    .hasSeverity(Severity.ERROR)
+                    .hasLineStart(16)
+                    .hasLineEnd(16)
+                    .hasColumnStart(8)
+                    .hasColumnEnd(41)
+                    .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
+                    .hasMessage("Dead code");
+
+            softly.assertThat(report.get(2))
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasLineStart(22)
+                    .hasLineEnd(22)
+                    .hasColumnStart(9)
+                    .hasColumnEnd(10)
+                    .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
+                    .hasMessage("The value of the local variable x is not used");
+
+            softly.assertThat(report.get(3))
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasLineStart(27)
+                    .hasLineEnd(27)
+                    .hasColumnStart(8)
+                    .hasColumnEnd(41)
+                    .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
+                    .hasMessage(
+                            "Statement unnecessarily nested within else clause. The corresponding then clause does not complete normally");
+
+            softly.assertThat(report.get(4))
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasLineStart(33)
+                    .hasLineEnd(33)
+                    .hasColumnStart(13)
+                    .hasColumnEnd(19)
+                    .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
+                    .hasMessage("Comparing identical expressions");
+
+            softly.assertThat(report.get(5))
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasLineStart(35)
+                    .hasLineEnd(35)
+                    .hasColumnStart(1)
+                    .hasColumnEnd(96)
+                    .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
+                    .hasMessage("The allocated object is never used");
+        });
+    }
+
 }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/EclipseParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/EclipseParserTest.java
@@ -59,7 +59,7 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasLineStart(13)
                     .hasLineEnd(13)
                     .hasColumnStart(11)
-                    .hasColumnEnd(11 + 13)
+                    .hasColumnEnd(11 + 12)
                     .hasMessage("The method getOldValue() from the type SomeType is deprecated")
                     .hasFileName("/path/to/job/job-name/module/src/main/java/com/example/Example.java");
         });
@@ -190,7 +190,7 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasLineStart(8)
                     .hasLineEnd(8)
                     .hasColumnStart(13)
-                    .hasColumnEnd(17)
+                    .hasColumnEnd(16)
                     .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
                     .hasMessage("Type mismatch: cannot convert from float to Integer");
 
@@ -199,7 +199,7 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasLineStart(16)
                     .hasLineEnd(16)
                     .hasColumnStart(8)
-                    .hasColumnEnd(41)
+                    .hasColumnEnd(40)
                     .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
                     .hasMessage("Dead code");
 
@@ -208,7 +208,7 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasLineStart(22)
                     .hasLineEnd(22)
                     .hasColumnStart(9)
-                    .hasColumnEnd(10)
+                    .hasColumnEnd(9)
                     .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
                     .hasMessage("The value of the local variable x is not used");
 
@@ -217,7 +217,7 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasLineStart(27)
                     .hasLineEnd(27)
                     .hasColumnStart(8)
-                    .hasColumnEnd(41)
+                    .hasColumnEnd(40)
                     .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
                     .hasMessage(
                             "Statement unnecessarily nested within else clause. The corresponding then clause does not complete normally");
@@ -227,7 +227,7 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasLineStart(33)
                     .hasLineEnd(33)
                     .hasColumnStart(13)
-                    .hasColumnEnd(19)
+                    .hasColumnEnd(18)
                     .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
                     .hasMessage("Comparing identical expressions");
 
@@ -236,9 +236,30 @@ public class EclipseParserTest extends AbstractIssueParserTest {
                     .hasLineStart(35)
                     .hasLineEnd(35)
                     .hasColumnStart(1)
-                    .hasColumnEnd(96)
+                    .hasColumnEnd(95)
                     .hasFileName("C:/devenv/workspace/x/y/src/main/java/y/ECE.java")
                     .hasMessage("The allocated object is never used");
+        });
+    }
+
+    /**
+     * Test for the info log level for the eclipse compiler.
+     */
+    @Test
+    void columnCounting() {
+        Report report = parse("eclipse-columns.txt");
+
+        assertThat(report).hasSize(1);
+
+        assertSoftly(softly -> {
+            softly.assertThat(report.get(0))
+                    .hasSeverity(Severity.ERROR)
+                    .hasLineStart(2)
+                    .hasLineEnd(2)
+                    .hasColumnStart(1)
+                    .hasColumnEnd(5)
+                    .hasFileName("C:/TEMP/Column.java")
+                    .hasMessage("Syntax error on token \"12345\", delete this token");
         });
     }
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/eclipse-columns.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/eclipse-columns.txt
@@ -1,0 +1,9 @@
+# 10/29/18, 3:53:36 PM EDT
+# Eclipse Compiler for Java(TM) v20180905-0317, 3.15.0, Copyright IBM Corp 2000, 2015. All rights reserved.
+----------
+1. ERROR in C:\TEMP\Column.java (at line 2)
+	12345
+	^^^^^
+Syntax error on token "12345", delete this token
+----------
+1 problem (1 error)

--- a/src/test/resources/edu/hm/hafner/analysis/parser/eclipse-withinfo.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/eclipse-withinfo.txt
@@ -1,0 +1,42 @@
+# 10/15/18, 2:50:59 PM EDT
+# Eclipse Compiler for Java(TM) v20180905-0317, 3.15.0, Copyright IBM Corp 2000, 2015. All rights reserved.
+----------
+1. ERROR in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 8)
+	Integer x = 0.0f;
+	            ^^^^
+Type mismatch: cannot convert from float to Integer
+----------
+2. ERROR in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 16)
+	} else {
+            x = 20;
+        }
+	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Dead code
+----------
+3. WARNING in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 22)
+	Integer x;
+	        ^
+The value of the local variable x is not used
+----------
+4. WARNING in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 27)
+	} else {
+            x = 30;
+        }
+	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Statement unnecessarily nested within else clause. The corresponding then clause does not complete normally
+----------
+5. INFO in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 33)
+	Boolean x = 7 == 7;
+	            ^^^^^^
+Comparing identical expressions
+----------
+6. INFO in C:\devenv\workspace\x\y\src\main\java\y\ECE.java (at line 35)
+	new Object() {
+            {
+                System.out.println(x);
+            }
+        };
+	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The allocated object is never used
+----------
+6 problems (2 errors, 2 warnings, 2 info)

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue21377.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue21377.txt
@@ -1,6 +1,6 @@
 [INFO] Compiling 5 source files to /path/to/job/job-name/module/target/classes
 [WARNING] /path/to/job/job-name/module/src/main/java/com/example/Example.java:[13]
-    something.getOldValue();
-              ^^^^^^^^^^^^^
+	something.getOldValue();
+	          ^^^^^^^^^^^^^
 The method getOldValue() from the type SomeType is deprecated
 1 problem (1 warning)


### PR DESCRIPTION
* Support for 'INFO' at priority WARNING_LOW
* 'ERROR' is now at priority ERROR
* Note for how markers are counted (different from XML output)
* Skip leading type marker for log-in-log situations
* Allow source code to be one or more lines long
* Account for leading tab in column pointer line
* Correct error in test input of JENKINS-21377