### PR TITLE
[JENKINS-55733] - CppCheck parser ignores errors without location.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>9.5.0</revision>
+    <revision>9.4.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <source.encoding>UTF-8</source.encoding>
     <project.build.sourceEncoding>${source.encoding}</project.build.sourceEncoding>
@@ -75,7 +75,7 @@
     <spotbugs.parser.library.version>6.0.4</spotbugs.parser.library.version>
     <j2html.version>1.4.0</j2html.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <violations-lib.version>1.140</violations-lib.version>
+    <violations-lib.version>1.141</violations-lib.version>
     <json.version>20201115</json.version>
 
     <argLine>-Djava.util.logging.config.file=logging.properties</argLine>

--- a/src/test/java/edu/hm/hafner/analysis/parser/violations/CppCheckAdapterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/violations/CppCheckAdapterTest.java
@@ -64,7 +64,11 @@ class CppCheckAdapterTest extends AbstractParserTest {
                 .hasSeverity(Severity.WARNING_HIGH);
     }
 
-    /** Verifies that the parser finds multiple locations (line ranges) for a given warning. */
+    /**
+     * Verifies that the parser finds multiple locations (line ranges) for a given warning.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-55733">Issue 55733</a>
+     */
     @Test
     void shouldFindMultipleLocations() {
         Report report = parse("issue55733.xml");
@@ -86,7 +90,11 @@ class CppCheckAdapterTest extends AbstractParserTest {
         assertThat(report.get(1).getLineRanges()).isEqualTo(new LineRangeList(new LineRange(335)));
     }
 
-    /** Verifies that the parser finds multiple locations (line ranges) for a given warning with the same error ID. */
+    /**
+     * Verifies that the parser finds multiple locations (line ranges) for a given warning with the same error ID.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-55733">Issue 55733</a>
+     */
     @Test
     void shouldFindMultipleLocationsWithSameId() {
         Report report = parse("issue55733-multiple-tags-with-same-id.xml");
@@ -106,6 +114,18 @@ class CppCheckAdapterTest extends AbstractParserTest {
                 .hasMessage("Variable 'that' is reassigned a value before the old one has been used.")
                 .hasType("redundantAssignment");
         assertThat(report.get(1).getLineRanges()).isEqualTo(new LineRangeList(new LineRange(51)));
+    }
+
+    /**
+     * Verifies that the parser finds errors without location.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-64519">Issue 64519</a>
+     */
+    @Test
+    void shouldFindErrorWithoutLocation() {
+        Report report = parse("issue64519.xml");
+
+        assertThat(report).hasSize(1);
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/violations/CppCheckAdapterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/violations/CppCheckAdapterTest.java
@@ -3,6 +3,7 @@ package edu.hm.hafner.analysis.parser.violations;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.AbstractParserTest;
+import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.LineRange;
 import edu.hm.hafner.analysis.LineRangeList;
 import edu.hm.hafner.analysis.Report;
@@ -126,6 +127,10 @@ class CppCheckAdapterTest extends AbstractParserTest {
         Report report = parse("issue64519.xml");
 
         assertThat(report).hasSize(1);
+        Issue issue = report.get(0);
+
+        assertThat(issue).hasFileName("-")
+                .hasMessage("Cppcheck cannot find all the include files (use --check-config for details). Cppcheck cannot find all the include files. Cppcheck can check the code without the include files found. But the results will probably be more accurate if all the include files are found. Please check your project's include directories and add all of them as include directories for Cppcheck. To see what files Cppcheck cannot find use --check-config.");
     }
 
     @Override

--- a/src/test/resources/edu/hm/hafner/analysis/parser/violations/issue64519.xml
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/violations/issue64519.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<results version="2">
+  <cppcheck version="1.82"/>
+  <errors>
+    <error id="missingInclude" severity="information"
+           msg="Cppcheck cannot find all the include files (use --check-config for details)"
+           verbose="Cppcheck cannot find all the include files. Cppcheck can check the code without the include files found. But the results will probably be more accurate if all the include files are found. Please check your project's include directories and add all of them as include directories for Cppcheck. To see what files Cppcheck cannot find use --check-config."/>
+  </errors>
+</results>


### PR DESCRIPTION
Exposes [JENKINS-55733](https://issues.jenkins-ci.org/browse/JENKINS-55733)