### PR TITLE
Add support for parsing Kotlin errors

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -25,7 +25,7 @@ public class JavacParser extends LookaheadParser {
     private static final String JAVAC_WARNING_PATTERN
             = "^(?:\\S+\\s+)?"                // optional preceding arbitrary number of characters that are not a
                                               // whitespace followed by whitespace. This can be used for timestamps.
-            + "(?:(?:\\[(WARNING|ERROR)\\]|w:)\\s+)" // optional [WARNING] or [ERROR] or w:
+            + "(?:(?:\\[(WARNING|ERROR)\\]|w:|e:)\\s+)" // optional [WARNING] or [ERROR] or w: or e:
             + "([^\\[\\(]*):\\s*"             // group 1: filename
             + "[\\[\\(]"                      // [ or (
             + "(\\d+)[.,;]*"                  // group 2: line number
@@ -34,6 +34,9 @@ public class JavacParser extends LookaheadParser {
             + ":?"                            // optional :
             + "(?:\\[(\\w+)\\])?"             // group 4: optional category
             + "\\s*(.*)$";                    // group 5: message
+
+    private static final String SEVERITY_ERROR = "ERROR";
+    private static final String SEVERITY_ERROR_SHORT = "e:";
 
     /**
      * Creates a new instance of {@link JavacParser}.
@@ -44,7 +47,7 @@ public class JavacParser extends LookaheadParser {
 
     @Override
     protected boolean isLineInteresting(final String line) {
-        return line.contains("[") || line.contains("w:");
+        return line.contains("[") || line.contains("w:") || line.contains("e:");
     }
 
     @Override
@@ -55,7 +58,7 @@ public class JavacParser extends LookaheadParser {
         }
 
         String type = matcher.group(1);
-        if ("ERROR".equals(type)) {
+        if (SEVERITY_ERROR.equals(type) || SEVERITY_ERROR_SHORT.equals(type)) {
             builder.setSeverity(Severity.ERROR);
         }
         else {

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -137,6 +137,16 @@ class JavacParserTest extends AbstractParserTest {
     }
 
     /**
+     * Parses an error log written by Gradle containing 1 Kotlin error.
+     */
+    @Test
+    void kotlinGradleError() {
+        Report errors = parse("kotlin-gradle-error.txt");
+
+        assertThat(errors).hasSize(1);
+    }
+
+    /**
      * Verifies that arrays in deprecated methods are correctly handled.
      */
     @Test

--- a/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-gradle-error.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-gradle-error.txt
@@ -1,0 +1,7 @@
+> Configure project :app
+Configuration 'compile' in project ':app' is deprecated. Use 'implementation' instead.
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+app: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.android.databinding:compiler:3.0.1'.
+e: /project/app/src/main/java/ui/Activity.kt: (214, 35): Unresolved reference: feth


### PR DESCRIPTION
This adds support for parsing Kotlin errors like

```
e: /project/app/src/main/java/ui/Activity.kt: (214, 35): Unresolved reference: feth
```

Previously, only Kotlin warnings would be parsed. However, with the Jenkins Warnings NG plugin being able to push warnings/errors to GitHub as GitHub Checks, having Kotlin errors directly in GitHub would be a nice addition 🙂.