### PR TITLE
Add Flawfinder Parser

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/FlawfinderParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/FlawfinderParser.java
@@ -1,0 +1,53 @@
+package edu.hm.hafner.analysis.parser;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.RegexpLineParser;
+
+/**
+ * A parser for the flawfinder warnings.
+ *
+ * @author Dom Postorivo
+ */
+public class FlawfinderParser extends RegexpLineParser {
+    private static final long serialVersionUID = 8088991846076174837L;
+
+    private static final String FLAWFINDER_WARNING_PATTERN =
+            "^(?<file>.*):(?<line>\\d+): .\\[(?<severity>[012345])\\] \\((?<category>[a-z0-9]*)\\) (?<message>.*)$";
+
+    private static final int FLAWFINDER_HIGH_THRESHOLD = 4;
+    private static final int FLAWFINDER_NORMAL_THRESHOLD = 2;
+
+    /**
+     * Creates a new instance of {@link FlawfinderParser}.
+     */
+    public FlawfinderParser() {
+        super(FLAWFINDER_WARNING_PATTERN);
+    }
+
+    @Override
+    protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
+        String message = matcher.group("message");
+        String category = matcher.group("category");
+        int severity = Integer.parseInt(matcher.group("severity"));
+        Severity priority = Severity.WARNING_LOW;
+
+        if (severity >= FLAWFINDER_HIGH_THRESHOLD) {
+            priority = Severity.WARNING_HIGH;
+        }
+        else if (severity >= FLAWFINDER_NORMAL_THRESHOLD) {
+            priority = Severity.WARNING_NORMAL;
+        }
+
+        return builder.setFileName(matcher.group("file"))
+                .setLineStart(matcher.group("line"))
+                .setCategory(category)
+                .setMessage(message)
+                .setSeverity(priority)
+                .buildOptional();
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/parser/FlawfinderParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/FlawfinderParserTest.java
@@ -1,0 +1,45 @@
+package edu.hm.hafner.analysis.parser;
+
+import edu.hm.hafner.analysis.AbstractParserTest;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+
+/**
+ * Tests the class {@link FlawfinderParser}.
+ *
+ * @author Dom Postorivo
+ */
+class FlawfinderParserTest extends AbstractParserTest {
+    FlawfinderParserTest() {
+        super("flawfinder.log");
+    }
+
+    @Override
+    protected FlawfinderParser createParser() {
+        return new FlawfinderParser();
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        softly.assertThat(report).hasSize(3);
+        softly.assertThat(report.get(0))
+                .hasFileName("src/Bar.c")
+                .hasLineStart(779)
+                .hasCategory("buffer")
+                .hasMessage("strncat:Easily used incorrectly (e.g., incorrectly computing the correct maximum size to add) [MS-banned] (CWE-120).")
+                .hasSeverity(Severity.WARNING_HIGH);
+        softly.assertThat(report.get(1))
+                .hasFileName("src/main.c")
+                .hasLineStart(114)
+                .hasCategory("format")
+                .hasMessage("printf:If format strings can be influenced by an attacker, they can be exploited (CWE-134).  Use a constant for the format specification.")
+                .hasSeverity(Severity.WARNING_NORMAL);
+        softly.assertThat(report.get(2))
+                .hasFileName("src/Bar.c")
+                .hasLineStart(246)
+                .hasCategory("buffer")
+                .hasMessage("scanf:It's unclear if the %s limit in the format string is small enough (CWE-120).")
+                .hasSeverity(Severity.WARNING_LOW);
+    }
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/flawfinder.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/flawfinder.log
@@ -1,0 +1,27 @@
+Flawfinder version 2.0.8, (C) 2001-2017 David A. Wheeler.
+Number of rules (primarily dangerous function names) in C/C++ ruleset: 223
+Examining src/Foo.h
+Examining src/Bar.c
+Examining src/Bar.h
+Examining src/main.c
+Examining test/test_Bar.c
+
+FINAL RESULTS:
+
+src/Bar.c:779:  [5] (buffer) strncat:Easily used incorrectly (e.g., incorrectly computing the correct maximum size to add) [MS-banned] (CWE-120).
+src/main.c:114:  [3] (format) printf:If format strings can be influenced by an attacker, they can be exploited (CWE-134).  Use a constant for the format specification.
+src/Bar.c:246:  [1] (buffer) scanf:It's unclear if the %s limit in the format string is small enough (CWE-120).
+
+ANALYSIS SUMMARY:
+
+Hits = 5
+Lines analyzed = 2416 in approximately 0.03 seconds (70867 lines/second)
+Physical Source Lines of Code (SLOC) = 1694
+Hits@level = [0] 143 [1]  16 [2]  27 [3]   1 [4]   1 [5]   4
+Hits@level+ = [0+] 191 [1+]  48 [2+]  32 [3+]   5 [4+]   5 [5+]   4
+Hits/KSLOC@level+ = [0+] 112.751 [1+] 28.3353 [2+] 18.8902 [3+] 2.95159 [4+] 2.95159 [5+] 2.36128
+Not every hit is necessarily a security vulnerability.
+There may be other security vulnerabilities; review your code!
+See 'Secure Programming HOWTO'
+(https://dwheeler.com/secure-programs) for more information.
+


### PR DESCRIPTION
This change adds a Flawfinder parser which is a static analysis tool for finding potential security flaws in C/C++.  Project can be found here: https://github.com/david-a-wheeler/flawfinder