### PR TITLE
IntelParser: Check for project number in regex

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/IntelParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/IntelParser.java
@@ -17,7 +17,7 @@ import edu.hm.hafner.analysis.Severity;
  */
 public class IntelParser extends FastRegexpLineParser {
     private static final long serialVersionUID = 8409744276858003050L;
-    private static final String INTEL_PATTERN = "^(.*)\\((\\d*)\\)?:(?:\\s*\\(col\\. (\\d+)\\))?.*("
+    private static final String INTEL_PATTERN = "^(\\d+>)?(.*)\\((\\d*)\\)?:(?:\\s*\\(col\\. (\\d+)\\))?.*("
             + "(?:remark|warning|error)\\s*#*\\d*)\\s*:\\s*(.*)$";
 
     /**
@@ -34,7 +34,7 @@ public class IntelParser extends FastRegexpLineParser {
 
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
-        String category = StringUtils.capitalize(matcher.group(4));
+        String category = StringUtils.capitalize(matcher.group(5));
 
         Severity priority;
         if (StringUtils.startsWith(category, "Remark")) {
@@ -47,11 +47,11 @@ public class IntelParser extends FastRegexpLineParser {
             priority = Severity.WARNING_NORMAL;
         }
 
-        return builder.setFileName(matcher.group(1))
-                .setLineStart(matcher.group(2))
-                .setColumnStart(matcher.group(3))
+        return builder.setFileName(matcher.group(2))
+                .setLineStart(matcher.group(3))
+                .setColumnStart(matcher.group(4))
                 .setCategory(category)
-                .setMessage(matcher.group(5))
+                .setMessage(matcher.group(6))
                 .setSeverity(priority)
                 .buildOptional();
     }

--- a/src/test/java/edu/hm/hafner/analysis/parser/IntelParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/IntelParserTest.java
@@ -24,7 +24,7 @@ class IntelParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(7);
+        softly.assertThat(report).hasSize(8);
         softly.assertThat(report.get(0))
                 .hasSeverity(Severity.WARNING_LOW)
                 .hasCategory("Remark")
@@ -82,6 +82,14 @@ class IntelParserTest extends AbstractParserTest {
                 .hasLineEnd(1)
                 .hasMessage("Syntax error, found END-OF-STATEMENT when expecting one of: ( % [ : . = =>")
                 .hasFileName("t.f90");
+
+        softly.assertThat(report.get(7))
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasCategory("Error ")
+                .hasLineStart(17)
+                .hasLineEnd(17)
+                .hasMessage("expected a \";\"")
+                .hasFileName("main.cpp");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/intelc.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/intelc.txt
@@ -9,3 +9,6 @@ D:\Hudson\workspace\boo\serviceif.cpp(17): remark #1418: external function defin
 /path/to/file1.f90(1): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [X]
 /path/to/file2.f(806): remark #8577: The scale factor (k) and number of fractional digits (d) do not have the allowed combination of either -d < k <= 0 or 0 < k < d+2. Expect asterisks as output.
 t.f90(1): error #5082: Syntax error, found END-OF-STATEMENT when expecting one of: ( % [ : . = =>
+
+# Visual Studio project number
+1>main.cpp(17): error : expected a ";"


### PR DESCRIPTION
Add a group to the regular expression to  check for the pattern '\d+>' at the beginning of the line. The line starts with a "project number" followed by '>' when using the Intel Compiler through Visual Studio.

A new test is added to test it.