### PR TITLE
[JENKINS-57638] Add configurable report names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>analysis-model</artifactId>
-  <version>8.0.0-beta9</version>
+  <version>${revision}${changelist}</version>
 
   <packaging>jar</packaging>
 
@@ -20,7 +20,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}</url>
-    <tag>analysis-model-8.0.0-beta9</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <licenses>
@@ -47,7 +47,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>8.0.0-beta9</revision>
+    <revision>8.0.0-beta10</revision>
     <changelist>-SNAPSHOT</changelist>
     <source.encoding>UTF-8</source.encoding>
     <project.build.sourceEncoding>${source.encoding}</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.hm.hafner</groupId>
   <artifactId>analysis-model</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>8.0.0-beta9</version>
 
   <packaging>jar</packaging>
 
@@ -20,7 +20,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}</url>
-    <tag>${scmTag}</tag>
+    <tag>analysis-model-8.0.0-beta9</tag>
   </scm>
 
   <licenses>

--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -21,6 +22,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.impl.factory.Lists;
@@ -59,6 +61,7 @@ public class Report implements Iterable<Issue>, Serializable {
     private final List<String> errorMessages = new ArrayList<>();
 
     private final Set<String> fileNames = new HashSet<>();
+    private Map<String, String> namesByOrigin = new HashMap<>();
 
     private int duplicatesSize = 0;
 
@@ -183,8 +186,22 @@ public class Report implements Iterable<Issue>, Serializable {
     }
 
     /**
-     * Adds the specified file name to the set of file names in this report. The file name identifies the file
-     * that has been processed to obtain all the issues of this report.
+     * Called after de-serialization to improve the memory usage and to initialize fields that have been introduced
+     * after the first release.
+     *
+     * @return this
+     */
+    protected Object readResolve() {
+        if (namesByOrigin == null) {
+            namesByOrigin = new HashMap<>();
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds the specified file name to the set of file names in this report. The file name identifies the file that has
+     * been processed to obtain all the issues of this report.
      *
      * @param fileName
      *         the report file name to add
@@ -623,6 +640,7 @@ public class Report implements Iterable<Issue>, Serializable {
         destination.duplicatesSize += source.duplicatesSize;
         destination.infoMessages.addAll(source.infoMessages);
         destination.errorMessages.addAll(source.errorMessages);
+        destination.namesByOrigin.putAll(source.namesByOrigin);
     }
 
     /**
@@ -749,6 +767,30 @@ public class Report implements Iterable<Issue>, Serializable {
         result = 31 * result + errorMessages.hashCode();
         result = 31 * result + duplicatesSize;
         return result;
+    }
+
+    /**
+     * Returns a human readable name for the specified {@code origin} of this report.
+     *
+     * @param origin
+     *         the origin to get the human readable name for
+     *
+     * @return the name, or an empty string ifg noi such name has been set
+     */
+    public String getNameOfOrigin(final String origin) {
+        return namesByOrigin.getOrDefault(origin, StringUtils.EMPTY);
+    }
+
+    /**
+     * Provides a human readable name for the specified {@code origin} of this report.
+     *
+     * @param origin
+     *         the origin to define a name for
+     * @param name
+     *         the human readable name
+     */
+    public void setNameOfOrigin(final String origin, final String name) {
+        namesByOrigin.put(origin, name);
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/ReportTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/ReportTest.java
@@ -56,6 +56,49 @@ class ReportTest extends SerializableTest<Report> {
             .setFileName("file-3")
             .setSeverity(Severity.WARNING_LOW)
             .build();
+    private static final String NO_NAME = "";
+
+    @Test
+    void shouldProvideOriginMappings() {
+        Report report = new Report();
+
+        assertThat(report.getNameOfOrigin("id")).isEqualTo(NO_NAME);
+
+        report.setNameOfOrigin("id", "name");
+        assertThat(report.getNameOfOrigin("id")).isEqualTo("name");
+
+        report.setNameOfOrigin("second", "another name");
+        assertThat(report.getNameOfOrigin("id")).isEqualTo("name");
+        assertThat(report.getNameOfOrigin("second")).isEqualTo("another name");
+
+        report.setNameOfOrigin("id", "changed");
+        assertThat(report.getNameOfOrigin("id")).isEqualTo("changed");
+        assertThat(report.getNameOfOrigin("second")).isEqualTo("another name");
+    }
+
+    @Test
+    void shouldMergeOriginMappings() {
+        Report first = new Report();
+
+        first.setNameOfOrigin("first", "first name");
+        assertThat(first.getNameOfOrigin("first")).isEqualTo("first name");
+
+        Report second = new Report();
+
+        second.setNameOfOrigin("second", "second name");
+        assertThat(second.getNameOfOrigin("second")).isEqualTo("second name");
+
+        assertThat(first.getNameOfOrigin("second")).isEqualTo(NO_NAME);
+        assertThat(second.getNameOfOrigin("first")).isEqualTo(NO_NAME);
+
+        first.addAll(second);
+        assertThat(first.getNameOfOrigin("first")).isEqualTo("first name");
+        assertThat(first.getNameOfOrigin("second")).isEqualTo("second name");
+
+        Report third = first.copyEmptyInstance();
+        assertThat(third.getNameOfOrigin("first")).isEqualTo("first name");
+        assertThat(third.getNameOfOrigin("second")).isEqualTo("second name");
+    }
 
     @Test
     void shouldStoreFileNames() {
@@ -709,6 +752,8 @@ class ReportTest extends SerializableTest<Report> {
         byte[] restored = readAllBytes(SERIALIZATION_NAME);
 
         assertThatSerializableCanBeRestoredFrom(restored);
+
+        // FIXME: we need at least a test for the XML part
     }
 
     /** Verifies that equals checks all properties. */


### PR DESCRIPTION
Each report should have a map of origin IDs to human readable names.

Required for https://github.com/jenkinsci/warnings-ng-plugin/pull/207