### PR TITLE
Ignore timestamper-plugin 1.9 prefixes when parsing Clang log messages.

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/ClangParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ClangParser.java
@@ -17,7 +17,9 @@ import edu.hm.hafner.analysis.RegexpLineParser;
 public class ClangParser extends RegexpLineParser {
     private static final long serialVersionUID = -3015592762345283182L;
 
-    private static final String CLANG_WARNING_PATTERN = "^\\s*(?:\\d+%)?([^%]*?):(\\d+):(?:(\\d+):)?" + "(?:"
+    private static final String CLANG_WARNING_PATTERN = "^"
+            + "(?:\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z\\])?" // Ignore timestamper-plugin 1.9 prefix.
+            + "\\s*(?:\\d+%)?([^%]*?):(\\d+):(?:(\\d+):)?" + "(?:"
             + "(?:\\{\\d+:\\d+-\\d+:\\d+\\})+:)?\\s*(warning|[^\\[\\]]*error):" + "\\s*(.*?)(?:\\[([^\\[]*)\\])?$";
     private static final Pattern IGNORE_FORMAT = Pattern.compile("^-\\[.*\\].*$");
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/ClangParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/ClangParserTest.java
@@ -193,4 +193,28 @@ class ClangParserTest extends AbstractParserTest {
                     .hasSeverity(Severity.WARNING_NORMAL);
         });
     }
+
+    /**
+     * Parses a file with one error that contains a timestamp prefix from timestamper-plugin 1.9.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-56484">Issue 56484</a>
+     */
+    @Test
+    void issue56484() {
+        Report warnings = parse("issue56484.txt");
+
+        assertThat(warnings).hasSize(1);
+
+        assertSoftly(softly -> {
+            softly.assertThat(warnings.get(0))
+                    .hasLineStart(1)
+                    .hasLineEnd(1)
+                    .hasColumnStart(2)
+                    .hasColumnEnd(2)
+                    .hasMessage("This is an error.")
+                    .hasFileName("test.c")
+                    .hasCategory(DEFAULT_CATEGORY)
+                    .hasSeverity(Severity.WARNING_HIGH);
+        });
+    }
 }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue56484.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue56484.txt
@@ -1,0 +1,1 @@
+[2019-03-22T19:49:00.841Z] test.c:1:2: error: This is an error.


### PR DESCRIPTION
Revised version of https://github.com/jenkinsci/analysis-model/pull/128 — uses timestamper-plugin's actual `ISO_OFFSET_DATE_TIME` storage format (now tested both in isolation and in a full Jenkins dev environment).