### PR TITLE
Use find rather than match in regexp filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/jenkinsci/analysis-model/compare/analysis-model-4.0.0...master)
+
 ### Fixed
 - [JENKINS-56333](https://issues.jenkins-ci.org/browse/JENKINS-56333): 
 MsBuild Parser: Treat errors as errors and not warning (high).
+
+### Changed
+- Filters now work on a substring of the property, you don't need to create a regular
+expression that matches the whole property value anymore. 
 
 ## [4.0.0](https://github.com/jenkinsci/analysis-model/compare/analysis-model-3.0.0...analysis-model-4.0.0) - 2019-3-20
 

--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -30,6 +30,7 @@ import edu.hm.hafner.util.Ensure;
 import edu.hm.hafner.util.NoSuchElementException;
 import edu.hm.hafner.util.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
+
 import static java.util.stream.Collectors.*;
 
 /**
@@ -748,7 +749,7 @@ public class Report implements Iterable<Issue>, Serializable {
             Collection<Predicate<Issue>> filters = new ArrayList<>();
             for (String pattern : patterns) {
                 filters.add(issueToFilter -> Pattern.compile(pattern, Pattern.DOTALL)
-                        .matcher(propertyToFilter.apply(issueToFilter)).matches() == (type == FilterType.INCLUDE));
+                        .matcher(propertyToFilter.apply(issueToFilter)).find() == (type == FilterType.INCLUDE));
             }
 
             if (type == FilterType.INCLUDE) {

--- a/src/test/java/edu/hm/hafner/analysis/IssueFilterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/IssueFilterTest.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.Report.IssueFilterBuilder;
+
 import static edu.hm.hafner.analysis.assertj.Assertions.*;
 
 /**
@@ -38,6 +39,23 @@ class IssueFilterTest {
             .setType("Type3")
             .setMessage("Message3")
             .build();
+
+    @Test
+    void shouldUseFindRatherThanMatch() {
+        Predicate<? super Issue> predicate = new IssueFilterBuilder().setIncludeMessageFilter("something").build();
+
+        Report report = new Report();
+        report.add(new IssueBuilder().setLineStart(1).setMessage("something").build());
+        report.add(new IssueBuilder().setLineStart(2).setMessage(" something").build());
+        report.add(new IssueBuilder().setLineStart(3).setMessage("something ").build());
+        report.add(new IssueBuilder().setLineStart(4).setMessage(" something ").build());
+        report.add(new IssueBuilder().setLineStart(5).setMessage("Before something After").build());
+        report.add(new IssueBuilder().setLineStart(6).setMessage("Before something").build());
+        report.add(new IssueBuilder().setLineStart(7).setMessage("something After").build());
+
+        Report filtered = report.filter(predicate);
+        assertThat(filtered).hasSize(7);
+    }
 
     @Test
     void shouldMatchMultiLines() {


### PR DESCRIPTION
All issue filters use a regular expression to match the content of an issue property. Currently the filter pattern must match the whole string property. This is somewhat cumbersome and not obvious to users. So this PR changes this behavior: now `Pattern.find` is used to find the next match in a substring of the property (Previously, `Pattern.matches` has been used). 