### PR TITLE
Fix parsing Ansible Lint output

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AnsibleLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnsibleLintParser.java
@@ -8,14 +8,17 @@ import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.RegexpLineParser;
 
 /**
- * A parser for the ansible lint warnings.
+ * A parser for Ansible Lint warnings.
+ * 
+ * The parser expects the Ansible Lint output to be in a "parseable output in the format of pep8".
+ * Pass the argument {@code -p} to Ansible Lint to get a compatible output.
  *
  * @author Ce Qi
  */
 public class AnsibleLintParser extends RegexpLineParser {
     private static final long serialVersionUID = 8481090596321427484L;
 
-    private static final String ANSIBLE_LINT_WARNING_PATTERN = "(.*)\\:([0-9]*)\\:\\s*\\[.*(ANSIBLE[0-9]*)\\]\\s(.*)";
+    private static final String ANSIBLE_LINT_WARNING_PATTERN = "(.*)\\:([0-9]*)\\:\\s*\\[(.*)\\]\\s(.*)";
 
     /**
      * Creates a new instance of {@link AnsibleLintParser}.

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
@@ -12,44 +12,51 @@ import edu.hm.hafner.analysis.assertj.SoftAssertions;
 /**
  * Tests the class {@link AnsibleLintParser}.
  */
-class AnsibleLintTest extends AbstractParserTest {
-    AnsibleLintTest() {
+class AnsibleLintParserTest extends AbstractParserTest {
+    AnsibleLintParserTest() {
         super("ansibleLint.txt");
     }
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(4);
+        assertThat(report).hasSize(5);
 
         Iterator<Issue> iterator = report.iterator();
         softly.assertThat(iterator.next())
                 .hasSeverity(Severity.WARNING_NORMAL)
-                .hasCategory("ANSIBLE0002")
+                .hasCategory("EANSIBLE0002")
                 .hasLineStart(2)
                 .hasLineEnd(2)
                 .hasMessage("Trailing whitespace")
                 .hasFileName("/workspace/roles/backup/tasks/main.yml");
         softly.assertThat(iterator.next())
                 .hasSeverity(Severity.WARNING_NORMAL)
-                .hasCategory("ANSIBLE0012")
+                .hasCategory("EANSIBLE0012")
                 .hasLineStart(1)
                 .hasLineEnd(1)
                 .hasMessage("Commands should not change things if nothing needs doing")
                 .hasFileName("/workspace/roles/upgrade/tasks/main.yml");
         softly.assertThat(iterator.next())
                 .hasSeverity(Severity.WARNING_NORMAL)
-                .hasCategory("ANSIBLE0011")
+                .hasCategory("EANSIBLE0011")
                 .hasLineStart(12)
                 .hasLineEnd(12)
                 .hasMessage("All tasks should be named")
                 .hasFileName("/workspace/roles/upgrade/tasks/main.yml");
         softly.assertThat(iterator.next())
                 .hasSeverity(Severity.WARNING_NORMAL)
-                .hasCategory("ANSIBLE0013")
+                .hasCategory("EANSIBLE0013")
                 .hasLineStart(12)
                 .hasLineEnd(12)
                 .hasMessage("Use shell only when shell functionality is required")
                 .hasFileName("/workspace/roles/roll_forward_target/tasks/main.yml");
+        softly.assertThat(iterator.next())
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("E301")
+                .hasLineStart(9)
+                .hasLineEnd(9)
+                .hasMessage("Commands should not change things if nothing needs doing")
+                .hasFileName("/workspace/roles/some_role/tasks/main.yml");
     }
 
     @Override

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
@@ -2,3 +2,5 @@
 /workspace/roles/upgrade/tasks/main.yml:1: [EANSIBLE0012] Commands should not change things if nothing needs doing
 /workspace/roles/upgrade/tasks/main.yml:12: [EANSIBLE0011] All tasks should be named
 /workspace/roles/roll_forward_target/tasks/main.yml:12: [EANSIBLE0013] Use shell only when shell functionality is required
+
+/workspace/roles/some_role/tasks/main.yml:9: [E301] Commands should not change things if nothing needs doing


### PR DESCRIPTION
According to [the Ansible list of rules](https://docs.ansible.com/ansible-lint/rules/default_rules.html), the rule category is not prefixed with `ANSIBLE` anymore but instead with an `E`. This is covered by what I get as output of Ansible Lint 4.0.1:

```
+ /usr/bin/env bash -c set -eo pipefail; ansible-lint -p site.yml | tee output-lint.txt
/home/rancher/jenkins/workspace/rga_ansible-office_PR-19/roles/jenkins_slave/tasks/create_jenkins_user.yml:9: [E301] Commands should not change things if nothing needs doing
/home/rancher/jenkins/workspace/rga_ansible-office_PR-19/roles/jenkins_slave/tasks/install_java.yml:1: [E301] Commands should not change things if nothing needs doing
/home/rancher/jenkins/workspace/rga_ansible-office_PR-19/roles/jenkins_slave/tasks/update_software.yml:2: [E301] Commands should not change things if nothing needs doing
```

Thus, I updated the regex in this repo to properly fix parsing the Ansible Lint output with the Warnings Next Generation plugin. I checked with [regex101](https://regex101.com/r/r2xs1r/5) that the new regex matches both `ANSIBLE` and just `E`. As I'm not sure whether Ansible wants to use other prefixes than `E` as well, I basically allowed everything with capital letters.

Should I create further PRs to make the change propagate to the Warnings Next Generation Plugin?