### PR TITLE
Tweak regex to restore matching on older versions of IAR for ARM

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/IarParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/IarParser.java
@@ -14,12 +14,13 @@ import edu.hm.hafner.analysis.Severity;
  *
  * @author Claus Klein
  * @author Ullrich Hafner
+ * @author Jon Ware
  */
 public class IarParser extends RegexpLineParser {
     private static final long serialVersionUID = 7695540852439013425L;
 
     private static final String IAR_WARNING_PATTERN = ANT_TASK 
-            + "(?:(.*)\\((\\d+)\\) : )?(Error|Remark|Warning|Fatal [Ee]rror)\\[(\\w+)\\]: (.*)$";
+            + "(?:\"?(.*?)\"?[\\(,](\\d+)\\)?\\s+:?\\s+)?(Error|Remark|Warning|Fatal [Ee]rror)\\[(\\w+)\\]: (.*)$";
 
     /**
      * Creates a new instance of {@link IarParser}.

--- a/src/test/java/edu/hm/hafner/analysis/parser/IarParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/IarParserTest.java
@@ -10,6 +10,7 @@ import edu.hm.hafner.analysis.assertj.SoftAssertions;
  * Tests the class {@link IarParser}.
  *
  * @author Ullrich Hafner
+ * @author Jon Ware
  */
 class IarParserTest extends AbstractParserTest {
     IarParserTest() {
@@ -23,7 +24,7 @@ class IarParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(5).hasDuplicatesSize(1);
+        assertThat(report).hasSize(6).hasDuplicatesSize(1);
 
         softly.assertThat(report.get(0))
                 .hasSeverity(Severity.WARNING_NORMAL)
@@ -60,5 +61,12 @@ class IarParserTest extends AbstractParserTest {
                 .hasLineEnd(0)
                 .hasMessage("cannot open source file \"c:\\JenkinsJobs\\900ZH\\Workspace\\Lib\\Drivers\\_Obsolete\\Uart\\UartInterface.c\"")
                 .hasFileName("-");
+	softly.assertThat(report.get(5))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("Pe177")
+                .hasLineStart(861)
+                .hasLineEnd(861)
+                .hasMessage("function \"FlashErase\" was declared but never referenced")
+                .hasFileName("d:/jenkins/workspace/Nightly/src/flash/flashdrv.c");
     }
 }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue8823.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue8823.txt
@@ -4,3 +4,4 @@
 c:\JenkinsJobs\900ZH\Workspace\Product.900ZH\Src\System\AdditionalResources.h(17) : Fatal Error[Pe1696]: cannot open source file "System/ProcDef_LPC17xx.h"
 C:\dev\bsc\daqtask.c(43) : Warning[Pe177]: variable "pgMsgEnv" was declared but never referenced
 Fatal Error[Pe1696]: cannot open source file "c:\JenkinsJobs\900ZH\Workspace\Lib\Drivers\_Obsolete\Uart\UartInterface.c"
+"d:\jenkins\workspace\Nightly\src\flash\flashdrv.c",861  Warning[Pe177]: function "FlashErase" was declared but never referenced


### PR DESCRIPTION
Older versions of IAR for ARM (We currently use 7.20.2) report warnings in a different format.
e.g.
"d:\jenkins\workspace\Nightly\src\flash\flashdrv.c",861  Warning[Pe177]: function "FlashErase" was declared but never referenced

These could be identified by the parser prior to commit  c234b942.

I've tweaked the regex to restore functionality with these older versions, without breaking the current matching behaviour.

Please consider for a merge into master.

