### PR TITLE
[JENKINS-54506] fixed Some compiler warnings are misidentified as Javadoc warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [JENKINS-55805](https://issues.jenkins-ci.org/browse/JENKINS-55805): 
 JavaDoc Parser: Improved performance (skip overly long lines).
+- [JENKINS-54506](https://issues.jenkins-ci.org/browse/JENKINS-54506):
+JavaDoc Parser: Java errors were detected as JavaDoc warnings.
 - [JENKINS-55750](https://issues.jenkins-ci.org/browse/JENKINS-55750),
 [PR#102](https://github.com/jenkinsci/analysis-model/pull/102): 
 IarParser: Added support for absolute Windows paths.

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavaDocParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavaDocParser.java
@@ -33,7 +33,7 @@ public class JavaDocParser extends RegexpLineParser {
     @Override
     protected boolean isLineInteresting(final String line) {
         return super.isLineInteresting(line)
-                && (line.contains("javadoc") || line.contains("@") || hasErrorPrefixAndErrorInMessage(line));
+                && (line.contains("javadoc") || line.contains(" @") || hasErrorPrefixAndErrorInMessage(line));
     }
 
     private boolean hasErrorPrefixAndErrorInMessage(final String line) {

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavaDocParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavaDocParserTest.java
@@ -10,6 +10,8 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.assertj.SoftAssertions;
 
+import java.util.Iterator;
+
 import static edu.hm.hafner.analysis.assertj.Assertions.*;
 import static edu.hm.hafner.analysis.assertj.SoftAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -213,11 +215,11 @@ class JavaDocParserTest extends AbstractParserTest {
     @Test
     void issue7718() {
         Report warnings = parse("issue7718.txt");
-
         assertThat(warnings).hasSize(7);
 
+        Iterator<Issue> iterator = warnings.iterator();
         assertSoftly(softly -> {
-            softly.assertThat(warnings.get(0))
+            softly.assertThat(iterator.next())
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasCategory("JavaDoc @sys")
                     .hasLineStart(0)
@@ -225,14 +227,66 @@ class JavaDocParserTest extends AbstractParserTest {
                     .hasMessage("Text of tag @sys.prop in class ch.post.pf.mw.service.common.alarm.AlarmingService is too long!")
                     .hasFileName("-");
 
-            softly.assertThat(warnings.get(1))
+            softly.assertThat(iterator.next())
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasCategory("-")
                     .hasLineStart(57)
                     .hasLineEnd(57)
                     .hasMessage("@(#) is an unknown tag.")
                     .hasFileName("/u01/src/KinePolygon.java");
+
+            softly.assertThat(iterator.next())
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasCategory("JavaDoc @param")
+                    .hasLineStart(26)
+                    .hasLineEnd(26)
+                    .hasMessage("@param argument \"wBuffer\" is not a parameter name.")
+                    .hasFileName("/u01/src/SpeedUnit.java");
+
+            softly.assertThat(iterator.next())
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasCategory("JavaDoc @return")
+                    .hasLineStart(65)
+                    .hasLineEnd(65)
+                    .hasMessage("@return tag cannot be used in method with void return type.")
+                    .hasFileName("/u01/src/code/com/abc/Argument.java");
+
+            softly.assertThat(iterator.next())
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasCategory("JavaDoc @see")
+                    .hasLineStart(1005)
+                    .hasLineEnd(1005)
+                    .hasMessage("Tag @see: can't find climb(int,")
+                    .hasFileName("/u01/src/code/com/abc/acPerformance/AcPerformanceServicesImpl.java");
+
+            softly.assertThat(iterator.next())
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasCategory("JavaDoc @return")
+                    .hasLineStart(517)
+                    .hasLineEnd(517)
+                    .hasMessage("Tag @return cannot be used in field documentation. It can only be used in the following types of documentation: method.")
+                    .hasFileName("/u01/src/code/com/abc/CodedRouteFormat.java");
+
+            softly.assertThat(iterator.next())
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasCategory("JavaDoc @List")
+                    .hasLineStart(64)
+                    .hasLineEnd(64)
+                    .hasMessage("@List is an unknown tag.")
+                    .hasFileName("/u01/src/code/com/abc/adasupport/EnhancedListIterator.java");
         });
+    }
+
+    /**
+     * Parses a log with Java compiler message (false positive).
+     *
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-54506">Issue 54506</a>
+     */
+    @Test
+    void issue54506() {
+        Report warnings = parse("issue54506.txt");
+
+        assertThat(warnings).isEmpty();
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue54506.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue54506.txt
@@ -1,0 +1,3 @@
+[ImmutableEnumChecker] enums should be immutable: 'Type' has field 'mime' of type 'com.acme.MyEnumType', the declaration of type 'com.acme.MyEnumType' is not annotated with @com.google.errorprone.annotations.Immutable
+
+[UnitTestGroup2] 2019-01-08 14:02:07 /opt/data/jenkins/Pipeline-Bitbucket/core@2/processing/src/java/com/acme/export/print/AbstractPdfExporter.java:54: warning: [deprecation] createTmpDirectory(String) in FileUtils has been deprecated


### PR DESCRIPTION
when there is a whitespace before the @ sign then it shall be indicated as interesing line for the JavaDoc parser, with this I was able to reduce the false positive.

Check also some issue7718 cases.