### PR TITLE
CppLint message with colon

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/CppLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CppLintParser.java
@@ -17,7 +17,7 @@ import static edu.hm.hafner.util.IntegerParser.parseInt;
 public class CppLintParser extends RegexpLineParser {
     private static final long serialVersionUID = 1737791073711198075L;
 
-    private static final String PATTERN = "^\\s*(.*)\\s*[(:](\\d*)\\)?:\\s*(.*)\\s*\\[(.*)\\] \\[(.*)\\]$";
+    private static final String PATTERN = "^\\s*(.*)\\s*[(:](\\d+)\\)?:\\s*(.*)\\s*\\[(.*)\\] \\[(.*)\\]$";
     private static final int SEVERITY_HIGH_LIMIT = 5;
     private static final int SEVERITY_NORMAL_LIMIT = 3;
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/CppLintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CppLintParserTest.java
@@ -60,6 +60,26 @@ class CppLintParserTest extends AbstractParserTest {
                 .hasSeverity(Severity.WARNING_LOW);
     }
 
+    /**
+     * Test CppLint messge with double colon.
+     */
+    @Test
+    void cpplintMessageWithColon() {
+        Report warnings = parse("cpplint-message-with-colon.txt");
+
+        assertThat(warnings).hasSize(1);
+
+        assertSoftly(softly -> {
+            softly.assertThat(warnings.get(0))
+                    .hasLineStart(1)
+                    .hasLineEnd(1)
+                    .hasMessage("Is this a non-const reference? If so, make const or use a pointer: std::vector<int> & indices")
+                    .hasFileName("/path/to/file.cpp")
+                    .hasCategory("runtime/references")
+                    .hasSeverity(Severity.WARNING_LOW);
+        });
+    }
+
     @Override
     protected CppLintParser createParser() {
         return new CppLintParser();

--- a/src/test/resources/edu/hm/hafner/analysis/parser/cpplint-message-with-colon.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/cpplint-message-with-colon.txt
@@ -1,0 +1,1 @@
+/path/to/file.cpp:1: Is this a non-const reference? If so, make const or use a pointer: std::vector<int> & indices  [runtime/references] [2]


### PR DESCRIPTION
Require the line number to be at least one digit by changing from "*" to "+". This will prevent the parser from treating the C++ scope resolution operator (::) as the separator between the filename, line number and message.

As shown in the test I had problem with the following message:
`/path/to/file.cpp:1: Is this a non-const reference? If so, make const or use a pointer: std::vector<int> & indices  [runtime/references] [2]`
where the filename would be set to `/path/to/file.cpp:1: Is this a non-const reference? If so, make const or use a pointer: std`, the line number an empty string and the message just `vector<int> & indices`

I am not sure I put the test in the correct place. Please advise me if you have any other suggestions.