### PR TITLE
Pylint: Add types and make categories types and categories, categories

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
@@ -19,7 +19,7 @@ public class PyLintParser extends RegexpLineParser {
     private static final long serialVersionUID = 4464053085862883240L;
 
     // the default pattern matches "--output-format=parseable" output.
-    private static final String PYLINT_PATTERN = "(?<path>[^:]*)(?:\\:(?<module>.*))?:(?<line>\\d+): \\[(?<type>(?<category>[A-Z])\\d*)(?:\\((?<symbol>.*)\\), )?.*?\\] (?<message>.*)";
+    private static final String PYLINT_PATTERN = "(?<path>[^:]*)(?:\\:(?<module>.*))?:(?<line>\\d+): \\[(?<type>(?<category>[A-Z])\\d*)?(?:\\((?<symbol>.*)\\), )?.*?\\] (?<message>.*)";
 
     private static final String UNKNOWN_CAT = "pylint-unknown-category";
     private static final String UNKNOWN_TYPE = "pylint-unknown-type";
@@ -92,7 +92,7 @@ public class PyLintParser extends RegexpLineParser {
         // priority.
 
         // See http://docs.pylint.org/output.html for definitions of the categories
-        if (category.isEmpty()) {
+        if (StringUtils.isEmpty(category)) {
             // if the category is missing from the output, default to 'normal'.
             return Severity.WARNING_NORMAL;
         }

--- a/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
@@ -22,7 +22,7 @@ public class PyLintParser extends RegexpLineParser {
     private static final String PYLINT_PATTERN = "(?<path>[^:]*)(?:\\:(?<module>.*))?:(?<line>\\d+): \\[(?<type>(?<category>[A-Z])\\d*)(?:\\((?<symbol>.*)\\), )?.*?\\] (?<message>.*)";
 
     private static final String UNKNOWN_CAT = "pylint-unknown-category";
-    private static final String UNKNOWN_TYPE = "pylint-unkown-type";
+    private static final String UNKNOWN_TYPE = "pylint-unknown-type";
 
     /**
      * Creates a new instance of {@link PyLintParser}.
@@ -40,7 +40,7 @@ public class PyLintParser extends RegexpLineParser {
     protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
         String category = matcher.group("category");
         builder.setSeverity(mapPriority(category));
-        builder.setCategory(StringUtils.firstNonBlank(mapCategory(category), UNKNOWN_CAT));
+        builder.setCategory(mapCategory(category));
         builder.setType(StringUtils.firstNonBlank(matcher.group("symbol"), matcher.group("type"), UNKNOWN_TYPE));
 
         final String moduleName = matcher.group("module");
@@ -65,7 +65,7 @@ public class PyLintParser extends RegexpLineParser {
     }
 
     private String mapCategory(final String category) {
-        if (category.isEmpty()) {
+        if (StringUtils.isEmpty(category)) {
             return UNKNOWN_CAT;
         }
         switch (category) {

--- a/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
@@ -19,9 +19,10 @@ public class PyLintParser extends RegexpLineParser {
     private static final long serialVersionUID = 4464053085862883240L;
 
     // the default pattern matches "--output-format=parseable" output.
-    private static final String PYLINT_PATTERN = "(?<path>[^:]*)(?:\\:(?<module>.*))?:(?<line>\\d+): \\[(?<category>\\D\\d*)(?:\\((?<symbol>.*)\\), )?.*?\\] (?<message>.*)";
+    private static final String PYLINT_PATTERN = "(?<path>[^:]*)(?:\\:(?<module>.*))?:(?<line>\\d+): \\[(?<type>(?<category>[A-Z])\\d*)(?:\\((?<symbol>.*)\\), )?.*?\\] (?<message>.*)";
 
-    private static final String UNKNOWN_CAT = "pylint-unknown";
+    private static final String UNKNOWN_CAT = "pylint-unknown-category";
+    private static final String UNKNOWN_TYPE = "pylint-unkown-type";
 
     /**
      * Creates a new instance of {@link PyLintParser}.
@@ -39,7 +40,8 @@ public class PyLintParser extends RegexpLineParser {
     protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
         String category = matcher.group("category");
         builder.setSeverity(mapPriority(category));
-        builder.setCategory(StringUtils.firstNonBlank(matcher.group("symbol"), category, UNKNOWN_CAT));
+        builder.setCategory(StringUtils.firstNonBlank(mapCategory(category), UNKNOWN_CAT));
+        builder.setType(StringUtils.firstNonBlank(matcher.group("symbol"), matcher.group("type"), UNKNOWN_TYPE));
 
         final String moduleName = matcher.group("module");
         if (moduleName != null) {
@@ -62,6 +64,29 @@ public class PyLintParser extends RegexpLineParser {
                 .buildOptional();
     }
 
+    private String mapCategory(final String category) {
+        if (category.isEmpty()) {
+            return UNKNOWN_CAT;
+        }
+        switch (category) {
+            case "I":
+                return "Informational";
+            case "R":
+                return "Refactor";
+            case "C":
+                return "Convention";
+            case "W":
+                return "Warning";
+            case "E":
+                return "Error";
+            case "F":
+                return "Fatal";
+
+            default:
+                return UNKNOWN_CAT;
+        }
+    }
+
     private Severity mapPriority(final String category) {
         // First letter of the Pylint classification is one of F/E/W/R/C. E/F/W are high
         // priority.
@@ -71,21 +96,23 @@ public class PyLintParser extends RegexpLineParser {
             // if the category is missing from the output, default to 'normal'.
             return Severity.WARNING_NORMAL;
         }
-        switch (category.charAt(0)) {
+        switch (category) {
+            // [I]nformational messages that Pylint emits (do not contribute to your analysis score)
             // [R]efactor for a ?good practice? metric violation
             // [C]onvention for coding standard violation
-            case 'R':
-            case 'C':
+            case "I":
+            case "R":
+            case "C":
                 return Severity.WARNING_LOW;
 
             // [W]arning for stylistic problems, or minor programming issues
-            case 'W':
+            case "W":
                 return Severity.WARNING_NORMAL;
 
             // [E]rror for important programming issues (i.e. most probably bug)
             // [F]atal for errors which prevented further processing
-            case 'E':
-            case 'F':
+            case "E":
+            case "F":
                 return Severity.WARNING_HIGH;
 
             default:

--- a/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PyLintParser.java
@@ -110,10 +110,11 @@ public class PyLintParser extends RegexpLineParser {
                 return Severity.WARNING_NORMAL;
 
             // [E]rror for important programming issues (i.e. most probably bug)
-            // [F]atal for errors which prevented further processing
             case "E":
-            case "F":
                 return Severity.WARNING_HIGH;
+            // [F]atal for errors which prevented further processing
+            case "F":
+                return Severity.ERROR;
 
             default:
                 return Severity.WARNING_LOW;

--- a/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
@@ -27,7 +27,7 @@ class PylintParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(20);
+        assertThat(report).hasSize(21);
 
         Iterator<Issue> iterator = report.iterator();
         softly.assertThat(iterator.next())
@@ -36,7 +36,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/non_existant.py")
                 .hasType("fatal")
                 .hasCategory("Fatal")
-                .hasSeverity(Severity.ERROR);
+                .hasSeverity(Severity.ERROR)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(16)
@@ -44,7 +46,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("bad-whitespace")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(24)
@@ -52,7 +56,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("superfluous-parens")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(1)
@@ -60,7 +66,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("missing-docstring")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(5)
@@ -68,7 +76,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("invalid-name")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(6)
@@ -76,7 +86,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("invalid-name")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(7)
@@ -84,7 +96,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("invalid-name")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(8)
@@ -92,7 +106,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("invalid-name")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(9)
@@ -100,7 +116,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("invalid-name")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(26)
@@ -108,7 +126,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("invalid-name")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(26)
@@ -116,7 +136,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("missing-docstring")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(27)
@@ -124,7 +146,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("missing-docstring")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(27)
@@ -132,7 +156,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("no-self-argument")
                 .hasCategory("Error")
-                .hasSeverity(Severity.WARNING_HIGH);
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(30)
@@ -140,7 +166,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("dangerous-default-value")
                 .hasCategory("Warning")
-                .hasSeverity(Severity.WARNING_NORMAL);
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(30)
@@ -148,7 +176,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("missing-docstring")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(30)
@@ -156,7 +186,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("no-self-use")
                 .hasCategory("Refactor")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(33)
@@ -164,7 +196,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("import-error")
                 .hasCategory("Error")
-                .hasSeverity(Severity.WARNING_HIGH);
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(33)
@@ -172,7 +206,9 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("wrong-import-position")
                 .hasCategory("Convention")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
 
         softly.assertThat(iterator.next())
                 .hasLineStart(33)
@@ -180,21 +216,34 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("unused-import")
                 .hasCategory("Warning")
-                .hasSeverity(Severity.WARNING_NORMAL);
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasModuleName("-")
+                .hasPackageName("-");
+
         softly.assertThat(iterator.next())
                 .hasLineStart(32)
                 .hasMessage("Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("c-extension-no-member")
                 .hasCategory("Informational")
-                .hasSeverity(Severity.WARNING_LOW);
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
+
+        softly.assertThat(iterator.next())
+                .hasLineStart(34)
+                .hasMessage("Unused import deadbeef")
+                .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
+                .hasType("unused-import")
+                .hasCategory("pylint-unknown-category")
+                .hasSeverity(Severity.WARNING_NORMAL);
     }
 
     @Test
     void shouldParseReportWithoutSymbol() {
         Report report = parse("pyLint.txt");
 
-        assertThat(report).hasSize(8);
+        assertThat(report).hasSize(9);
 
         Iterator<Issue> iterator = report.iterator();
         SoftAssertions.assertSoftly(softly -> {
@@ -205,7 +254,9 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/cachedhttp.py")
                     .hasType("C")
                     .hasCategory("Convention")
-                    .hasSeverity(Severity.WARNING_LOW);
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasModuleName("-")
+                    .hasPackageName("-");
 
             softly.assertThat(iterator.next())
                     .hasLineStart(28)
@@ -214,7 +265,9 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/tv.py")
                     .hasType("C0103")
                     .hasCategory("Convention")
-                    .hasSeverity(Severity.WARNING_LOW);
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasModuleName("-")
+                    .hasPackageName("-");
 
             softly.assertThat(iterator.next())
                     .hasLineStart(35)
@@ -223,7 +276,9 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/tv.py")
                     .hasType("C0111")
                     .hasCategory("Convention")
-                    .hasSeverity(Severity.WARNING_LOW);
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasModuleName("-")
+                    .hasPackageName("-");
 
             softly.assertThat(iterator.next())
                     .hasLineStart(39)
@@ -232,7 +287,9 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/tv.py")
                     .hasType("E0213")
                     .hasCategory("Error")
-                    .hasSeverity(Severity.WARNING_HIGH);
+                    .hasSeverity(Severity.WARNING_HIGH)
+                    .hasModuleName("-")
+                    .hasPackageName("-");
 
             softly.assertThat(iterator.next())
                     .hasLineStart(5)
@@ -241,7 +298,9 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/tv.py")
                     .hasType("F0401")
                     .hasCategory("Fatal")
-                    .hasSeverity(Severity.ERROR);
+                    .hasSeverity(Severity.ERROR)
+                    .hasModuleName("-")
+                    .hasPackageName("-");
 
             softly.assertThat(iterator.next())
                     .hasLineStart(39)
@@ -250,33 +309,42 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/tv.py")
                     .hasType("W0102")
                     .hasCategory("Warning")
-                    .hasSeverity(Severity.WARNING_NORMAL);
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasModuleName("-")
+                    .hasPackageName("-");
+
             softly.assertThat(iterator.next())
                     .hasLineStart(1)
                     .hasLineEnd(1)
                     .hasMessage("Unused import os (unused-import)")
                     .hasFileName("trunk/src/python_package/module_name.py")
-                    .hasCategory("W0611")
+                    .hasType("W0611")
+                    .hasCategory("Warning")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasModuleName("python_package.module_name")
                     .hasPackageName("python_package");
+
             softly.assertThat(iterator.next())
                     .hasLineStart(1)
                     .hasLineEnd(1)
                     .hasMessage("Unused import os (unused-import)")
                     .hasFileName("trunk/src/module_name_no_package.py")
-                    .hasCategory("W0611")
+                    .hasType("W0611")
+                    .hasCategory("Warning")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasModuleName("module_name_no_package")
                     .hasPackageName("-");
+
             softly.assertThat(iterator.next())
                     .hasLineStart(32)
                     .hasLineEnd(32)
                     .hasMessage("Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.")
                     .hasFileName("trunk/src/python/tv.py")
-                    .hasType("c-extension-no-member")
+                    .hasType("I1101")
                     .hasCategory("Informational")
-                    .hasSeverity(Severity.WARNING_LOW);
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasModuleName("-")
+                    .hasPackageName("-");
         });
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
@@ -27,7 +27,7 @@ class PylintParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(21);
+        assertThat(report).hasSize(22);
 
         Iterator<Issue> iterator = report.iterator();
         softly.assertThat(iterator.next())
@@ -236,7 +236,19 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
                 .hasType("unused-import")
                 .hasCategory("pylint-unknown-category")
-                .hasSeverity(Severity.WARNING_NORMAL);
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasModuleName("-")
+                .hasPackageName("-");
+
+        softly.assertThat(iterator.next())
+                .hasLineStart(35)
+                .hasMessage("This is a category/type that dooesn't exists in Pylint")
+                .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
+                .hasType("new-unknown-issue")
+                .hasCategory("pylint-unknown-category")
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasModuleName("-")
+                .hasPackageName("-");
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
@@ -27,141 +27,167 @@ class PylintParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(19);
+        assertThat(report).hasSize(20);
 
         Iterator<Issue> iterator = report.iterator();
         softly.assertThat(iterator.next())
                 .hasLineStart(1)
                 .hasMessage("No module named src/test/resources/non_existant.py")
                 .hasFileName("src/test/resources/non_existant.py")
-                .hasCategory("fatal")
+                .hasType("fatal")
+                .hasCategory("Fatal")
                 .hasSeverity(Severity.WARNING_HIGH);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(16)
                 .hasMessage("Exactly one space required around assignment")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("bad-whitespace")
+                .hasType("bad-whitespace")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(24)
                 .hasMessage("Unnecessary parens after 'print' keyword")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("superfluous-parens")
+                .hasType("superfluous-parens")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(1)
                 .hasMessage("Missing module docstring")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("missing-docstring")
+                .hasType("missing-docstring")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(5)
                 .hasMessage("Constant name \"shift\" doesn't conform to UPPER_CASE naming style")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("invalid-name")
+                .hasType("invalid-name")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(6)
                 .hasMessage("Constant name \"choice\" doesn't conform to UPPER_CASE naming style")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("invalid-name")
+                .hasType("invalid-name")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(7)
                 .hasMessage("Constant name \"word\" doesn't conform to UPPER_CASE naming style")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("invalid-name")
+                .hasType("invalid-name")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(8)
                 .hasMessage("Constant name \"letters\" doesn't conform to UPPER_CASE naming style")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("invalid-name")
+                .hasType("invalid-name")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(9)
                 .hasMessage("Constant name \"encoded\" doesn't conform to UPPER_CASE naming style")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("invalid-name")
+                .hasType("invalid-name")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(26)
                 .hasMessage("Class name \"test\" doesn't conform to PascalCase naming style")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("invalid-name")
+                .hasType("invalid-name")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(26)
                 .hasMessage("Missing class docstring")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("missing-docstring")
+                .hasType("missing-docstring")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(27)
                 .hasMessage("Missing method docstring")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("missing-docstring")
+                .hasType("missing-docstring")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(27)
                 .hasMessage("Method should have \"self\" as first argument")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("no-self-argument")
+                .hasType("no-self-argument")
+                .hasCategory("Error")
                 .hasSeverity(Severity.WARNING_HIGH);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(30)
                 .hasMessage("Dangerous default value [] as argument")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("dangerous-default-value")
+                .hasType("dangerous-default-value")
+                .hasCategory("Warning")
                 .hasSeverity(Severity.WARNING_NORMAL);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(30)
                 .hasMessage("Missing method docstring")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("missing-docstring")
+                .hasType("missing-docstring")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(30)
                 .hasMessage("Method could be a function")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("no-self-use")
+                .hasType("no-self-use")
+                .hasCategory("Refactor")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(33)
                 .hasMessage("Unable to import 'deadbeef'")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("import-error")
+                .hasType("import-error")
+                .hasCategory("Error")
                 .hasSeverity(Severity.WARNING_HIGH);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(33)
                 .hasMessage("Import \"import deadbeef\" should be placed at the top of the module")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("wrong-import-position")
+                .hasType("wrong-import-position")
+                .hasCategory("Convention")
                 .hasSeverity(Severity.WARNING_LOW);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(33)
                 .hasMessage("Unused import deadbeef")
                 .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
-                .hasCategory("unused-import")
+                .hasType("unused-import")
+                .hasCategory("Warning")
                 .hasSeverity(Severity.WARNING_NORMAL);
+        softly.assertThat(iterator.next())
+                .hasLineStart(32)
+                .hasMessage("Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.")
+                .hasFileName("src/test/resources/python_src/pypackage/pymodule.py")
+                .hasType("c-extension-no-member")
+                .hasCategory("Informational")
+                .hasSeverity(Severity.WARNING_LOW);
     }
 
     @Test
@@ -177,7 +203,8 @@ class PylintParserTest extends AbstractParserTest {
                     .hasLineEnd(3)
                     .hasMessage("Line too long (85/80)")
                     .hasFileName("trunk/src/python/cachedhttp.py")
-                    .hasCategory("C")
+                    .hasType("C")
+                    .hasCategory("Convention")
                     .hasSeverity(Severity.WARNING_LOW);
 
             softly.assertThat(iterator.next())
@@ -185,7 +212,8 @@ class PylintParserTest extends AbstractParserTest {
                     .hasLineEnd(28)
                     .hasMessage("Invalid name \"seasonCount\" (should match [a-z_][a-z0-9_]{2,30}$)")
                     .hasFileName("trunk/src/python/tv.py")
-                    .hasCategory("C0103")
+                    .hasType("C0103")
+                    .hasCategory("Convention")
                     .hasSeverity(Severity.WARNING_LOW);
 
             softly.assertThat(iterator.next())
@@ -193,7 +221,8 @@ class PylintParserTest extends AbstractParserTest {
                     .hasLineEnd(35)
                     .hasMessage("Missing docstring")
                     .hasFileName("trunk/src/python/tv.py")
-                    .hasCategory("C0111")
+                    .hasType("C0111")
+                    .hasCategory("Convention")
                     .hasSeverity(Severity.WARNING_LOW);
 
             softly.assertThat(iterator.next())
@@ -201,7 +230,8 @@ class PylintParserTest extends AbstractParserTest {
                     .hasLineEnd(39)
                     .hasMessage("Method should have \"self\" as first argument")
                     .hasFileName("trunk/src/python/tv.py")
-                    .hasCategory("E0213")
+                    .hasType("E0213")
+                    .hasCategory("Error")
                     .hasSeverity(Severity.WARNING_HIGH);
 
             softly.assertThat(iterator.next())
@@ -209,7 +239,8 @@ class PylintParserTest extends AbstractParserTest {
                     .hasLineEnd(5)
                     .hasMessage("Unable to import 'deadbeef'")
                     .hasFileName("trunk/src/python/tv.py")
-                    .hasCategory("F0401")
+                    .hasType("F0401")
+                    .hasCategory("Fatal")
                     .hasSeverity(Severity.WARNING_HIGH);
 
             softly.assertThat(iterator.next())
@@ -217,7 +248,8 @@ class PylintParserTest extends AbstractParserTest {
                     .hasLineEnd(39)
                     .hasMessage("Dangerous default value \"[]\" as argument")
                     .hasFileName("trunk/src/python/tv.py")
-                    .hasCategory("W0102")
+                    .hasType("W0102")
+                    .hasCategory("Warning")
                     .hasSeverity(Severity.WARNING_NORMAL);
             softly.assertThat(iterator.next())
                     .hasLineStart(1)
@@ -237,6 +269,14 @@ class PylintParserTest extends AbstractParserTest {
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasModuleName("module_name_no_package")
                     .hasPackageName("-");
+            softly.assertThat(iterator.next())
+                    .hasLineStart(32)
+                    .hasLineEnd(32)
+                    .hasMessage("Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.")
+                    .hasFileName("trunk/src/python/tv.py")
+                    .hasType("c-extension-no-member")
+                    .hasCategory("Informational")
+                    .hasSeverity(Severity.WARNING_LOW);
         });
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PylintParserTest.java
@@ -36,7 +36,7 @@ class PylintParserTest extends AbstractParserTest {
                 .hasFileName("src/test/resources/non_existant.py")
                 .hasType("fatal")
                 .hasCategory("Fatal")
-                .hasSeverity(Severity.WARNING_HIGH);
+                .hasSeverity(Severity.ERROR);
 
         softly.assertThat(iterator.next())
                 .hasLineStart(16)
@@ -241,7 +241,7 @@ class PylintParserTest extends AbstractParserTest {
                     .hasFileName("trunk/src/python/tv.py")
                     .hasType("F0401")
                     .hasCategory("Fatal")
-                    .hasSeverity(Severity.WARNING_HIGH);
+                    .hasSeverity(Severity.ERROR);
 
             softly.assertThat(iterator.next())
                     .hasLineStart(39)

--- a/src/test/resources/edu/hm/hafner/analysis/parser/pyLint.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/pyLint.txt
@@ -6,3 +6,4 @@ trunk/src/python/tv.py:5: [F0401, ] Unable to import 'deadbeef'
 trunk/src/python/tv.py:39: [W0102, Episode.__init__] Dangerous default value "[]" as argument
 trunk/src/python_package/module_name.py:python_package.module_name:1: [W0611, ] Unused import os (unused-import)
 trunk/src/module_name_no_package.py:module_name_no_package:1: [W0611, ] Unused import os (unused-import)
+trunk/src/python/tv.py:32: [I1101(c-extension-no-member), run] Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.

--- a/src/test/resources/edu/hm/hafner/analysis/parser/pyLint.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/pyLint.txt
@@ -6,4 +6,4 @@ trunk/src/python/tv.py:5: [F0401, ] Unable to import 'deadbeef'
 trunk/src/python/tv.py:39: [W0102, Episode.__init__] Dangerous default value "[]" as argument
 trunk/src/python_package/module_name.py:python_package.module_name:1: [W0611, ] Unused import os (unused-import)
 trunk/src/module_name_no_package.py:module_name_no_package:1: [W0611, ] Unused import os (unused-import)
-trunk/src/python/tv.py:32: [I1101(c-extension-no-member), run] Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.
+trunk/src/python/tv.py:32: [I1101, run] Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.

--- a/src/test/resources/edu/hm/hafner/analysis/parser/pylint_parseable.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/pylint_parseable.txt
@@ -23,6 +23,7 @@ src/test/resources/python_src/pypackage/pymodule.py:33: [C0413(wrong-import-posi
 src/test/resources/python_src/pypackage/pymodule.py:33: [W0611(unused-import), ] Unused import deadbeef
 src/test/resources/python_src/pypackage/pymodule.py:32: [I1101(c-extension-no-member), run] Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.
 src/test/resources/python_src/pypackage/pymodule.py:34: [(unused-import), ] Unused import deadbeef
+src/test/resources/python_src/pypackage/pymodule.py:35: [Z9999(new-unknown-issue), ] This is a category/type that dooesn't exists in Pylint
 
 --------------------------------------------------------------------
 Your code has been rated at -0.40/10 (previous run: -0.40/10, +0.00)

--- a/src/test/resources/edu/hm/hafner/analysis/parser/pylint_parseable.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/pylint_parseable.txt
@@ -22,7 +22,7 @@ src/test/resources/python_src/pypackage/pymodule.py:33: [E0401(import-error), ] 
 src/test/resources/python_src/pypackage/pymodule.py:33: [C0413(wrong-import-position), ] Import "import deadbeef" should be placed at the top of the module
 src/test/resources/python_src/pypackage/pymodule.py:33: [W0611(unused-import), ] Unused import deadbeef
 src/test/resources/python_src/pypackage/pymodule.py:32: [I1101(c-extension-no-member), run] Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.
-
+src/test/resources/python_src/pypackage/pymodule.py:34: [(unused-import), ] Unused import deadbeef
 
 --------------------------------------------------------------------
 Your code has been rated at -0.40/10 (previous run: -0.40/10, +0.00)

--- a/src/test/resources/edu/hm/hafner/analysis/parser/pylint_parseable.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/pylint_parseable.txt
@@ -21,6 +21,8 @@ src/test/resources/python_src/pypackage/pymodule.py:30: [R0201(no-self-use), tes
 src/test/resources/python_src/pypackage/pymodule.py:33: [E0401(import-error), ] Unable to import 'deadbeef'
 src/test/resources/python_src/pypackage/pymodule.py:33: [C0413(wrong-import-position), ] Import "import deadbeef" should be placed at the top of the module
 src/test/resources/python_src/pypackage/pymodule.py:33: [W0611(unused-import), ] Unused import deadbeef
+src/test/resources/python_src/pypackage/pymodule.py:32: [I1101(c-extension-no-member), run] Module 'PySide2.QtWidgets' has no 'QApplication' member, but source is unavailable.
+
 
 --------------------------------------------------------------------
 Your code has been rated at -0.40/10 (previous run: -0.40/10, +0.00)


### PR DESCRIPTION
As mentionned in [Jira](https://issues.jenkins-ci.org/browse/JENKINS-44915?focusedCommentId=303793&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-303793), the actual categories for Pylint should be types.

So I took the time to do the change. So I swapped the categories for the types, and introduced real categories. Now the Pylint parser does the same thing as the other parsers.

Note that I also added the category `[I]nformational` since it was missing and it's a valid Pylint category.