### PR TITLE
Add Foodcritic parser for linting Chef cookbooks.

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/FoodcriticParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/FoodcriticParser.java
@@ -1,0 +1,38 @@
+package edu.hm.hafner.analysis.parser;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.RegexpLineParser;
+
+/**
+ * A parser for Foodcritic warnings.
+ *
+ * @author Rich Schumacher
+ */
+public class FoodcriticParser extends RegexpLineParser {
+    private static final long serialVersionUID = -5338881031392241140L;
+
+    private static final String FOODCRITIC_WARNING_PATTERN =
+            "^(?<category>FC\\d+): (?<message>[^:]+): (?<file>[^:]+):(?<line>\\d+)$";
+
+    /**
+     * Creates a new instance of {@link FoodcriticParser}.
+     */
+    public FoodcriticParser() {
+        super(FOODCRITIC_WARNING_PATTERN);
+    }
+
+    @Override
+    protected Optional<Issue> createIssue(final Matcher matcher, final IssueBuilder builder) {
+        return builder.setFileName(matcher.group("file"))
+                .setLineStart(matcher.group("line"))
+                .setCategory(matcher.group("category"))
+                .setMessage(matcher.group("message"))
+                .setSeverity(Severity.WARNING_NORMAL)
+                .buildOptional();
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/parser/FoodcriticParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/FoodcriticParserTest.java
@@ -1,0 +1,61 @@
+package edu.hm.hafner.analysis.parser;
+
+import edu.hm.hafner.analysis.AbstractParserTest;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+
+/**
+ * Tests the class {@link FoodcriticParser}.
+ *
+ * @author Rich Schumacher
+ */
+class FoodcriticParserTest extends AbstractParserTest {
+    FoodcriticParserTest() {
+        super("foodcritic.log");
+    }
+
+    @Override
+    protected FoodcriticParser createParser() {
+        return new FoodcriticParser();
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        softly.assertThat(report).hasSize(5);
+        softly.assertThat(report.get(0))
+                .hasFileName("./foo/attributes/default.rb")
+                .hasLineStart(8)
+                .hasCategory("FC001")
+                .hasMessage("Use strings in preference to symbols to access node attributes")
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        softly.assertThat(report.get(1))
+                .hasFileName("./foo/recipes/default.rb")
+                .hasLineStart(80)
+                .hasCategory("FC002")
+                .hasMessage("Avoid string interpolation where not required")
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        softly.assertThat(report.get(2))
+                .hasFileName("foo/definitions/foo.rb")
+                .hasLineStart(1)
+                .hasCategory("FC015")
+                .hasMessage("Consider converting definition to a Custom Resource")
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        softly.assertThat(report.get(3))
+                .hasFileName("./foo/attributes/default.rb")
+                .hasLineStart(30)
+                .hasCategory("FC019")
+                .hasMessage("Access node attributes in a consistent manner")
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        softly.assertThat(report.get(4))
+                .hasFileName("./foo/metadata.rb")
+                .hasLineStart(1)
+                .hasCategory("FC064")
+                .hasMessage("Ensure issues_url is set in metadata")
+                .hasSeverity(Severity.WARNING_NORMAL);
+    }
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/foodcritic.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/foodcritic.log
@@ -1,0 +1,8 @@
+Checking 11 files
+x...x.....x
+
+FC001: Use strings in preference to symbols to access node attributes: ./foo/attributes/default.rb:8
+FC002: Avoid string interpolation where not required: ./foo/recipes/default.rb:80
+FC015: Consider converting definition to a Custom Resource: foo/definitions/foo.rb:1
+FC019: Access node attributes in a consistent manner: ./foo/attributes/default.rb:30
+FC064: Ensure issues_url is set in metadata: ./foo/metadata.rb:1


### PR DESCRIPTION
This change adds a parser for [Foodcritic](http://www.foodcritic.io), a linting tool for [Chef](https://www.chef.io/) cookbooks.