### PR TITLE
56737 - Allow timestamps preceding javac warnings

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -19,7 +19,8 @@ public class JavacParser extends RegexpLineParser {
     private static final long serialVersionUID = 7199325311690082782L;
 
     private static final String JAVAC_WARNING_PATTERN
-            = "^(?:\\[\\p{Alnum}*\\]\\s+)?"
+            = "^(?:\\S+\\s)?"                 // optional preceding arbitrary number of characters that are not a
+                                              // whitespace followed by one whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:)\\s+)" // optional [WARNING] or [ERROR] or w:
             + "([^\\[\\(]*):\\s*" +             // group 1: filename
             "[\\[\\(]" +                      // [ or (

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -65,6 +65,21 @@ class JavacParserTest extends AbstractParserTest {
     }
 
     /**
+     * Parses a log with 3 valid and 3 invalid timestamp preceding warnings.
+     * This test is related to issue https://issues.jenkins-ci.org/browse/JENKINS-56737
+     */
+    @Test
+    void shouldParseTimestamps() {
+        Report warnings = parse("javac-timestamps.txt");
+
+        assertThat(warnings).hasSize(4);
+        assertThat(warnings.get(0)).hasMessage("Test1");
+        assertThat(warnings.get(1)).hasMessage("Test2");
+        assertThat(warnings.get(2)).hasMessage("Test3");
+        assertThat(warnings.get(3)).hasMessage("Test4");
+    }
+
+    /**
      * Parses a warning log with two false positives.
      *
      * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-14043">Issue 14043</a>

--- a/src/test/resources/edu/hm/hafner/analysis/parser/javac-timestamps.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/javac-timestamps.txt
@@ -1,0 +1,12 @@
+Normal warning:
+[WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test1
+
+Valid warning strings with timestamps:
+08:52:34.395 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test2
+08:52:34 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test3
+08:52 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test4
+
+Invalid warning strings:
+ 08:52:34 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test5
+08:52:34[WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test6
+08:52:34 additional [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test7


### PR DESCRIPTION
Related to Issue https://issues.jenkins-ci.org/browse/JENKINS-56737

Javac warnings were not matched if a timestamp preceded the message.

Example:
08:52:34.395 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] redundant cast to long

Solution:
Warnings with timestamps will now be matched. The preceding word has to to be a arbitrary number of characters that are no whitespace followed by one whitespace. It is not checked if the preceding word is a timestamp at all because of the various timestamp formats that are allowed.