### PR TITLE
Fix for JENKINS-55373

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -35,7 +35,10 @@ public class MsBuildParser extends RegexpLineParser {
 
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
-        builder.setFileName(determineFileName(matcher));
+        String fileName = determineFileName(matcher);
+        if (!"MSBUILD".equals(fileName.trim())) {
+            builder.setFileName(fileName);
+        }
 
         if (StringUtils.isNotBlank(matcher.group(2))) {
             return builder.setLineStart(0)

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -211,7 +211,6 @@ class MsBuildParserTest extends AbstractParserTest {
 
         assertSoftly(softly -> {
             softly.assertThat(warnings.get(0))
-                    .hasFileName("MSBUILD")
                     .hasCategory("CA2210")
                     .hasType("Microsoft.Design")
                     .hasSeverity(Severity.WARNING_NORMAL)


### PR DESCRIPTION
By setting the filename to MSBUILD in cases when
no fielname is specified within the message, follow-up
plugins will try to search for a non-existing file,
yielding to unnecessary error messages.