### PR TITLE
Allow arbitrary w/s between timestamp and maven log line

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -19,17 +19,17 @@ public class JavacParser extends RegexpLineParser {
     private static final long serialVersionUID = 7199325311690082782L;
 
     private static final String JAVAC_WARNING_PATTERN
-            = "^(?:\\S+\\s)?"                 // optional preceding arbitrary number of characters that are not a
-                                              // whitespace followed by one whitespace. This can be used for timestamps.
+            = "^(?:\\S+\\s+)?"                // optional preceding arbitrary number of characters that are not a
+                                              // whitespace followed by whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:)\\s+)" // optional [WARNING] or [ERROR] or w:
-            + "([^\\[\\(]*):\\s*" +             // group 1: filename
-            "[\\[\\(]" +                      // [ or (
-            "(\\d+)[.,;]*" +                  // group 2: line number
-            "\\s?(\\d+)?" +                   // group 3: optional column
-            "[\\]\\)]\\s*" +                  // ] or )
-            ":?" +                            // optional :
-            "(?:\\[(\\w+)\\])?" +             // group 4: optional category
-            "\\s*(.*)$";                      // group 5: message
+            + "([^\\[\\(]*):\\s*"             // group 1: filename
+            + "[\\[\\(]"                      // [ or (
+            + "(\\d+)[.,;]*"                  // group 2: line number
+            + "\\s?(\\d+)?"                   // group 3: optional column
+            + "[\\]\\)]\\s*"                  // ] or )
+            + ":?"                            // optional :
+            + "(?:\\[(\\w+)\\])?"             // group 4: optional category
+            + "\\s*(.*)$";                    // group 5: message
 
     /**
      * Creates a new instance of {@link JavacParser}.

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -85,11 +85,12 @@ class JavacParserTest extends AbstractParserTest {
     void shouldParseTimestamps() {
         Report warnings = parse("javac-timestamps.txt");
 
-        assertThat(warnings).hasSize(4);
+        assertThat(warnings).hasSize(5);
         assertThat(warnings.get(0)).hasMessage("Test1");
         assertThat(warnings.get(1)).hasMessage("Test2");
         assertThat(warnings.get(2)).hasMessage("Test3");
         assertThat(warnings.get(3)).hasMessage("Test4");
+        assertThat(warnings.get(4)).hasMessage("Test8");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/javac-timestamps.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/javac-timestamps.txt
@@ -5,6 +5,7 @@ Valid warning strings with timestamps:
 08:52:34.395 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test2
 08:52:34 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test3
 08:52 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test4
+08:52  [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test8
 
 Invalid warning strings:
  08:52:34 [WARNING] /my/path/to/workspace/src/main/java/my/package/TemporalJsonSeqFiling.java:[86,76] Test5


### PR DESCRIPTION
On jenkins 2.165 with timestamper plugin 1.9, a declarative
pipeline as:

    pipeline {
        options {
            timestamps()
        }
        stages {
            // ... maven build
        }
    }

generates log lines with two whitespaces after the timestamps.

This change allows arbitrary whitespace; additionally it tidies
up the string concatenation of the regex.

See: https://www.regexplanet.com/share/index.html?share=yyyydxkgm6r