### PR TITLE
[JENKINS-57365] Fixes false positives for MsBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/jenkinsci/analysis-model/compare/analysis-model-5.0.0...master)
 
+### Fixed
+- [JENKINS-57365](https://issues.jenkins-ci.org/browse/JENKINS-57365),
+[PR#174](https://github.com/jenkinsci/analysis-model/pull/174): 
+Fixes false positives for MsBuild if e.g. a build project name contains the string info/note/warning.
+
 ## [5.0.1](https://github.com/jenkinsci/analysis-model/compare/analysis-model-5.0.0...analysis-model-5.0.1) - 2019-5-12
 
 - [JENKINS-57379](https://issues.jenkins-ci.org/browse/JENKINS-57379),

--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -22,7 +22,7 @@ public class MsBuildParser extends RegexpLineParser {
     private static final String MS_BUILD_WARNING_PATTERN
             = "(?:^(?:.*)Command line warning ([A-Za-z0-9]+):\\s*(.*)\\s*\\[(.*)\\])|"
             + ANT_TASK + "(?:(?:\\s*(?:\\d+|\\d+:\\d+)>)?(?:(?:(?:(.*?)\\((\\d*)(?:,(\\d+))?[a-zA-Z]*?\\)|.*LINK)\\s*:|"
-            + "(.*):)\\s*([A-z-_]*\\s?(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))[^A-Za-z0-9]\\s*:?\\s*([A-Za-z0-9\\-_]+)?"
+            + "(.*):)\\s*([A-z-_]*\\s(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))[^A-Za-z0-9]\\s*:?\\s*([A-Za-z0-9\\-_]+)?"
             + "\\s*:\\s(?:\\s*([A-Za-z0-9.]+)\\s*:)?\\s*(.*?)(?: \\[([^\\]]*)[/\\\\][^\\]\\\\]+\\])?"
             + "|(.*)\\s*:.*error\\s*(LNK[0-9]+):\\s*(.*)))$";
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -792,6 +792,18 @@ class MsBuildParserTest extends AbstractParserTest {
         });
     }
 
+    /**
+     * Parses a file with false positives if a build project name contains info.
+     *
+     * @see <a href="http://issues.jenkins-ci.org/browse/JENKINS-57365">Issue 57365</a>
+     */
+    @Test
+    void issue57365() {
+        Report warnings = parse("issue57365.txt");
+
+        assertThat(warnings).isEmpty();
+    }
+
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
         softly.assertThat(report)

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue57365.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue57365.txt
@@ -1,0 +1,1 @@
+311>------ Build started: Project: sysinfo, Configuration: Debug Win32 ------


### PR DESCRIPTION
Fixes false positives for MsBuild if e.g. a build project name contains the string info/note/warning.

This change requires a whitespace in front of the strings note, info, warning or fatal error to be recognized as the corresponding warnings.
See also: https://issues.jenkins-ci.org/browse/JENKINS-57365