### PR TITLE
add Test and fix to Issue 48647

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Javac parser: Add the ability to parse warnings with preceding timestamps.
 - [JENKINS-56214](https://issues.jenkins-ci.org/browse/JENKINS-56214),
 [PR#142](https://github.com/jenkinsci/analysis-model/pull/142)
 ChackStyle parser: Map errors to severity ERROR (rather than WARNING_HIGH)
+- [JENKINS-48647](https://issues.jenkins-ci.org/browse/JENKINS-48647): 
+MsBuild Parser: Update regular expression to detect logging prefixes.
 
 ### Changed
 - Filters now work on a substring of the property, you don't need to create a regular

--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -21,7 +21,7 @@ public class MsBuildParser extends RegexpLineParser {
 
     private static final String MS_BUILD_WARNING_PATTERN
             = "(?:^(?:.*)Command line warning ([A-Za-z0-9]+):\\s*(.*)\\s*\\[(.*)\\])|"
-            + ANT_TASK + "(?:(?:\\s*\\d+>)?(?:(?:(?:(.*)\\((\\d*)(?:,(\\d+))?.*\\)|.*LINK)\\s*:|"
+            + ANT_TASK + "(?:(?:\\s*(?:\\d+|\\d+:\\d+)>)?(?:(?:(?:(.*)\\((\\d*)(?:,(\\d+))?.*\\)|.*LINK)\\s*:|"
             + "(.*):)\\s*([A-z-_]*\\s?(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))[^A-Za-z0-9]\\s*:?\\s*([A-Za-z0-9\\-_]+)"
             + "\\s*:\\s(?:\\s*([A-Za-z0-9.]+)\\s*:)?\\s*(.*?)(?: \\[([^\\]]*)[/\\\\][^\\]\\\\]+\\])?"
             + "|(.*)\\s*:.*error\\s*(LNK[0-9]+):\\s*(.*)))$";

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -705,6 +705,32 @@ class MsBuildParserTest extends AbstractParserTest {
         });
     }
 
+    /**
+     * Update regular expression to detect logging prefixes like <pre>17:4></pre>.
+     *
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-48647">Issue 48647</a>
+     */
+    @Test
+    void issue48647() {
+        Report warnings = parse("issue48647.txt");
+
+        assertThat(warnings)
+                .hasSize(1)
+                .hasSeverities(0, 0, 1, 0);
+
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("Filters/FilterBuilder.cs")
+                .hasCategory("CS0168")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasMessage("There is maybe a mistake.")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(229)
+                .hasLineEnd(229)
+                .hasColumnStart(34)
+                .hasColumnEnd(34));
+    }
+
     private ReaderFactory createIssue2383File() {
         return createReaderFactory("file.txt", IOUtils.toInputStream("Src\\Parser\\CSharp\\cs.ATG (2242,17):  Warning"
                 + " CS0168: The variable 'type' is declared but never used\r\nC:\\Src\\Parser\\CSharp\\file.cs"

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue48647.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue48647.txt
@@ -1,0 +1,1 @@
+17:4>Filters\FilterBuilder.cs(229,34): warning CS0168 : There is maybe a mistake.


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-48647

when log lines start with a prefix, e.g. "17:4>", it will be removed by regular expression. 