### PR TITLE
Normalize Windows drive letters to upper case.

### DIFF
--- a/src/main/java/edu/hm/hafner/util/PathUtil.java
+++ b/src/main/java/edu/hm/hafner/util/PathUtil.java
@@ -19,6 +19,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 public class PathUtil {
     private static final String BACK_SLASH = "\\";
     private static final String SLASH = "/";
+    private static final String DRIVE_LETTER_PREFIX = "^[a-z]:/.*"; 
 
     /**
      * Returns the string representation of the specified path. The path will be actually resolved in the file system
@@ -38,7 +39,8 @@ public class PathUtil {
     /**
      * Returns the string representation of the specified path. The path will be actually resolved in the file system
      * and will be returned as fully qualified absolute path. In case of an error, i.e. if the file is not found, the
-     * provided {@code path} will be returned unchanged (but normalized using the UNIX path separator).
+     * provided {@code path} will be returned unchanged (but normalized using the UNIX path separator and upper case
+     * drive letter).
      *
      * @param path
      *         the path to get the absolute path for
@@ -57,7 +59,8 @@ public class PathUtil {
     /**
      * Returns the string representation of the specified path. The path will be actually resolved in the file system
      * and will be returned as fully qualified absolute path. In case of an error, i.e. if the file is not found, the
-     * provided {@code path} will be returned unchanged (but normalized using the UNIX path separator).
+     * provided {@code path} will be returned unchanged (but normalized using the UNIX path separator and upper case
+     * drive letter).
      *
      * @param path
      *         the path to get the absolute path for
@@ -74,7 +77,11 @@ public class PathUtil {
     }
 
     private String makeUnixPath(final String fileName) {
-        return fileName.replace(BACK_SLASH, SLASH);
+        String unixStyle = fileName.replace(BACK_SLASH, SLASH);
+        if (unixStyle.matches(DRIVE_LETTER_PREFIX)) {
+            unixStyle = StringUtils.capitalize(unixStyle);
+        }
+        return unixStyle;
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/parser/CppLintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CppLintParserTest.java
@@ -56,7 +56,7 @@ class CppLintParserTest extends AbstractParserTest {
                 .hasLineStart(824)
                 .hasLineEnd(824)
                 .hasMessage("Tab found; better to use spaces")
-                .hasFileName("c:/Workspace/Trunk/Project/P1/class.cpp")
+                .hasFileName("C:/Workspace/Trunk/Project/P1/class.cpp")
                 .hasCategory("whitespace/tab")
                 .hasSeverity(Severity.WARNING_LOW);
     }

--- a/src/test/java/edu/hm/hafner/analysis/parser/FxcopParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/FxcopParserTest.java
@@ -33,13 +33,13 @@ class FxcopParserTest extends AbstractParserTest {
                 .hasLineStart(299)
                 .hasLineEnd(299)
                 .hasMessage("<a href=\"http://msdn2.microsoft.com/library/ms182190(VS.90).aspx\">SpecifyIFormatProvider</a> - Because the behavior of 'decimal.ToString(string)' could vary based on the current user's locale settings, replace this call in 'FilmFacadeBase.Price.get()' with a call to 'decimal.ToString(string, IFormatProvider)'. If the result of 'decimal.ToString(string, IFormatProvider)' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.")
-                .hasFileName("c:/Hudson/data/jobs/job1/workspace/test/Space/TestBase.cs");
+                .hasFileName("C:/Hudson/data/jobs/job1/workspace/test/Space/TestBase.cs");
         softly.assertThat(report.get(1)).hasSeverity(Severity.ERROR)
                 .hasCategory("Microsoft.Naming")
                 .hasLineStart(37)
                 .hasLineEnd(37)
                 .hasMessage("<a href=\"http://msdn2.microsoft.com/library/bb264474(VS.90).aspx\">CompoundWordsShouldBeCasedCorrectly</a> - In member 'MyControl.InitialParameters(bool)', the discrete term 'javascript' in parameter name 'javascript' should be expressed as a compound word, 'javaScript'.")
-                .hasFileName("c:/Hudson/data/jobs/job1/workspace/web/UserControls/MyControl.ascx.cs");
+                .hasFileName("C:/Hudson/data/jobs/job1/workspace/web/UserControls/MyControl.ascx.cs");
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/parser/GendarmeParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GendarmeParserTest.java
@@ -38,7 +38,7 @@ class GendarmeParserTest extends AbstractParserTest {
                 .hasLineStart(10)
                 .hasLineEnd(10)
                 .hasMessage("This method does not use any instance fields, properties or methods and can be made static.")
-                .hasFileName("c:/Dev/src/hudson/Hudson.Domain/Dog.cs")
+                .hasFileName("C:/Dev/src/hudson/Hudson.Domain/Dog.cs")
                 .hasCategory("MethodCanBeMadeStaticRule")
                 .hasSeverity(Severity.WARNING_LOW);
 
@@ -47,7 +47,7 @@ class GendarmeParserTest extends AbstractParserTest {
                 .hasLineEnd(22)
                 .hasMessage(
                         "This method does not use any instance fields, properties or methods and can be made static.")
-                .hasFileName("c:/Dev/src/hudson/Hudson.Domain/Dog.cs")
+                .hasFileName("C:/Dev/src/hudson/Hudson.Domain/Dog.cs")
                 .hasCategory("MethodCanBeMadeStaticRule")
                 .hasSeverity(Severity.WARNING_LOW);
     }

--- a/src/test/java/edu/hm/hafner/analysis/parser/IarParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/IarParserTest.java
@@ -56,7 +56,7 @@ class IarParserTest extends AbstractParserTest {
                 .hasLineStart(17)
                 .hasLineEnd(17)
                 .hasMessage("cannot open source file \"System/ProcDef_LPC17xx.h\"")
-                .hasFileName("c:/JenkinsJobs/900ZH/Workspace/Product.900ZH/Src/System/AdditionalResources.h");
+                .hasFileName("C:/JenkinsJobs/900ZH/Workspace/Product.900ZH/Src/System/AdditionalResources.h");
         softly.assertThat(report.get(3))
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasCategory("Pe177")
@@ -77,7 +77,7 @@ class IarParserTest extends AbstractParserTest {
                 .hasLineStart(861)
                 .hasLineEnd(861)
                 .hasMessage("function \"FlashErase\" was declared but never referenced")
-                .hasFileName("d:/jenkins/workspace/Nightly/src/flash/flashdrv.c");
+                .hasFileName("D:/jenkins/workspace/Nightly/src/flash/flashdrv.c");
     }
 
     /**
@@ -125,7 +125,7 @@ class IarParserTest extends AbstractParserTest {
                     .hasLineStart(432)
                     .hasLineEnd(432)
                     .hasMessage("expression must be a pointer to a complete object type")
-                    .hasFileName("c:/external/specific/cpp/iar_cxxabi.cpp");
+                    .hasFileName("C:/external/specific/cpp/iar_cxxabi.cpp");
             softly.assertThat(warnings.get(1))
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasCategory("Pe549")

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -144,7 +144,7 @@ class MsBuildParserTest extends AbstractParserTest {
 
         assertSoftly(softly -> {
             softly.assertThat(warnings.get(0))
-                    .hasFileName("c:/solutiondir/projectdir/src/main.cpp")
+                    .hasFileName("C:/solutiondir/projectdir/src/main.cpp")
                     .hasCategory("C4996")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage(
@@ -157,7 +157,7 @@ class MsBuildParserTest extends AbstractParserTest {
                     .hasColumnEnd(0);
 
             softly.assertThat(warnings.get(1))
-                    .hasFileName("c:/solutiondir/projectdir/src/main.cpp")
+                    .hasFileName("C:/solutiondir/projectdir/src/main.cpp")
                     .hasCategory("C4996")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage(
@@ -306,7 +306,7 @@ class MsBuildParserTest extends AbstractParserTest {
                     .hasColumnEnd(0);
 
             softly.assertThat(warnings.get(1))
-                    .hasFileName("i:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
+                    .hasFileName("I:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
                     .hasCategory("CA1801")
                     .hasType("Microsoft.Usage")
                     .hasSeverity(Severity.WARNING_NORMAL)
@@ -319,7 +319,7 @@ class MsBuildParserTest extends AbstractParserTest {
                     .hasColumnEnd(0);
 
             softly.assertThat(warnings.get(2))
-                    .hasFileName("i:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
+                    .hasFileName("I:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
                     .hasCategory("CA1801")
                     .hasType("Microsoft.Usage")
                     .hasSeverity(Severity.WARNING_NORMAL)
@@ -567,7 +567,7 @@ class MsBuildParserTest extends AbstractParserTest {
 
         assertSoftly(softly -> softly.assertThat(warnings.get(0))
                 .hasFileName(
-                        "c:/jci/jobs/external_nvtristrip/workspace/compiler/cl/config/debug/platform/win32/tfields/live/external/nvtristrip/nvtristrip.cpp")
+                        "C:/jci/jobs/external_nvtristrip/workspace/compiler/cl/config/debug/platform/win32/tfields/live/external/nvtristrip/nvtristrip.cpp")
                 .hasCategory("C4706")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("assignment within conditional expression")
@@ -635,7 +635,7 @@ class MsBuildParserTest extends AbstractParserTest {
 
         assertSoftly(softly -> {
             softly.assertThat(warnings.get(0))
-                    .hasFileName("c:/playpens/Catalyst/Platform/src/Ptc.Platform.Web/Package/Package.package")
+                    .hasFileName("C:/playpens/Catalyst/Platform/src/Ptc.Platform.Web/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage(
@@ -648,7 +648,7 @@ class MsBuildParserTest extends AbstractParserTest {
                     .hasColumnEnd(0);
 
             softly.assertThat(warnings.get(1))
-                    .hasFileName("c:/playpens/Catalyst/Platform/src/Ptc.Platform.Web/Package/Package.package")
+                    .hasFileName("C:/playpens/Catalyst/Platform/src/Ptc.Platform.Web/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage(
@@ -662,7 +662,7 @@ class MsBuildParserTest extends AbstractParserTest {
 
             softly.assertThat(warnings.get(2))
                     .hasFileName(
-                            "c:/playpens/Catalyst/Platform/src/Ptc.Platform.ShowcaseSiteTemplate/Package/Package.package")
+                            "C:/playpens/Catalyst/Platform/src/Ptc.Platform.ShowcaseSiteTemplate/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage(
@@ -676,7 +676,7 @@ class MsBuildParserTest extends AbstractParserTest {
 
             softly.assertThat(warnings.get(3))
                     .hasFileName(
-                            "c:/playpens/Catalyst/Platform/src/Ptc.Platform.ShowcaseSiteTemplate/Package/Package.package")
+                            "C:/playpens/Catalyst/Platform/src/Ptc.Platform.ShowcaseSiteTemplate/Package/Package.package")
                     .hasCategory("SPT6")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage(

--- a/src/test/java/edu/hm/hafner/analysis/parser/TiCcsParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/TiCcsParserTest.java
@@ -55,7 +55,7 @@ class TiCcsParserTest extends AbstractParserTest {
                 .hasLineStart(2578)
                 .hasLineEnd(2578)
                 .hasMessage("variable")
-                .hasFileName("c:/DOCUME~1/JLINNE~1/LOCALS~1/Temp/0360811");
+                .hasFileName("C:/DOCUME~1/JLINNE~1/LOCALS~1/Temp/0360811");
         softly.assertThat(report.get(5))
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasLineStart(11)

--- a/src/test/java/edu/hm/hafner/analysis/parser/dry/simian/SimianParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/dry/simian/SimianParserTest.java
@@ -13,8 +13,8 @@ import edu.hm.hafner.analysis.assertj.SoftAssertions;
  * Tests the extraction of Simian's analysis results.
  */
 class SimianParserTest extends AbstractParserTest {
-    private static final String MATRIX_RUN = "c:/java/hudson/matrix/MatrixRun.java";
-    private static final String MAVEN_BUILD = "c:/java/hudson/maven/MavenBuild.java";
+    private static final String MATRIX_RUN = "C:/java/hudson/matrix/MatrixRun.java";
+    private static final String MAVEN_BUILD = "C:/java/hudson/maven/MavenBuild.java";
 
     SimianParserTest() {
         super("onefile.xml");
@@ -101,7 +101,7 @@ class SimianParserTest extends AbstractParserTest {
     }
 
     private String getFileName(final int number) {
-        return String.format("c:/java/foo%d.java", number);
+        return String.format("C:/java/foo%d.java", number);
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/util/PathUtilTest.java
+++ b/src/test/java/edu/hm/hafner/util/PathUtilTest.java
@@ -74,6 +74,13 @@ class PathUtilTest extends ResourceTest {
     }
 
     @Test
+    void normalizeDriveLetter() {
+        PathUtil pathUtil = new PathUtil();
+
+        assertThat(pathUtil.getAbsolutePath("c:\\tmp")).isEqualTo("C:/tmp");
+    }
+
+    @Test
     void stayInSymbolicLinks() throws IOException {
         Path current = Paths.get(".");
         Path real = current.toRealPath();


### PR DESCRIPTION
Inside of `AffectedFilesResolver.isInWorkspace()` of the warnings-ng project, the check fails in cases where different sources of file names may have upper case drive letters or lower case ones, on Windows.  This normalizes paths to force the drive letter into caps.

[AffectedFilesResolver.java](https://github.com/jenkinsci/warnings-ng-plugin/blob/master/src/main/java/io/jenkins/plugins/analysis/core/util/AffectedFilesResolver.java)