### PR TITLE
Convert RuboCop Parser to use named groups

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/RuboCopParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/RuboCopParser.java
@@ -17,7 +17,8 @@ import edu.hm.hafner.analysis.RegexpLineParser;
 public class RuboCopParser extends RegexpLineParser {
     private static final long serialVersionUID = 7199325311690082783L;
 
-    private static final String RUBOCOP_WARNING_PATTERN = "^([^:]+):(\\d+):(\\d+): ([RCWEF]): (\\S+): (.*)$";
+    private static final String RUBOCOP_WARNING_PATTERN =
+            "^(?<file>.[^:]+):(?<line>\\d+):(?<column>\\d+): (?<severity>[RCWEF]): (?<category>\\S+): (?<message>.*)$";
     private static final String ERROR = "E";
     private static final String FATAL = "F";
 
@@ -30,21 +31,21 @@ public class RuboCopParser extends RegexpLineParser {
 
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
-        String message = matcher.group(6);
-        String category = guessCategoryIfEmpty(matcher.group(5), message);
+        String message = matcher.group("message");
+        String category = guessCategoryIfEmpty(matcher.group("category"), message);
 
-        String severity = matcher.group(4);
+        String severity = matcher.group("severity");
         Severity priority = Severity.WARNING_NORMAL;
         if (ERROR.equals(severity) || FATAL.equals(severity)) {
             priority = Severity.WARNING_HIGH;
         }
 
-        return builder.setFileName(matcher.group(1))
-                .setLineStart(matcher.group(2))
+        return builder.setFileName(matcher.group("file"))
+                .setLineStart(matcher.group("line"))
                 .setCategory(category)
                 .setMessage(message)
                 .setSeverity(priority)
-                .setColumnStart(matcher.group(3))
+                .setColumnStart(matcher.group("column"))
                 .buildOptional();
     }
 }


### PR DESCRIPTION
Just a bit of clean up. Was basing the flawfinder parser on this parser so I took the advice offered in that pull and applied it here.