### PR TITLE
[JENKINS-59865] Skip lines that contain total time summary

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/SbtScalacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SbtScalacParser.java
@@ -16,7 +16,7 @@ import edu.hm.hafner.analysis.RegexpLineParser;
 public class SbtScalacParser extends RegexpLineParser {
     private static final long serialVersionUID = -4233964844965517977L;
 
-    private static final String SBT_WARNING_PATTERN = "^(\\[warn\\]|\\[error\\])\\s*(.*?):(\\d+)(?::\\d+)?:\\s*(.*)$";
+    private static final String SBT_WARNING_PATTERN = "^(\\[warn\\]|\\[error\\](?!\\s+Total\\stime:))\\s*(.*?):(\\d+)(?::\\d+)?:\\s*(.*)$"; 
 
     /**
      * Creates a new instance of {@link SbtScalacParser}.

--- a/src/test/resources/edu/hm/hafner/analysis/parser/sbtScalac.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/sbtScalac.txt
@@ -2,4 +2,5 @@
 [warn]     Thread.currentThread.stop()
 [error] /home/user/.jenkins/jobs/job/workspace/another/path/SomeFile.scala:9: ';' expected but identifier found.
 [warn] /home/user/.jenkins/jobs/job/workspace/Main.scala:4:18: implicit numeric widening
+[error] Total time: 127 s, completed Oct 7, 2019 9:11:30 AM
 [error] /home/user/.jenkins/jobs/job/workspace/Main.scala:5:11: Invalid literal number


### PR DESCRIPTION
This is the refinement of a previous pull request without the binary files. 

Resolved issue where [error] Total time: 127 s, completed Oct 7, 2019 9:11:30 AM was noted as an error when parsing the output of SBT parser.

- added '[error] Total time: 127 s, completed Oct 7, 2019 9:11:30 AM' to test file for SbtScalacParserTest.java

- changed regex to "^(\\[warn\\]|\\[error\\](?!\\s+Total\\stime:))\\s*(.*?):(\\d+)(?::\\d+)?:\\s*(.*)$" to add negative lookahead prevening it from picking up '[error] Total time:' identifier 