### PR TITLE
Add new log format for GHSMulti compiler

### DIFF
--- a/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
@@ -19,7 +19,7 @@ class GhsMultiParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(5);
+        softly.assertThat(report).hasSize(6);
         softly.assertThat(report.get(0))
                 .hasSeverity(Severity.ERROR)
                 .hasCategory("#5")
@@ -56,6 +56,14 @@ class GhsMultiParserTest extends AbstractParserTest {
                 .hasCategory("#177-D")
                 .hasLineStart(23)
                 .hasMessage("variable \"myvar\" was declared but never referenced\n  static const uint32 myvar")
+                .hasFileName("D:/workspace/TEST/mytest.c");
+
+        softly.assertThat(report.get(5))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("#11-D")
+                .hasLineStart(639)
+                .hasColumnStart(10)
+                .hasMessage("unrecognized preprocessing directive")
                 .hasFileName("D:/workspace/TEST/mytest.c");
 
     }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ghsmulti.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ghsmulti.txt
@@ -26,3 +26,5 @@ Done
 "D:/workspace/TEST/mytest.c", line 23: warning #177-D: variable "myvar" was declared but never referenced
   static const uint32 myvar
                       ^
+
+"D:/workspace/TEST/mytest.c", line 639 (col. 10): warning #11-D: unrecognized preprocessing directive


### PR DESCRIPTION
On GHS Multi 201914_2fp we get some output logs with the following format : 

> "D:/workspace/TEST/mytest.c", line 639 (col. 10): warning #11-D: unrecognized preprocessing directive

Due to this new column output, warnings are no more matched by parser.