### PR TITLE
[AntJavaParser] Ignore warnings that contain a `@` symbol

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AntJavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AntJavacParser.java
@@ -36,7 +36,8 @@ public class AntJavacParser extends RegexpLineParser {
     @Override
     protected boolean isLineInteresting(final String line) {
         return super.isLineInteresting(line)
-                && (line.contains("warning") || line.contains("error") || line.contains("\u8b66\u544a"));
+                && (line.contains("warning") || line.contains("error") || line.contains("\u8b66\u544a"))
+                && !line.contains("@");
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/AntJavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AntJavacParserTest.java
@@ -35,6 +35,18 @@ class AntJavacParserTest extends AbstractParserTest {
     }
 
     /**
+     * Parses a warning log with JavaDoc warnings.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-63346">Issue 63346</a>
+     */
+    @Test
+    void issue63346() {
+        Report report = parse("issue63346.txt");
+
+        assertThat(report).isEmpty();
+    }
+
+    /**
      * Parses a warning log with two warnings.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-24611">Issue 24611</a>

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -45,6 +45,18 @@ class JavacParserTest extends AbstractParserTest {
     }
 
     /**
+     * Parses a warning log with JavaDoc warnings.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-63346">Issue 63346</a>
+     */
+    @Test
+    void issue63346() {
+        Report report = parse("issue63346.txt");
+
+        assertThat(report).isEmpty();
+    }
+
+    /**
      * Parses a warning log with two false positives.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-55805">Issue 55805</a>

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue63346.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue63346.txt
@@ -1,0 +1,29 @@
+[2020-08-05T20:06:07.664Z] [INFO] --- maven-jar-plugin:3.2.0:test-jar (maybe-test-jar) @ ldap ---
+[2020-08-05T20:06:08.600Z] [INFO] Skipping packaging of the test-jar
+[2020-08-05T20:06:08.600Z] [INFO] 
+[2020-08-05T20:06:08.600Z] [INFO] --- maven-source-plugin:3.2.1:jar-no-fork (attach-sources) @ ldap ---
+[2020-08-05T20:06:08.600Z] [INFO] Building jar: /home/jenkins/workspace/Plugins_ldap-plugin_PR-48/target/ldap-sources.jar
+[2020-08-05T20:06:08.600Z] [INFO] 
+[2020-08-05T20:06:08.600Z] [INFO] --- maven-source-plugin:3.2.1:test-jar-no-fork (attach-test-sources) @ ldap ---
+[2020-08-05T20:06:08.600Z] [INFO] Skipping source per configuration.
+[2020-08-05T20:06:08.600Z] [INFO] 
+[2020-08-05T20:06:08.600Z] [INFO] --- maven-javadoc-plugin:3.2.0:jar (attach-javadocs) @ ldap ---
+[2020-08-05T20:06:11.887Z] [INFO] No previous run data found, generating javadoc.
+[2020-08-05T20:06:13.796Z] [INFO] 
+[2020-08-05T20:06:13.796Z] 100 warnings
+[2020-08-05T20:06:13.796Z] [WARNING] Javadoc Warnings
+[2020-08-05T20:06:13.796Z] [WARNING] /home/jenkins/workspace/Plugins_ldap-plugin_PR-48/src/main/java/hudson/security/LDAPSecurityRealm.java:480: warning: no @param for server
+[2020-08-05T20:06:13.796Z] [WARNING] public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+[2020-08-05T20:06:13.796Z] [WARNING] ^
+[2020-08-05T20:06:13.796Z] [WARNING] /home/jenkins/workspace/Plugins_ldap-plugin_PR-48/src/main/java/hudson/security/LDAPSecurityRealm.java:480: warning: no @param for rootDN
+[2020-08-05T20:06:13.796Z] [WARNING] public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+[2020-08-05T20:06:13.796Z] [WARNING] ^
+[2020-08-05T20:06:13.796Z] [WARNING] /home/jenkins/workspace/Plugins_ldap-plugin_PR-48/src/main/java/hudson/security/LDAPSecurityRealm.java:480: warning: no @param for userSearchBase
+[2020-08-05T20:06:13.796Z] [WARNING] public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+[2020-08-05T20:06:13.796Z] [WARNING] ^
+[2020-08-05T20:06:13.796Z] [WARNING] /home/jenkins/workspace/Plugins_ldap-plugin_PR-48/src/main/java/hudson/security/LDAPSecurityRealm.java:480: warning: no @param for userSearch
+[2020-08-05T20:06:13.796Z] [WARNING] public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+[2020-08-05T20:06:13.796Z] [WARNING] ^
+[2020-08-05T20:06:13.796Z] [WARNING] /home/jenkins/workspace/Plugins_ldap-plugin_PR-48/src/main/java/hudson/security/LDAPSecurityRealm.java:480: warning: no @param for groupSearchBase
+[2020-08-05T20:06:13.796Z] [WARNING] public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+[2020-08-05T20:06:13.796Z] [WARNING] ^


### PR DESCRIPTION
Warnings with an `@` symbol are JavaDoc warnings and should be parsed by the JavaDoc parser.

A simple quick fix for https://issues.jenkins-ci.org/browse/JENKINS-63346. Should be improved if this fix skips other warnings that are related to annotations.