### PR TITLE
Add support for package and module in Pylint

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
@@ -45,8 +45,13 @@ public class PyLintParser extends RegexpLineParser {
         if (moduleName != null) {
             if (moduleName.contains(".")) {
                 builder.setPackageName(moduleName.substring(0, moduleName.lastIndexOf(".")));
+            } else {
+                builder.setPackageName("-");
             }
             builder.setModuleName(moduleName);
+        } else {
+            builder.setPackageName("-")
+                .setModuleName("-");
         }
 
         return builder.setFileName(matcher.group("path"))

--- a/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
@@ -19,7 +19,7 @@ public class PyLintParser extends RegexpLineParser {
     private static final long serialVersionUID = 4464053085862883240L;
 
     // the default pattern matches "--output-format=parseable" output.
-    private static final String PYLINT_PATTERN = "(?<path>.*):(?<line>\\d+): \\[(?<category>\\D\\d*)(?:\\((?<symbol>.*)\\), )?.*?\\] (?<message>.*)";
+    private static final String PYLINT_PATTERN = "(?<path>[^:]*)(?:\\:(?<module>.*))?:(?<line>\\d+): \\[(?<category>\\D\\d*)(?:\\((?<symbol>.*)\\), )?.*?\\] (?<message>.*)";
 
     private static final String UNKNOWN_CAT = "pylint-unknown";
 
@@ -40,6 +40,14 @@ public class PyLintParser extends RegexpLineParser {
         String category = matcher.group("category");
         builder.setSeverity(mapPriority(category));
         builder.setCategory(StringUtils.firstNonBlank(matcher.group("symbol"), category, UNKNOWN_CAT));
+
+        final String moduleName = matcher.group("module");
+        if (moduleName != null) {
+            if (moduleName.contains(".")) {
+                builder.setPackageName(moduleName.substring(0, moduleName.lastIndexOf(".")));
+            }
+            builder.setModuleName(moduleName);
+        }
 
         return builder.setFileName(matcher.group("path"))
                 .setLineStart(matcher.group("line"))

--- a/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
@@ -45,11 +45,13 @@ public class PyLintParser extends RegexpLineParser {
         if (moduleName != null) {
             if (moduleName.contains(".")) {
                 builder.setPackageName(moduleName.substring(0, moduleName.lastIndexOf(".")));
-            } else {
+            }
+            else {
                 builder.setPackageName("-");
             }
             builder.setModuleName(moduleName);
-        } else {
+        }
+        else {
             builder.setPackageName("-")
                 .setModuleName("-");
         }

--- a/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
@@ -236,7 +236,7 @@ class PylintParserTest extends AbstractParserTest {
                     .hasCategory("W0611")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasModuleName("module_name_no_package")
-                    .hasPackageName(null);
+                    .hasPackageName("-");
         });
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
@@ -168,7 +168,7 @@ class PylintParserTest extends AbstractParserTest {
     void shouldParseReportWithoutSymbol() {
         Report report = parse("pyLint.txt");
 
-        assertThat(report).hasSize(6);
+        assertThat(report).hasSize(8);
 
         Iterator<Issue> iterator = report.iterator();
         SoftAssertions.assertSoftly(softly -> {
@@ -219,6 +219,24 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/tv.py")
                     .hasCategory("W0102")
                     .hasSeverity(Severity.WARNING_NORMAL);
+            softly.assertThat(iterator.next())
+                    .hasLineStart(1)
+                    .hasLineEnd(1)
+                    .hasMessage("Unused import os (unused-import)")
+                    .hasFileName("trunk/src/python_package/module_name.py")
+                    .hasCategory("W0611")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasModuleName("python_package.module_name")
+                    .hasPackageName("python_package");
+            softly.assertThat(iterator.next())
+                    .hasLineStart(1)
+                    .hasLineEnd(1)
+                    .hasMessage("Unused import os (unused-import)")
+                    .hasFileName("trunk/src/module_name_no_package.py")
+                    .hasCategory("W0611")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasModuleName("module_name_no_package")
+                    .hasPackageName(null);
         });
     }
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/pyLint.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/pyLint.txt
@@ -4,3 +4,5 @@ trunk/src/python/tv.py:35: [C0111, Episode] Missing docstring
 trunk/src/python/tv.py:39: [E0213, Episode.__init__] Method should have "self" as first argument
 trunk/src/python/tv.py:5: [F0401, ] Unable to import 'deadbeef'
 trunk/src/python/tv.py:39: [W0102, Episode.__init__] Dangerous default value "[]" as argument
+trunk/src/python_package/module_name.py:python_package.module_name:1: [W0611, ] Unused import os (unused-import)
+trunk/src/module_name_no_package.py:module_name_no_package:1: [W0611, ] Unused import os (unused-import)


### PR DESCRIPTION
Add support for package and module in Pylint.

In python, a project can look like:
```
src
└── package
    ├── __init__.py
    ├── sub_package1
    │   ├── __init__.py
    │   ├── module1.py
    │   └── module2.py
    └── sub_package2
        ├── __init__.py
        ├── module3.py
        └── module4.py
```

So if a file named `__init__.py` exists in a folder, python will consider that folder as a package (or sub-package, but it's the same as a package, so no big difference). And any file that ends in `.py` is called a module.

Since warnings-ng supports package and module, I decided to also add support for them in the pylint parser.