### PR TITLE
IntelParser: Look for "message" as well

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/IntelParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/IntelParser.java
@@ -18,7 +18,7 @@ import edu.hm.hafner.analysis.Severity;
 public class IntelParser extends RegexpLineParser {
     private static final long serialVersionUID = 8409744276858003050L;
     private static final String INTEL_PATTERN = "^(\\d+>)?(.*)\\((\\d*)\\)?:(?:\\s*\\(col\\. (\\d+)\\))?.*("
-            + "(?:remark|warning|error)\\s*#*\\d*)\\s*:\\s*(.*)$";
+            + "(?:message|remark|warning|error)\\s*#*\\d*)\\s*:\\s*(.*)$";
 
     /**
      * Creates a new instance of {@link IntelParser}.
@@ -29,7 +29,7 @@ public class IntelParser extends RegexpLineParser {
 
     @Override
     protected boolean isLineInteresting(final String line) {
-        return line.contains("warning") || line.contains("error") || line.contains("remark");
+        return line.contains("warning") || line.contains("error") || line.contains("remark") || line.contains("message");
     }
 
     @Override
@@ -37,7 +37,7 @@ public class IntelParser extends RegexpLineParser {
         String category = StringUtils.capitalize(matcher.group(5));
 
         Severity priority;
-        if (StringUtils.startsWith(category, "Remark")) {
+        if (StringUtils.startsWith(category, "Remark") || StringUtils.startsWith(category, "Message")) {
             priority = Severity.WARNING_LOW;
         }
         else if (StringUtils.startsWith(category, "Error")) {

--- a/src/test/java/edu/hm/hafner/analysis/parser/IntelParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/IntelParserTest.java
@@ -24,7 +24,7 @@ class IntelParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(8);
+        softly.assertThat(report).hasSize(9);
         softly.assertThat(report.get(0))
                 .hasSeverity(Severity.WARNING_LOW)
                 .hasCategory("Remark")
@@ -90,6 +90,14 @@ class IntelParserTest extends AbstractParserTest {
                 .hasLineEnd(17)
                 .hasMessage("expected a \";\"")
                 .hasFileName("main.cpp");
+
+        softly.assertThat(report.get(8))
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasCategory("Message #593")
+                .hasLineStart(35)
+                .hasLineEnd(35)
+                .hasMessage("variable \"var\" was set but never used")
+                .hasFileName("D:/path/to/source/file.cpp");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/intelc.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/intelc.txt
@@ -12,3 +12,6 @@ t.f90(1): error #5082: Syntax error, found END-OF-STATEMENT when expecting one o
 
 # Visual Studio project number
 1>main.cpp(17): error : expected a ";"
+
+# message
+D:\path\to\source\file.cpp(35): message #593: variable "var" was set but never used


### PR DESCRIPTION
Look for diagnostics with the category "message" (in addition to remark,
warning and error). At the highest warning levels the Intel compiler
outputs these "warnings" which should be parsed as well.

A test is added to show it is working.