### PR TITLE
[JENKINS-59440] Add support for multi-module maven builds

### DIFF
--- a/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
@@ -157,6 +157,15 @@ class MavenConsoleParserTest extends AbstractParserTest {
                         + "    +-com.&lt;org&gt;:telesign:1.1\n"
                         + "      +-com.google.code.gson:gson:2.2.1</code></pre>");
     }
+    
+    @Test
+    void shouldIdentifyMavenModules() {
+        Report warnings = parse("maven-multimodule.log");
+        
+        assertThat(warnings).hasSize(2);
+        assertThat(warnings.get(0)).hasModuleName("edu.hm.hafner:analysis-model");
+        assertThat(warnings.get(1)).hasModuleName("edu.hm.hafner:some-other-plugin");
+    }
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {

--- a/src/test/resources/edu/hm/hafner/analysis/parser/maven-multimodule.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/maven-multimodule.log
@@ -1,0 +1,34 @@
+[INFO] Scanning for projects...
+[INFO]
+[INFO] --------------------< edu.hm.hafner:analysis-model >--------------------
+[INFO] Building Static Analysis Model and Parsers 2.0.0-SNAPSHOT
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO]
+[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ analysis-model ---
+[INFO] Changes detected - recompiling the module!
+[INFO] Compiling 125 source files to /Users/hafner/Development/git/analysis-model/target/test-classes
+[INFO]
+[INFO] --- maven-surefire-plugin:2.22.1:test (default-test) @ analysis-model ---
+[INFO]
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] --- maven-checkstyle-plugin:3.0.0:checkstyle (run-checkstyle) @ analysis-model ---
+[WARNING] Unable to locate Source XRef to link to - DISABLED
+[INFO]
+[INFO] ------------------< edu.hm.hafner:some-other-plugin >-------------------
+[INFO] Building Some Other Plugin 2.0.0-SNAPSHOT
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO]
+[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ analysis-model ---
+[INFO] Changes detected - recompiling the module!
+[INFO] Compiling 125 source files to /Users/hafner/Development/git/analysis-model/target/test-classes
+[INFO]
+[INFO] --- maven-surefire-plugin:2.22.1:test (default-test) @ analysis-model ---
+[INFO]
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] --- maven-checkstyle-plugin:3.0.0:checkstyle (run-checkstyle) @ analysis-model ---
+[WARNING] Unable to locate Source XRef to link to - DISABLED
+[INFO]


### PR DESCRIPTION
This is a hacktoberfest contribution.

See [JENKINS-59440](https://issues.jenkins-ci.org/browse/JENKINS-59440).

The maven parser uses and displays the module in which the issue occured.