### PR TITLE
[JENKINS-57098] JSON Parser for Json report

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
@@ -1,0 +1,112 @@
+package edu.hm.hafner.analysis.parser;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.LineRange;
+import edu.hm.hafner.analysis.LineRangeList;
+import edu.hm.hafner.analysis.Severity;
+
+/**
+ * Base Parser JSON format.
+ *
+ * @author Jeremie Bresson
+ */
+public abstract class JsonBaseParser extends IssuePropertiesParser {
+    private static final long serialVersionUID = -2318844382394973833L;
+
+    /**
+     * Deserialize an Issue from a JSON object.
+     * @param jsonIssue the issue as JSON object
+     * @return issue instance
+     */
+    protected Optional<Issue> convertToIssue(final JSONObject jsonIssue) {
+        IssueBuilder builder = new IssueBuilder();
+        if (jsonIssue.has(ADDITIONAL_PROPERTIES)) {
+            builder.setAdditionalProperties(jsonIssue.getString(ADDITIONAL_PROPERTIES));
+        }
+        if (jsonIssue.has(CATEGORY)) {
+            builder.setCategory(jsonIssue.getString(CATEGORY));
+        }
+        if (jsonIssue.has(COLUMN_END)) {
+            builder.setColumnEnd(jsonIssue.getInt(COLUMN_END));
+        }
+        if (jsonIssue.has(COLUMN_START)) {
+            builder.setColumnStart(jsonIssue.getInt(COLUMN_START));
+        }
+        if (jsonIssue.has(DESCRIPTION)) {
+            builder.setDescription(jsonIssue.getString(DESCRIPTION));
+        }
+        if (jsonIssue.has(DIRECTORY)) {
+            builder.setDirectory(jsonIssue.getString(DIRECTORY));
+        }
+        if (jsonIssue.has(FINGERPRINT)) {
+            builder.setFingerprint(jsonIssue.getString(FINGERPRINT));
+        }
+        if (jsonIssue.has(FILE_NAME)) {
+            builder.setFileName(jsonIssue.getString(FILE_NAME));
+        }
+        if (jsonIssue.has(ID)) {
+            builder.setId(UUID.fromString(jsonIssue.getString(ID)));
+        }
+        if (jsonIssue.has(LINE_END)) {
+            builder.setLineEnd(jsonIssue.getInt(LINE_END));
+        }
+        if (jsonIssue.has(LINE_RANGES)) {
+            JSONArray jsonRanges = jsonIssue.getJSONArray(LINE_RANGES);
+            LineRangeList lineRanges = convertToLineRangeList(jsonRanges);
+            builder.setLineRanges(lineRanges);
+        }
+        if (jsonIssue.has(LINE_START)) {
+            builder.setLineStart(jsonIssue.getInt(LINE_START));
+        }
+        if (jsonIssue.has(MESSAGE)) {
+            builder.setMessage(jsonIssue.getString(MESSAGE));
+        }
+        if (jsonIssue.has(MODULE_NAME)) {
+            builder.setModuleName(jsonIssue.getString(MODULE_NAME));
+        }
+        if (jsonIssue.has(ORIGIN)) {
+            builder.setOrigin(jsonIssue.getString(ORIGIN));
+        }
+        if (jsonIssue.has(PACKAGE_NAME)) {
+            builder.setPackageName(jsonIssue.getString(PACKAGE_NAME));
+        }
+        if (jsonIssue.has(REFERENCE)) {
+            builder.setReference(jsonIssue.getString(REFERENCE));
+        }
+        if (jsonIssue.has(SEVERITY)) {
+            builder.setSeverity(Severity.valueOf(jsonIssue.getString(SEVERITY)));
+        }
+        if (jsonIssue.has(TYPE)) {
+            builder.setType(jsonIssue.getString(TYPE));
+        }
+        return builder.buildOptional();
+    }
+
+    private LineRangeList convertToLineRangeList(final JSONArray jsonRanges) {
+        LineRangeList lineRanges = new LineRangeList();
+        for (int i = 0; i < jsonRanges.length(); i++) {
+            JSONObject jsonRange = jsonRanges.getJSONObject(i);
+            if (jsonRange.has(LINE_RANGE_START)) {
+                if (jsonRange.has(LINE_RANGE_END)) {
+                    lineRanges.add(new LineRange(jsonRange.getInt(LINE_RANGE_START), jsonRange.getInt(
+                            LINE_RANGE_END)));
+                }
+                else {
+                    lineRanges.add(new LineRange(jsonRange.getInt(LINE_RANGE_START)));
+                }
+            }
+            else if (jsonRange.has(LINE_RANGE_END)) {
+                lineRanges.add(new LineRange(jsonRange.getInt(LINE_RANGE_END), jsonRange.getInt(
+                        LINE_RANGE_END)));
+            }
+        }
+        return lineRanges;
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonLogParser.java
@@ -22,7 +22,7 @@ import edu.hm.hafner.analysis.Severity;
  *
  * @author Jeremie Bresson
  */
-public class JsonParser extends IssuePropertiesParser {
+public class JsonLogParser extends IssuePropertiesParser {
     private static final long serialVersionUID = 1349282064371959197L;
 
     @Override

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonLogParser.java
@@ -1,33 +1,27 @@
 package edu.hm.hafner.analysis.parser;
 
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Stream;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import edu.hm.hafner.analysis.Issue;
-import edu.hm.hafner.analysis.IssueBuilder;
-import edu.hm.hafner.analysis.LineRange;
-import edu.hm.hafner.analysis.LineRangeList;
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
-import edu.hm.hafner.analysis.Severity;
 
 /**
  * Parser for logs in JSON format.
  *
  * @author Jeremie Bresson
  */
-public class JsonLogParser extends IssuePropertiesParser {
+public class JsonLogParser extends JsonBaseParser {
     private static final long serialVersionUID = 1349282064371959197L;
 
     @Override
     public boolean accepts(final ReaderFactory readerFactory) {
-        return !readerFactory.getFileName().endsWith(".xml");
+        return !readerFactory.getFileName().endsWith(".xml") && !readerFactory.getFileName().endsWith(".json");
     }
 
     @Override
@@ -36,6 +30,8 @@ public class JsonLogParser extends IssuePropertiesParser {
             Report report = new Report();
             lines.map(String::trim)
                 .filter(line -> !line.isEmpty())
+                .filter(line -> !line.startsWith("//"))
+                .filter(line -> !line.startsWith("#"))
                 .map(line -> parseIssue(line, report))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -47,97 +43,11 @@ public class JsonLogParser extends IssuePropertiesParser {
     private Optional<Issue> parseIssue(final String line, final Report report) {
         try {
             JSONObject jsonIssue = new JSONObject(line);
-
             return convertToIssue(jsonIssue);
         }
         catch (JSONException e) {
             report.logException(e, "Could not parse line: «%s»", line);
             return Optional.empty();
         }
-    }
-
-    private Optional<Issue> convertToIssue(final JSONObject jsonIssue) {
-        IssueBuilder builder = new IssueBuilder();
-        if (jsonIssue.has(ADDITIONAL_PROPERTIES)) {
-            builder.setAdditionalProperties(jsonIssue.getString(ADDITIONAL_PROPERTIES));
-        }
-        if (jsonIssue.has(CATEGORY)) {
-            builder.setCategory(jsonIssue.getString(CATEGORY));
-        }
-        if (jsonIssue.has(COLUMN_END)) {
-            builder.setColumnEnd(jsonIssue.getInt(COLUMN_END));
-        }
-        if (jsonIssue.has(COLUMN_START)) {
-            builder.setColumnStart(jsonIssue.getInt(COLUMN_START));
-        }
-        if (jsonIssue.has(DESCRIPTION)) {
-            builder.setDescription(jsonIssue.getString(DESCRIPTION));
-        }
-        if (jsonIssue.has(DIRECTORY)) {
-            builder.setDirectory(jsonIssue.getString(DIRECTORY));
-        }
-        if (jsonIssue.has(FINGERPRINT)) {
-            builder.setFingerprint(jsonIssue.getString(FINGERPRINT));
-        }
-        if (jsonIssue.has(FILE_NAME)) {
-            builder.setFileName(jsonIssue.getString(FILE_NAME));
-        }
-        if (jsonIssue.has(ID)) {
-            builder.setId(UUID.fromString(jsonIssue.getString(ID)));
-        }
-        if (jsonIssue.has(LINE_END)) {
-            builder.setLineEnd(jsonIssue.getInt(LINE_END));
-        }
-        if (jsonIssue.has(LINE_RANGES)) {
-            JSONArray jsonRanges = jsonIssue.getJSONArray(LINE_RANGES);
-            LineRangeList lineRanges = convertToLineRangeList(jsonRanges);
-            builder.setLineRanges(lineRanges);
-        }
-        if (jsonIssue.has(LINE_START)) {
-            builder.setLineStart(jsonIssue.getInt(LINE_START));
-        }
-        if (jsonIssue.has(MESSAGE)) {
-            builder.setMessage(jsonIssue.getString(MESSAGE));
-        }
-        if (jsonIssue.has(MODULE_NAME)) {
-            builder.setModuleName(jsonIssue.getString(MODULE_NAME));
-        }
-        if (jsonIssue.has(ORIGIN)) {
-            builder.setOrigin(jsonIssue.getString(ORIGIN));
-        }
-        if (jsonIssue.has(PACKAGE_NAME)) {
-            builder.setPackageName(jsonIssue.getString(PACKAGE_NAME));
-        }
-        if (jsonIssue.has(REFERENCE)) {
-            builder.setReference(jsonIssue.getString(REFERENCE));
-        }
-        if (jsonIssue.has(SEVERITY)) {
-            builder.setSeverity(Severity.valueOf(jsonIssue.getString(SEVERITY)));
-        }
-        if (jsonIssue.has(TYPE)) {
-            builder.setType(jsonIssue.getString(TYPE));
-        }
-        return builder.buildOptional();
-    }
-
-    private LineRangeList convertToLineRangeList(final JSONArray jsonRanges) {
-        LineRangeList lineRanges = new LineRangeList();
-        for (int i = 0; i < jsonRanges.length(); i++) {
-            JSONObject jsonRange = jsonRanges.getJSONObject(i);
-            if (jsonRange.has(LINE_RANGE_START)) {
-                if (jsonRange.has(LINE_RANGE_END)) {
-                    lineRanges.add(new LineRange(jsonRange.getInt(LINE_RANGE_START), jsonRange.getInt(
-                            LINE_RANGE_END)));
-                }
-                else {
-                    lineRanges.add(new LineRange(jsonRange.getInt(LINE_RANGE_START)));
-                }
-            }
-            else if (jsonRange.has(LINE_RANGE_END)) {
-                lineRanges.add(new LineRange(jsonRange.getInt(LINE_RANGE_END), jsonRange.getInt(
-                        LINE_RANGE_END)));
-            }
-        }
-        return lineRanges;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonLogParser.java
@@ -31,7 +31,7 @@ public class JsonLogParser extends JsonBaseParser {
             lines.map(String::trim)
                 .filter(line -> !line.isEmpty())
                 .filter(line -> !line.startsWith("//"))
-                .filter(line -> !line.startsWith("#"))
+                .filter(line -> line.charAt(0) != '#')
                 .map(line -> parseIssue(line, report))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonParser.java
@@ -1,0 +1,52 @@
+package edu.hm.hafner.analysis.parser;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import edu.hm.hafner.analysis.ParsingException;
+import edu.hm.hafner.analysis.ReaderFactory;
+import edu.hm.hafner.analysis.Report;
+
+/**
+ * Parser report in JSON format as exported by the "Jenkins Warnings Next Generation Plugin".
+ *
+ * @author Jeremie Bresson
+ */
+public class JsonParser extends JsonBaseParser {
+    private static final long serialVersionUID = -6494117943149352139L;
+    private static final String ISSUES = "issues";
+
+    @Override
+    public boolean accepts(final ReaderFactory readerFactory) {
+        return readerFactory.getFileName().endsWith(".json");
+    }
+
+    @Override
+    public Report parse(final ReaderFactory readerFactory) throws ParsingException {
+        try (Reader reader = readerFactory.create()) {
+            JSONObject jsonReport = (JSONObject) new JSONTokener(reader).nextValue();
+
+            Report report = new Report();
+            if (jsonReport.has(ISSUES)) {
+                JSONArray issues = jsonReport.getJSONArray(ISSUES);
+                StreamSupport.stream(issues.spliterator(), false)
+                        .filter(o -> o instanceof JSONObject)
+                        .map(o -> convertToIssue((JSONObject) o))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .forEach(report::add);
+            }
+            return report;
+        }
+        catch (IOException | JSONException e) {
+            throw new ParsingException(e);
+        }
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonLogParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonLogParserTest.java
@@ -70,8 +70,9 @@ class JsonLogParserTest extends AbstractParserTest {
     }
 
     @Test
-    void shouldNotAcceptXmlFiles() {
+    void shouldNotAcceptXmlAndJsonFiles() {
         assertThat(createParser().accepts(createReaderFactory("xmlParserDefault.xml"))).isFalse();
+        assertThat(createParser().accepts(createReaderFactory("issues.json"))).isFalse();
     }
 
     @Test
@@ -87,6 +88,14 @@ class JsonLogParserTest extends AbstractParserTest {
         assertThat(report).hasSize(0);
         assertThat(report.getErrorMessages()).contains("Could not parse line: «\"description\":\"an \\\"important\\\" description\"}»");
     }
+    
+    @Test
+    void emptyReport() {
+        JsonLogParser parser = createParser();
+        Report report = parser.parse(createReaderFactory("json-issues-empty.txt"));
+        assertThat(report).hasSize(0);
+    }
+
 
     @Override
     protected JsonLogParser createParser() {

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonLogParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonLogParserTest.java
@@ -13,10 +13,10 @@ import edu.hm.hafner.analysis.assertj.SoftAssertions;
 import static edu.hm.hafner.analysis.assertj.Assertions.*;
 
 /**
- * Tests the class {@link JsonParser}.
+ * Tests the class {@link JsonLogParser}.
  */
-class JsonParserTest extends AbstractParserTest {
-    JsonParserTest() {
+class JsonLogParserTest extends AbstractParserTest {
+    JsonLogParserTest() {
         super("json-issues.log");
     }
 
@@ -89,7 +89,7 @@ class JsonParserTest extends AbstractParserTest {
     }
 
     @Override
-    protected JsonParser createParser() {
-        return new JsonParser();
+    protected JsonLogParser createParser() {
+        return new JsonLogParser();
     }
 }

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
@@ -1,0 +1,91 @@
+package edu.hm.hafner.analysis.parser;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.AbstractParserTest;
+import edu.hm.hafner.analysis.LineRange;
+import edu.hm.hafner.analysis.ParsingException;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertj.SoftAssertions;
+
+import static edu.hm.hafner.analysis.assertj.Assertions.*;
+
+/**
+ * Tests the class {@link JsonParser}.
+ */
+class JsonParserTest extends AbstractParserTest {
+
+    JsonParserTest() {
+        super("issues.json");
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        assertThat(report).hasSize(5);
+        assertThat(report.getErrorMessages()).isEmpty();
+
+        softly.assertThat(report.get(0))
+                .hasFileName("directory/test-file.txt")
+                .containsExactlyLineRanges(new LineRange(110, 111), new LineRange(120, 121))
+                .hasCategory("category")
+                .hasDescription("description")
+                .hasType("type")
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasMessage("message")
+                .hasPackageName("packageName")
+                .hasModuleName("moduleName")
+                .hasOrigin("origin")
+                .hasReference("reference")
+                .hasFingerprint("9CED6585900DD3CFB97B914A3CEB0E79")
+                .hasAdditionalProperties("additionalProperties")
+                .hasId(UUID.fromString("e7011244-2dab-4a54-a27b-2d0697f8f813"));
+
+        softly.assertThat(report.get(1))
+                .hasFileName("test.xml")
+                .hasLineStart(110)
+                .hasLineEnd(111)
+                .hasColumnStart(210)
+                .hasColumnEnd(220)
+                .hasDescription("some description")
+                .hasSeverity(Severity.ERROR)
+                .hasMessage("some message");
+
+        softly.assertThat(report.get(2))
+                .hasFileName("test.txt")
+                .containsExactlyLineRanges(new LineRange(110, 110), new LineRange(320, 320))
+                .hasDescription("an \"important\" description")
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasMessage("an \"important\" message");
+
+        softly.assertThat(report.get(3))
+                .hasFileName("some.properties")
+                .hasLineStart(20)
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        softly.assertThat(report.get(4))
+                .hasFileName("file.xml")
+                .containsExactlyLineRanges(new LineRange(11, 12), new LineRange(21, 22))
+                .hasSeverity(Severity.WARNING_NORMAL);
+    }
+
+    @Test
+    void shouldNotAcceptTextFiles() {
+        assertThat(createParser().accepts(createReaderFactory("gcc.txt"))).isFalse();
+    }
+
+    @Test
+    void shouldThrowParserException() {
+        assertThatThrownBy(() -> createParser().parse(createReaderFactory("issues-invalid.json")))
+                .isInstanceOf(ParsingException.class);
+        assertThatThrownBy(() -> createParser().parse(createReaderFactory("issues-broken.json")))
+                .isInstanceOf(ParsingException.class);
+    }
+
+    @Override
+    protected JsonParser createParser() {
+        return new JsonParser();
+    }
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issues-broken.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issues-broken.json
@@ -1,0 +1,4 @@
+{
+    "_class": "io.jenkins.plugins.analysis.core.restapi.ReportApi",
+    "size": 5
+    "issues":  42,

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issues-invalid.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issues-invalid.json
@@ -1,0 +1,33 @@
+{
+    "_class": "io.jenkins.plugins.analysis.core.restapi.ReportApi",
+    "issues": [
+        {
+            "fileName": "test-file.txt",
+            "fileName": "other.txt",
+            "lineRanges": [
+                {
+                    "start": 110,
+                    "end": 111
+                },
+                {
+                    "start": 120,
+                    "end": 121
+                }
+            ],
+            "directory": "directory",
+            "category": "category",
+            "type": "type",
+            "severity": "LOW",
+            "message": "message",
+            "description": "description",
+            "packageName": "packageName",
+            "moduleName": "moduleName",
+            "origin": "origin",
+            "reference": "reference",
+            "fingerprint": "9CED6585900DD3CFB97B914A3CEB0E79",
+            "additionalProperties": "additionalProperties",
+            "id": "e7011244-2dab-4a54-a27b-2d0697f8f813"
+        }
+    ],
+    "size": 5
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issues-no-issues.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issues-no-issues.json
@@ -1,0 +1,4 @@
+{
+    "_class": "io.jenkins.plugins.analysis.core.restapi.ReportApi",
+    "size": 0
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issues.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issues.json
@@ -1,0 +1,84 @@
+{
+    "_class": "io.jenkins.plugins.analysis.core.restapi.ReportApi",
+    "issues": [
+        {
+            "fileName": "test-file.txt",
+            "lineRanges": [
+                {
+                    "start": 110,
+                    "end": 111
+                },
+                {
+                    "start": 120,
+                    "end": 121
+                }
+            ],
+            "directory": "directory",
+            "category": "category",
+            "type": "type",
+            "severity": "LOW",
+            "message": "message",
+            "description": "description",
+            "packageName": "packageName",
+            "moduleName": "moduleName",
+            "origin": "origin",
+            "reference": "reference",
+            "fingerprint": "9CED6585900DD3CFB97B914A3CEB0E79",
+            "additionalProperties": "additionalProperties",
+            "id": "e7011244-2dab-4a54-a27b-2d0697f8f813"
+        },
+        {
+            "fileName": "test.xml",
+            "severity": "ERROR",
+            "lineStart": 110,
+            "lineEnd": 111,
+            "columnStart": 210,
+            "columnEnd": 220,
+            "message": "some message",
+            "description": "some description"
+        },
+        {
+            "fileName": "test.txt",
+            "lineRanges": [
+                {
+                    "start": 110
+                },
+                {
+                    "end": 320
+                },
+                {}
+            ],
+            "severity": "HIGH",
+            "message": "an \"important\" message",
+            "description": "an \"important\" description"
+        },
+        {
+            "fileName": "some.properties",
+            "severity": "NORMAL",
+            "lineStart": 20,
+            "other":true,
+            "additional": "stuff"
+        },
+        {
+            "fileName": "file.xml",
+            "lineRanges": [
+                {
+                    "start": 11,
+                    "end": 12,
+                    "other": 10,
+                    "additional": "stuff"
+                },
+                {
+                    "s": 11,
+                    "e": 12,
+                    "start": 21,
+                    "end": 22
+                }
+            ]
+        },
+        "string",
+        true,
+        42
+    ],
+    "size": 5
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/json-issues-empty.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/json-issues-empty.txt
@@ -1,0 +1,2 @@
+// This is a test LOG, on each line an issue serialized in JSON format
+// {"fileName":"comment.txt","severity":"ERROR","lineStart":10,"description":"some comment"} 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/json-issues.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/json-issues.log
@@ -1,7 +1,13 @@
+// This is a test LOG, on each line an issue serialized in JSON format
+// {"fileName":"comment.txt","severity":"ERROR","lineStart":10,"description":"some comment"}
 {"fileName":"file.txt","lineRanges":[{"start":10,"end":11},{"start":20,"end":21}],"directory":"d","category":"c","type":"t","severity":"LOW","message":"msg","description":"d","packageName":"pn","moduleName":"mdl","origin":"orgn","reference":"ref","fingerprint":"fgpt","additionalProperties":"ap","id":"823b92b6-98eb-41c4-83ce-b6ec1ed6f98f"}
 {"fileName":"test.txt","severity":"ERROR","lineStart":10,"lineEnd":11,"columnStart":110,"columnEnd":120,"message":"some message","description":"some description"}
 
 {"fileName":"test.txt", "lineRanges":[{"start":10}, {"end":220}, {}], "severity":"HIGH", "message":"an \"important\" message", "description":"an \"important\" description"}
-
+    
     {"fileName":"some.properties","severity":"NORMAL", "lineStart":10, "other":value, "additional": "stuff"}
 {"fileName":"file.xml","lineRanges":[{"start":11, "end":12, "other":10, "additional": "stuff"}, {"s":11, "e":12, "start":21, "end":22}]}
+
+ # {"fileName":"comment.txt","severity":"ERROR","lineStart":10,"description":"some comment"}
+ # this is the end
+ 


### PR DESCRIPTION
As discussed in https://github.com/jenkinsci/analysis-model/pull/168#issuecomment-494269551 and the next comments, this PR organize JSON parser differently:

**1.** `JsonLogParser` (introduced as `JsonParser` in #168)

The format is a file (not `.xml` and not `.json`) where each line is an issue serialized as separated JSON object.

**2.** `JsonParser`

Parse a JSON report produced by the "[Jenkins Warnings Next Generation Plugin](https://github.com/jenkinsci/warnings-ng-plugin)" with the API call: `GET [build-url]/[tool-id]/all/api/json`

The format is json file (ending with `.json`) containing a valid JSON Object.
This object as a member `issues` containing an array of issues. Example:

```json
{
    "issues": [
        {"fileName": "file.txt", "lineStart": 5, "lineEnd": 5, "message": "Message 1"},
        {"fileName": "other.txt", "lineStart": 15, "lineEnd": 18, "message": "Message 2"}
    ]
}

```