### PR TITLE
Jenkins 52462: SonarQubeParser should read textRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/jenkinsci/analysis-model/compare/analysis-model-4.0.0...master)
+## [Unreleased](https://github.com/jenkinsci/analysis-model/compare/analysis-model-5.0.0...master)
+
+## [4.0.0](https://github.com/jenkinsci/analysis-model/compare/analysis-model-4.0.0...analysis-model-5.0.0) - 2019-4-10
 
 ### Added
 - [PR#132](https://github.com/jenkinsci/analysis-model/pull/132): 
 Added a parser for CMake warnings.
 - [PR#137](https://github.com/jenkinsci/analysis-model/pull/137):
 Added a parser for JSON output from Cargo.
+- [PR#155](https://github.com/jenkinsci/analysis-model/pull/155):
+Added textRange to SonarQubeParser.
 
 ### Fixed
 - [JENKINS-56333](https://issues.jenkins-ci.org/browse/JENKINS-56333),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/jenkinsci/analysis-model/compare/analysis-model-5.0.0...master)
-
-## [4.0.0](https://github.com/jenkinsci/analysis-model/compare/analysis-model-4.0.0...analysis-model-5.0.0) - 2019-4-10
+## [Unreleased](https://github.com/jenkinsci/analysis-model/compare/analysis-model-4.0.0...master)
 
 ### Added
 - [PR#132](https://github.com/jenkinsci/analysis-model/pull/132): 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>analysis-model</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeDiffParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeDiffParser.java
@@ -12,6 +12,8 @@ public class SonarQubeDiffParser extends SonarQubeParser {
 
     private static final String ISSUE_IS_NEW = "isNew";
     private static final String COMPONENT_MODULE_KEY = "moduleKey";
+    private static final String ISSUE_START_LINE = "startLine";
+    private static final String ISSUE_END_LINE = "endLine";
 
     @Override
     protected boolean accepts(final JSONObject object) {
@@ -26,5 +28,15 @@ public class SonarQubeDiffParser extends SonarQubeParser {
     @Override
     protected String getModulePath(final JSONObject component, final JSONObject issue) {
         return parseModulePath(component, COMPONENT_MODULE_KEY);
+    }
+
+    @Override
+    protected int parseStart(final JSONObject issue) {
+        return issue.optInt(ISSUE_START_LINE);
+    }
+
+    @Override
+    protected int parseEnd(final JSONObject issue) {
+        return issue.optInt(ISSUE_END_LINE);
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeIssuesParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeIssuesParser.java
@@ -9,8 +9,12 @@ import org.json.JSONObject;
  */
 public class SonarQubeIssuesParser extends SonarQubeParser {
     private static final long serialVersionUID = -8213765181968340929L;
-    
+
     private static final String ISSUE_SUB_PROJECT = "subProject";
+    private static final String ISSUE_TEXT_RANGE = "textRange";
+    private static final String ISSUE_TEXT_RANGE_START_LINE = "startLine";
+    private static final String ISSUE_TEXT_RANGE_END_LINE = "endLine";
+    private static final String ISSUE_LINE = "line";
 
     @Override
     protected boolean accepts(final JSONObject object) {
@@ -20,5 +24,21 @@ public class SonarQubeIssuesParser extends SonarQubeParser {
     @Override
     protected String getModulePath(final JSONObject component, final JSONObject issue) {
         return parseModulePath(issue, ISSUE_SUB_PROJECT);
+    }
+
+    @Override
+    protected int parseStart(final JSONObject issue) {
+        if (issue.has(ISSUE_TEXT_RANGE)) {
+            return issue.optJSONObject(ISSUE_TEXT_RANGE).optInt(ISSUE_TEXT_RANGE_START_LINE);
+        }
+        return issue.optInt(ISSUE_LINE);
+    }
+
+    @Override
+    protected int parseEnd(final JSONObject issue) {
+        if (issue.has(ISSUE_TEXT_RANGE)) {
+            return issue.optJSONObject(ISSUE_TEXT_RANGE).optInt(ISSUE_TEXT_RANGE_END_LINE);
+        }
+        return issue.optInt(ISSUE_LINE);
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeParser.java
@@ -36,8 +36,6 @@ public abstract class SonarQubeParser extends IssueParser {
     /** issue.message attribute. */
     private static final String ISSUE_MESSAGE = "message";
     /** issue.line attribute. */
-    private static final String ISSUE_LINE = "line";
-    /** issue.line attribute. */
     private static final String ISSUE_SEVERITY = "severity";
     /** issue.type attribute. */
     private static final String ISSUE_TYPE = "type";
@@ -144,6 +142,7 @@ public abstract class SonarQubeParser extends IssueParser {
         return new IssueBuilder()
                 .setFileName(parseFilename(issue))
                 .setLineStart(parseStart(issue))
+                .setLineEnd(parseEnd(issue))
                 .setType(parseType(issue))
                 .setCategory(CATEGORY_SONAR_QUBE)
                 .setMessage(parseMessage(issue))
@@ -198,9 +197,17 @@ public abstract class SonarQubeParser extends IssueParser {
      *
      * @return the start.
      */
-    private int parseStart(final JSONObject issue) {
-        return issue.optInt(ISSUE_LINE, -1);
-    }
+    protected abstract int parseStart(JSONObject issue);
+
+    /**
+     * Default parse for end.
+     *
+     * @param issue
+     *         the object to parse.
+     *
+     * @return the end.
+     */
+    protected abstract int parseEnd(JSONObject issue);
 
     /**
      * Default parse for type.

--- a/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SonarQubeParser.java
@@ -106,7 +106,7 @@ public abstract class SonarQubeParser extends IssueParser {
             if (object instanceof JSONObject) {
                 JSONObject issue = (JSONObject) object;
                 if (filterIssue(issue)) {
-                    report.add(createIssueFormJsonObject(issue));
+                    report.add(createIssueFromJsonObject(issue));
                 }
             }
         }
@@ -138,7 +138,7 @@ public abstract class SonarQubeParser extends IssueParser {
         return true; // Parse all issues by default
     }
 
-    private Issue createIssueFormJsonObject(final JSONObject issue) {
+    private Issue createIssueFromJsonObject(final JSONObject issue) {
         return new IssueBuilder()
                 .setFileName(parseFilename(issue))
                 .setLineStart(parseStart(issue))

--- a/src/test/java/edu/hm/hafner/analysis/parser/SonarQubeIssuesParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/SonarQubeIssuesParserTest.java
@@ -24,7 +24,7 @@ class SonarQubeIssuesParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(32);
+        softly.assertThat(report).hasSize(32).hasDuplicatesSize(0);
         softly.assertThat(report.get(0))
                 .hasFileName("src/com/tsystems/sbs/jenkinslib/SbsBuild.groovy")
                 .hasLineStart(631)

--- a/src/test/java/edu/hm/hafner/analysis/parser/SonarQubeIssuesParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/SonarQubeIssuesParserTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import edu.hm.hafner.analysis.AbstractParserTest;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.assertj.SoftAssertions;
+
 import static edu.hm.hafner.analysis.assertj.SoftAssertions.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -23,10 +24,11 @@ class SonarQubeIssuesParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(31);
+        softly.assertThat(report).hasSize(32);
         softly.assertThat(report.get(0))
                 .hasFileName("src/com/tsystems/sbs/jenkinslib/SbsBuild.groovy")
-                .hasLineStart(631);
+                .hasLineStart(631)
+                .hasLineEnd(631);
     }
 
     /**
@@ -38,11 +40,10 @@ class SonarQubeIssuesParserTest extends AbstractParserTest {
 
         assertThat(warnings).hasSize(106);
 
-        assertSoftly(softly -> {
-            softly.assertThat(warnings.get(0))
-                    .hasFileName("cart-common-folder/src/main/java/com/example/sonarqube/CloseResource.java")
-                    .hasLineStart(0);
-        });
+        assertSoftly(softly -> softly.assertThat(warnings.get(0))
+                .hasFileName("cart-common-folder/src/main/java/com/example/sonarqube/CloseResource.java")
+                .hasLineStart(0)
+                .hasLineEnd(0));
     }
 
     @Test


### PR DESCRIPTION
Fixed: https://issues.jenkins-ci.org/browse/JENKINS-52462
- Added parseEnd method and use textRange.
- Changed parseStart to abstract and implemented in both parsers.
- Fixed tests
- Increased version number and added info to changelog