### PR TITLE
Jenkins 42823: False positive with msbuild parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [JENKINS-55345](https://issues.jenkins-ci.org/browse/JENKINS-55345): 
 DocFX Parser: Ignore Info messages and do not treat them as warnings.
+- [JENKINS-42823](https://issues.jenkins-ci.org/browse/JENKINS-42823): 
+msbuild Parser: Fix false positive with parser.
 
 ## [3.0.0](https://github.com/jenkinsci/analysis-model/compare/analysis-model-2.1.2...analysis-model-3.0.0) - 2019-3-15
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -22,7 +22,7 @@ public class MsBuildParser extends RegexpLineParser {
     private static final String MS_BUILD_WARNING_PATTERN
             = "(?:^(?:.*)Command line warning ([A-Za-z0-9]+):\\s*(.*)\\s*\\[(.*)\\])|"
             + ANT_TASK + "(?:(?:\\s*\\d+>)?(?:(?:(?:(.*)\\((\\d*)(?:,(\\d+))?.*\\)|.*LINK)\\s*:|"
-            + "(.*):)\\s*([A-z-_]*\\s?(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))\\s*:?\\s*([A-Za-z0-9\\-_]+)"
+            + "(.*):)\\s*([A-z-_]*\\s?(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))[^A-Za-z0-9]\\s*:?\\s*([A-Za-z0-9\\-_]+)"
             + "\\s*:\\s(?:\\s*([A-Za-z0-9.]+)\\s*:)?\\s*(.*?)(?: \\[([^\\]]*)[/\\\\][^\\]\\\\]+\\])?"
             + "|(.*)\\s*:.*error\\s*(LNK[0-9]+):\\s*(.*)))$";
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -23,6 +23,17 @@ class MsBuildParserTest extends AbstractParserTest {
     }
 
     /**
+     * Parses a file with false positive message.
+     *
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-42823">Issue 42823</a>
+     */
+    @Test
+    void issue42823() {
+        Report warnings = parse("issue42823.txt");
+        assertThat(warnings).isEmpty();
+    }
+
+    /**
      * MSBuildParser should make relative paths absolute if cmake is used.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-56193">Issue 56193</a>

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue42823.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue42823.txt
@@ -1,0 +1,2 @@
+3: Known information: 
+a whitespace at the end of the line above is important.


### PR DESCRIPTION
probably it is better to generate the wrong string instead of store it in the file. What do you think?