### PR TITLE
[JENKINS-60859] Improve type detection for CheckStyle variants

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/checkstyle/CheckStyleParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/checkstyle/CheckStyleParser.java
@@ -90,7 +90,10 @@ public class CheckStyleParser extends IssueParser {
     }
 
     private String getType(@CheckForNull final String source) {
-        return StringUtils.substringAfterLast(source, ".");
+        if (StringUtils.contains(source, '.')) {
+            return StringUtils.substringAfterLast(source, ".");
+        }
+        return source;
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/parser/CheckStyleParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CheckStyleParserTest.java
@@ -70,6 +70,33 @@ class CheckStyleParserTest extends AbstractParserTest {
     }
 
     /**
+     * Verifies that the error types of hadolint checks are correctly extracted.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-60859">Issue 60859</a>
+     */
+    @Test
+    void shouldExtractTypeEvenIfNoDotPresent() {
+        Report report = parseInCheckStyleFolder("issue60859.xml");
+
+        assertThat(report).hasSize(3);
+        assertThat(report.get(0)).hasMessage(
+                "Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`")
+                .hasFileName("Dockerfile")
+                .hasLineStart(13)
+                .hasType("DL3018");
+        assertThat(report.get(1)).hasMessage(
+                "In POSIX sh, set option pipefail is undefined.")
+                .hasFileName("Dockerfile")
+                .hasLineStart(16)
+                .hasType("SC2039");
+        assertThat(report.get(2)).hasMessage(
+                "Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check")
+                .hasFileName("Dockerfile")
+                .hasLineStart(16)
+                .hasType("DL4006");
+    }
+
+    /**
      * Tests parsing of a file with Scala style warnings.
      *
      * @see <a href="http://www.scalastyle.org">Scala Style Homepage</a>

--- a/src/test/resources/edu/hm/hafner/analysis/parser/checkstyle/issue60859.xml
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/checkstyle/issue60859.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<checkstyle version='4.3'>
+  <file name='Dockerfile'>
+    <error line='13' column='1' severity='warning'
+           message='Pin versions in apk add. Instead of &#96;apk add &#60;package&#62;&#96; use &#96;apk add &#60;package&#62;&#61;&#60;version&#62;&#96;'
+           source='DL3018'/>
+    <error line='16' column='1' severity='warning' message='In POSIX sh&#44; set option pipefail is undefined.'
+           source='SC2039'/>
+    <error line='16' column='1' severity='warning'
+           message='Set the SHELL option &#45;o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash&#44; or disable this check'
+           source='DL4006'/>
+  </file>
+</checkstyle>


### PR DESCRIPTION
The CheckStyle parser does not work correctly for reports generated by other tools. E.g., hadolint reports the type of a warning using a simple string. This type is not correctly detected, see [JENKINS-60859](https://issues.jenkins-ci.org/browse/JENKINS-60859).

This PR simplifies the type detection: if the type is not in the native CheckStyle format (that contains a dot) then the whole
type will be returned.