### PR TITLE
[JENKINS-57428] Ignore errorprone warnings in the javac-parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>analysis-model</artifactId>
-  <version>6.0.4-SNAPSHOT</version>
+  <version>7.0.0-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -5,8 +5,10 @@ import java.util.regex.Matcher;
 
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.IssueBuilder;
-import edu.hm.hafner.analysis.RegexpLineParser;
+import edu.hm.hafner.analysis.LookaheadParser;
+import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.util.LookaheadStream;
 
 import static edu.hm.hafner.analysis.Categories.*;
 
@@ -15,8 +17,10 @@ import static edu.hm.hafner.analysis.Categories.*;
  *
  * @author Ullrich Hafner
  */
-public class JavacParser extends RegexpLineParser {
+public class JavacParser extends LookaheadParser {
     private static final long serialVersionUID = 7199325311690082782L;
+
+    private static final String ERRORPRONE_URL_PATTERN = "\\s+\\(see https?://errorprone\\S+\\s*\\)";
 
     private static final String JAVAC_WARNING_PATTERN
             = "^(?:\\S+\\s+)?"                // optional preceding arbitrary number of characters that are not a
@@ -44,7 +48,12 @@ public class JavacParser extends RegexpLineParser {
     }
 
     @Override
-    protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
+    protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
+            final IssueBuilder builder) throws ParsingException {        
+        if (lookahead.hasNext(ERRORPRONE_URL_PATTERN)) {
+            return Optional.empty();
+        }
+
         String type = matcher.group(1);
         if ("ERROR".equals(type)) {
             builder.setSeverity(Severity.ERROR);

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -20,7 +20,7 @@ import static edu.hm.hafner.analysis.Categories.*;
 public class JavacParser extends LookaheadParser {
     private static final long serialVersionUID = 7199325311690082782L;
 
-    private static final String ERRORPRONE_URL_PATTERN = "\\s+\\(see https?://errorprone\\S+\\s*\\)";
+    private static final String ERRORPRONE_URL_PATTERN = "\\s+\\(see https?://\\S+\\s*\\)";
 
     private static final String JAVAC_WARNING_PATTERN
             = "^(?:\\S+\\s+)?"                // optional preceding arbitrary number of characters that are not a

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -62,7 +62,7 @@ class JavacParserTest extends AbstractParserTest {
     void shouldParseAnsiColorCodedLog() {
         Report report = parse("maven-ansi.txt");
 
-        assertThat(report).hasSize(6);
+        assertThat(report).hasSize(4);
     }
 
     /**
@@ -198,6 +198,10 @@ class JavacParserTest extends AbstractParserTest {
         assertThat(warnings).hasSize(2);
         assertThat(warnings.get(0)).hasSeverity(Severity.ERROR);
         assertThat(warnings.get(1)).hasSeverity(Severity.ERROR);
+        
+        warnings = parse("errorprone-maven.log");
+        
+        assertThat(warnings).hasSize(0);
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -62,7 +62,7 @@ class JavacParserTest extends AbstractParserTest {
     void shouldParseAnsiColorCodedLog() {
         Report report = parse("maven-ansi.txt");
 
-        assertThat(report).hasSize(13);
+        assertThat(report).hasSize(6);
     }
 
     /**
@@ -189,6 +189,15 @@ class JavacParserTest extends AbstractParserTest {
         assertThatWarningIsAtLine(iterator.next(), 47);
         assertThatWarningIsAtLine(iterator.next(), 69);
         assertThatWarningIsAtLine(iterator.next(), 105);
+    }
+
+    @Test
+    void shouldNotIncludeErrorprone() {
+        Report warnings = parse("javac-errorprone.txt");
+        
+        assertThat(warnings).hasSize(2);
+        assertThat(warnings.get(0)).hasSeverity(Severity.ERROR);
+        assertThat(warnings.get(1)).hasSeverity(Severity.ERROR);
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/javac-errorprone.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/javac-errorprone.txt
@@ -1,0 +1,7 @@
+[ERROR] /home/jenkins/workspace/nings-plugin_hm-edu-testing-ILHMAVFV64G6RU3LAS4H3JHXF7CSO4KT7MY22WMDJ4EHQY7IVHTQ/src/test/java/io/jenkins/plugins/analysis/warnings/IssuesRecorderITest.java:[38,9] cannot access io.jenkins.plugins.analysis.core.model.LabelProviderFactoryITest
+  class file for io.jenkins.plugins.analysis.core.model.LabelProviderFactoryITest not found
+[ERROR] /home/jenkins/workspace/nings-plugin_hm-edu-testing-ILHMAVFV64G6RU3LAS4H3JHXF7CSO4KT7MY22WMDJ4EHQY7IVHTQ/src/test/java/io/jenkins/plugins/analysis/warnings/IssuesRecorderITest.java:[39,9] cannot access io.jenkins.plugins.analysis.core.model.LabelProviderFactoryITest.TestFactory
+  class file for io.jenkins.plugins.analysis.core.model.LabelProviderFactoryITest$TestFactory not found
+[WARNING] /Users/hafner/Development/jenkins/workspace/Model - Freestyle - New/src/main/java/edu/hm/hafner/analysis/parser/RobocopyParser.java:[29,45] [StringSplitter] String.split(String) has surprising behavior
+    (see http://errorprone.info/bugpattern/StringSplitter)
+  Did you mean 'String file = matcher.group(4).split("\\s{11}", -1)[0];'?


### PR DESCRIPTION
This is a hacktoberfest contribution.

See [JENKINS-57428](https://issues.jenkins-ci.org/browse/JENKINS-57428).

The JavacParser was changed to no longer include errorprone warnings.