### PR TITLE
[JENKINS-64155] Close stream in JunitAdapter

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/violations/JUnitAdapter.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/violations/JUnitAdapter.java
@@ -1,5 +1,7 @@
 package edu.hm.hafner.analysis.parser.violations;
 
+import java.util.stream.Stream;
+
 import edu.hm.hafner.analysis.ParsingCanceledException;
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.ReaderFactory;
@@ -42,8 +44,10 @@ public class JUnitAdapter extends AbstractViolationAdapter {
     }
 
     private int count(final ReaderFactory readerFactory, final String text) {
-        return Math.toIntExact(readerFactory.readStream()
-                .filter(line -> line.contains(text))
-                .count());
+        try (Stream<String> lines = readerFactory.readStream()) {
+            return Math.toIntExact(lines
+                    .filter(line -> line.contains(text))
+                    .count());
+        }
     }
 }


### PR DESCRIPTION
Just wrapping the readStream with a try-with-resources to autoclose the stream after use, similar to e.g. JsonLogParser.