### PR TITLE
Strengthen TaskingVx warning pattern

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParser.java
@@ -17,7 +17,7 @@ public class TaskingVxCompilerParser extends RegexpLineParser {
     private static final long serialVersionUID = -5225265084645449716L;
 
     /** Pattern of TASKING VX compiler warnings. */
-    private static final String TASKING_VX_COMPILER_WARNING_PATTERN = "^.*? (I|W|E|F)(\\d+): (?:\\[\"(.*?)\" (\\d+)"
+    private static final String TASKING_VX_COMPILER_WARNING_PATTERN = "^[a-z]+? (I|W|E|F)(\\d+): (?:\\[\"(.*?)\" (\\d+)"
             + "\\/(\\d+)\\] )?(.*)$";
 
     /**


### PR DESCRIPTION
Make TASKING_VX_COMPILER_WARNING_PATTERN more strict to reduce the possibility of matching messages output from other tools.