### PR TITLE
JENKINS-52477 - XML Parsers should use report encoding given in XML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [JENKINS-56333](https://issues.jenkins-ci.org/browse/JENKINS-56333): 
 MsBuild Parser: Treat errors as errors and not warning (high).
 
+- [JENKINS-52477](https://issues.jenkins-ci.org/browse/JENKINS-52477):
+FileReaderFactory: Detect charset from XML-header when not specified. 
+
 ### Changed
 - Filters now work on a substring of the property, you don't need to create a regular
 expression that matches the whole property value anymore. 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>analysis-model</artifactId>
-  <version>4.0.1-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/edu/hm/hafner/analysis/FileReaderFactory.java
+++ b/src/main/java/edu/hm/hafner/analysis/FileReaderFactory.java
@@ -80,8 +80,8 @@ public class FileReaderFactory extends ReaderFactory {
     private Charset detectCharset(final InputStream inputStream) throws IOException {
         Charset result = null;
 
-        try {
-            XMLStreamReader xmlStreamReader = XMLInputFactory.newInstance().createXMLStreamReader(new InputStreamReader(inputStream));
+        try (Reader reader = new InputStreamReader(inputStream)) {
+            XMLStreamReader xmlStreamReader = XMLInputFactory.newInstance().createXMLStreamReader(reader);
             String encodingTitle = xmlStreamReader.getCharacterEncodingScheme();
             if (encodingTitle != null) {
                 result = Charset.forName(encodingTitle);
@@ -90,7 +90,6 @@ public class FileReaderFactory extends ReaderFactory {
         catch (XMLStreamException e) {
             // Charset couldn't be detected
         }
-        inputStream.close();
 
         return result;
     }

--- a/src/main/java/edu/hm/hafner/analysis/FileReaderFactory.java
+++ b/src/main/java/edu/hm/hafner/analysis/FileReaderFactory.java
@@ -11,6 +11,10 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
 import org.apache.commons.io.input.BOMInputStream;
 
 import com.google.errorprone.annotations.MustBeClosed;
@@ -25,6 +29,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 public class FileReaderFactory extends ReaderFactory {
     private final Path file;
     private final String fileName;
+    private Charset charset;
+    private boolean charsetUndetected;
 
     /**
      * Creates a new factory to read the specified file with a given charset.
@@ -36,14 +42,29 @@ public class FileReaderFactory extends ReaderFactory {
      */
     public FileReaderFactory(final Path file, final @Nullable Charset charset) {
         super(charset);
-        
+
+        this.charset = charset;
+        charsetUndetected = charset == null;
         this.file = file;
         fileName = file.toAbsolutePath().toString().replace('\\', '/');
+    }
+
+    /**
+     * Creates a new factory to read the specified file. The charset will be detected from xml header.
+     *
+     * @param file
+     *         the file to open
+     */
+    public FileReaderFactory(final Path file) {
+        this(file, null);
     }
 
     @Override @MustBeClosed
     public Reader create() {
         try {
+            if (isCharsetUndetected()) {
+                setCharset(detectCharset(Files.newInputStream(file)));
+            }
             InputStream inputStream = Files.newInputStream(file);
 
             return new InputStreamReader(new BOMInputStream(inputStream), getCharset());
@@ -56,6 +77,24 @@ public class FileReaderFactory extends ReaderFactory {
         }
     }
 
+    private Charset detectCharset(final InputStream inputStream) throws IOException {
+        Charset result = null;
+
+        try {
+            XMLStreamReader xmlStreamReader = XMLInputFactory.newInstance().createXMLStreamReader(new InputStreamReader(inputStream));
+            String encodingTitle = xmlStreamReader.getCharacterEncodingScheme();
+            if (encodingTitle != null) {
+                result = Charset.forName(encodingTitle);
+            }
+        }
+        catch (XMLStreamException e) {
+            // Charset couldn't be detected
+        }
+        inputStream.close();
+
+        return result;
+    }
+
     /**
      * Returns the absolute path of the resource. The file name uses UNIX path separators.
      *
@@ -64,5 +103,18 @@ public class FileReaderFactory extends ReaderFactory {
     @Override
     public String getFileName() {
         return fileName;
+    }
+
+    @Override
+    public Charset getCharset() {
+        return charset == null ? super.getCharset() : charset;
+    }
+
+    private void setCharset(final Charset charset) {
+        this.charset = charset;
+    }
+
+    private boolean isCharsetUndetected() {
+        return charsetUndetected;
     }
 }

--- a/src/test/java/edu/hm/hafner/analysis/FileReaderFactoryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/FileReaderFactoryTest.java
@@ -1,0 +1,62 @@
+package edu.hm.hafner.analysis;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import static edu.hm.hafner.analysis.assertj.Assertions.*;
+
+/**
+ * Tests the class {@link FileReaderFactory}.
+ *
+ * @author Michael Schmid
+ */
+class FileReaderFactoryTest {
+    @Test
+    void useDefinedEncodingUtf8() {
+        FileReaderFactory sut = new FileReaderFactory(
+                new File("src/test/resources/edu/hm/hafner/analysis/encoded-with-UTF8.xml").toPath(),
+                StandardCharsets.UTF_8);
+        assertEncoding(sut, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void detectEncodingOfUtf8XmlFile() {
+        FileReaderFactory sut = new FileReaderFactory(
+                new File("src/test/resources/edu/hm/hafner/analysis/encoded-with-UTF8.xml").toPath());
+        assertEncoding(sut, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void useDefinedEncodingIso88591() {
+        FileReaderFactory sut = new FileReaderFactory(
+                new File("src/test/resources/edu/hm/hafner/analysis/encoded-with-ISO8859-1.xml").toPath(),
+                StandardCharsets.ISO_8859_1);
+        assertEncoding(sut, StandardCharsets.ISO_8859_1);
+    }
+
+    @Test
+    void detectEncodingOfIso88591XmlFile() {
+        FileReaderFactory sut = new FileReaderFactory(
+                new File("src/test/resources/edu/hm/hafner/analysis/encoded-with-ISO8859-1.xml").toPath());
+        assertEncoding(sut, StandardCharsets.ISO_8859_1);
+    }
+
+    @Test
+    void detectEncodingWithoutEncodingXmlFile() {
+        FileReaderFactory sut = new FileReaderFactory(
+                new File("src/test/resources/edu/hm/hafner/analysis/encoded-without-encoding.xml").toPath());
+        assertEncoding(sut, StandardCharsets.UTF_8);
+    }
+
+    private void assertEncoding(final FileReaderFactory sut, final Charset charset) {
+        Document document = sut.readDocument();
+        assertThat(sut.getCharset()).isEqualTo(charset);
+        assertThat(document.getElementsByTagName("text").item(0).getChildNodes().item(0).getNodeValue())
+                .isEqualTo("aä");
+    }
+
+}

--- a/src/test/resources/edu/hm/hafner/analysis/encoded-with-ISO8859-1.xml
+++ b/src/test/resources/edu/hm/hafner/analysis/encoded-with-ISO8859-1.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="ISO_8859-1"?>
+<text>aä</text>

--- a/src/test/resources/edu/hm/hafner/analysis/encoded-with-UTF8.xml
+++ b/src/test/resources/edu/hm/hafner/analysis/encoded-with-UTF8.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<text>aä</text>

--- a/src/test/resources/edu/hm/hafner/analysis/encoded-without-encoding.xml
+++ b/src/test/resources/edu/hm/hafner/analysis/encoded-without-encoding.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<text>aä</text>


### PR DESCRIPTION
Detect charset to use from xml header, when not specified in the FileReaderFactory constructor. Added a FileReaderFactory constructor without a charset parameter. 