### PR TITLE
Simplify NAG fortran parser tests

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/NagFortranParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/NagFortranParser.java
@@ -20,7 +20,8 @@ public class NagFortranParser extends LookaheadParser {
     private static final long serialVersionUID = 2072414911276743946L;
 
     private static final String NAGFOR_MSG_PATTERN = "^(Info|Warning|Questionable|Extension|Obsolescent|Deleted "
-            + "feature used|Error|Runtime Error|Fatal Error|Panic): (.+\\.[^,:\\n]+)(, line (\\d+))?: (.+(\\s+detected"
+            + "feature used|Error|Runtime Error|Fatal Error|Panic|Non-standard\\(Obsolete\\)|Extension\\(NAG\\)|Extension\\(F[0-9]+\\)): "
+            + "(.+\\.[^,:\\n]+)(, line (\\d+))?: (.+(\\s+detected"
             + " at .+)?)";
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/parser/NagFortranParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/NagFortranParserTest.java
@@ -33,12 +33,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Info")
                     .hasSeverity(Severity.WARNING_LOW)
                     .hasMessage("Unterminated last line of INCLUDE file")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(1);
         }
     }
 
@@ -58,12 +53,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Warning")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("Procedure pointer F pointer-assigned but otherwise unused")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(5);
         }
     }
 
@@ -84,12 +74,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage(
                             "Array constructor has polymorphic element P(5) (but the constructor value will not be polymorphic)")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(12)
-                    .hasLineEnd(12)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(12);
         }
     }
 
@@ -109,12 +94,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Extension")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("Left-hand side of intrinsic assignment is allocatable polymorphic variable X")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(9)
-                    .hasLineEnd(9)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(9);
         }
     }
 
@@ -134,12 +114,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Obsolescent")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("Fixed source form")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(1);
         }
     }
 
@@ -159,12 +134,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Deleted feature used")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("assigned GOTO statement")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(4)
-                    .hasLineEnd(4)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(4);
         }
     }
 
@@ -185,12 +155,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasSeverity(Severity.WARNING_HIGH)
                     .hasMessage(
                             "Character function length 7 is not same as argument F (no. 1) in reference to SUB from O8K (expected length 6)")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(0);
         }
     }
 
@@ -210,12 +175,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Runtime Error")
                     .hasSeverity(Severity.WARNING_HIGH)
                     .hasMessage("Reference to undefined POINTER P")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(7)
-                    .hasLineEnd(7)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(7);
         }
     }
 
@@ -235,12 +195,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Fatal Error")
                     .hasSeverity(Severity.WARNING_HIGH)
                     .hasMessage("SAME_NAME is not a derived type\n             detected at ::@N")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(5);
         }
     }
 
@@ -260,12 +215,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Panic")
                     .hasSeverity(Severity.WARNING_HIGH)
                     .hasMessage("User requested panic")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(1)
-                    .hasLineEnd(1)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(1);
         }
     }
 
@@ -285,12 +235,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Non-standard(Obsolete)")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("Byte count on numeric data type detected at *@8")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(2)
-                    .hasLineEnd(2)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(2);
         }
     }
 
@@ -310,12 +255,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Extension(NAG)")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("FORALL statement detected at 42@<end-of-statement>")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(8)
-                    .hasLineEnd(8)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(8);
         }
     }
 
@@ -335,12 +275,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Extension(F2018)")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("NON_RECURSIVE attribute detected at <end-of-statement>@NON_RECURSIVE")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(5)
-                    .hasLineEnd(5)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(5);
         }
     }
 
@@ -360,12 +295,7 @@ class NagFortranParserTest extends AbstractParserTest {
                     .hasCategory("Extension(F2008)")
                     .hasSeverity(Severity.WARNING_NORMAL)
                     .hasMessage("NUM_IMAGES intrinsic procedure")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(4)
-                    .hasLineEnd(4)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
+                    .hasLineStart(4);
         }
     }
 
@@ -379,73 +309,42 @@ class NagFortranParserTest extends AbstractParserTest {
                 .hasCategory("Info")
                 .hasSeverity(Severity.WARNING_LOW)
                 .hasMessage("Unterminated last line of INCLUDE file")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(1)
-                .hasLineEnd(1)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(1);
 
         softly.assertThat(report.get(1))
                 .hasFileName("C:/file2.f90")
                 .hasCategory("Warning")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("Procedure pointer F pointer-assigned but otherwise unused")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(5)
-                .hasLineEnd(5)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(5);
 
         softly.assertThat(report.get(2))
                 .hasFileName("/file3.f90")
                 .hasCategory("Questionable")
                 .hasSeverity(Severity.WARNING_NORMAL)
-                .hasMessage(
-                        "Array constructor has polymorphic element P(5) (but the constructor value will not be polymorphic)")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(12)
-                .hasLineEnd(12)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasMessage("Array constructor has polymorphic element P(5) (but the constructor value will not be polymorphic)")
+                .hasLineStart(12);
 
         softly.assertThat(report.get(3))
                 .hasFileName("file4.f90")
                 .hasCategory("Extension")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("Left-hand side of intrinsic assignment is allocatable polymorphic variable X")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(9)
-                .hasLineEnd(9)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(9);
 
         softly.assertThat(report.get(4))
                 .hasFileName("file5.f")
                 .hasCategory("Obsolescent")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("Fixed source form")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(1)
-                .hasLineEnd(1)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(1);
 
         softly.assertThat(report.get(5))
                 .hasFileName("file6.f90")
                 .hasCategory("Deleted feature used")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("assigned GOTO statement")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(4)
-                .hasLineEnd(4)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(4);
 
         softly.assertThat(report.get(6))
                 .hasFileName("file7.f90")
@@ -453,96 +352,56 @@ class NagFortranParserTest extends AbstractParserTest {
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasMessage(
                         "Character function length 7 is not same as argument F (no. 1) in reference to SUB from O8K (expected length 6)")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(0)
-                .hasLineEnd(0)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(0);
 
         softly.assertThat(report.get(7))
                 .hasFileName("file8.f90")
                 .hasCategory("Runtime Error")
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasMessage("Reference to undefined POINTER P")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(7)
-                .hasLineEnd(7)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(7);
 
         softly.assertThat(report.get(8))
                 .hasFileName("file9.f90")
                 .hasCategory("Fatal Error")
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasMessage("SAME_NAME is not a derived type\n             detected at ::@N")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(5)
-                .hasLineEnd(5)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(5);
 
         softly.assertThat(report.get(9))
                 .hasFileName("file10.f90")
                 .hasCategory("Panic")
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasMessage("User requested panic")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(1)
-                .hasLineEnd(1)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(1);
 
         softly.assertThat(report.get(10))
                 .hasFileName("msgs71.f90")
                 .hasCategory("Non-standard(Obsolete)")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("Byte count on numeric data type detected at *@8")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(2)
-                .hasLineEnd(2)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(2);
 
         softly.assertThat(report.get(11))
                 .hasFileName("msgs71.f90")
                 .hasCategory("Extension(NAG)")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("FORALL statement detected at 42@<end-of-statement>")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(8)
-                .hasLineEnd(8)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(8);
 
         softly.assertThat(report.get(12))
                 .hasFileName("msgs71.f90")
                 .hasCategory("Extension(F2018)")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("NON_RECURSIVE attribute detected at <end-of-statement>@NON_RECURSIVE")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(5)
-                .hasLineEnd(5)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(5);
 
         softly.assertThat(report.get(13))
                 .hasFileName("msgs71.f90")
                 .hasCategory("Extension(F2008)")
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasMessage("NUM_IMAGES intrinsic procedure")
-                .hasDescription("")
-                .hasPackageName("-")
-                .hasLineStart(4)
-                .hasLineEnd(4)
-                .hasColumnStart(0)
-                .hasColumnEnd(0);
+                .hasLineStart(4);
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/NagFortranParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/NagFortranParserTest.java
@@ -269,10 +269,110 @@ class NagFortranParserTest extends AbstractParserTest {
         }
     }
 
+    /**
+     * Test parsing of a file containing a Non-standard(Obsolete) message output by the NAG Fortran Compiler.
+     */
+    @Test
+    void testNonStandardObsoleteParser() {
+        Report warnings = parse("NagFortranNonStandardObsolete.txt");
+
+        assertThat(warnings).hasSize(1);
+        assertThatReportHasSeverities(warnings, 0, 0, 1, 0);
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            softly.assertThat(warnings.get(0))
+                    .hasFileName("msgs71.f90")
+                    .hasCategory("Non-standard(Obsolete)")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasMessage("Byte count on numeric data type detected at *@8")
+                    .hasDescription("")
+                    .hasPackageName("-")
+                    .hasLineStart(2)
+                    .hasLineEnd(2)
+                    .hasColumnStart(0)
+                    .hasColumnEnd(0);
+        }
+    }
+
+    /**
+     * Test parsing of a file containing a Extension(NAG) message output by the NAG Fortran Compiler.
+     */
+    @Test
+    void testExtensionNAGParser() {
+        Report warnings = parse("NagFortranExtensionNAG.txt");
+
+        assertThat(warnings).hasSize(1);
+        assertThatReportHasSeverities(warnings, 0, 0, 1, 0);
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            softly.assertThat(warnings.get(0))
+                    .hasFileName("msgs71.f90")
+                    .hasCategory("Extension(NAG)")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasMessage("FORALL statement detected at 42@<end-of-statement>")
+                    .hasDescription("")
+                    .hasPackageName("-")
+                    .hasLineStart(8)
+                    .hasLineEnd(8)
+                    .hasColumnStart(0)
+                    .hasColumnEnd(0);
+        }
+    }
+
+    /**
+     * Test parsing of a file containing a Extension(F2018) message output by the NAG Fortran Compiler.
+     */
+    @Test
+    void testExtensionF2018Parser() {
+        Report warnings = parse("NagFortranExtensionF2018.txt");
+
+        assertThat(warnings).hasSize(1);
+        assertThatReportHasSeverities(warnings, 0, 0, 1, 0);
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            softly.assertThat(warnings.get(0))
+                    .hasFileName("msgs71.f90")
+                    .hasCategory("Extension(F2018)")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasMessage("NON_RECURSIVE attribute detected at <end-of-statement>@NON_RECURSIVE")
+                    .hasDescription("")
+                    .hasPackageName("-")
+                    .hasLineStart(5)
+                    .hasLineEnd(5)
+                    .hasColumnStart(0)
+                    .hasColumnEnd(0);
+        }
+    }
+
+    /**
+     * Test parsing of a file containing a Extension(F2008) message output by the NAG Fortran Compiler.
+     */
+    @Test
+    void testExtensionF2008Parser() {
+        Report warnings = parse("NagFortranExtensionF2008.txt");
+
+        assertThat(warnings).hasSize(1);
+        assertThatReportHasSeverities(warnings, 0, 0, 1, 0);
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            softly.assertThat(warnings.get(0))
+                    .hasFileName("msgs71.f90")
+                    .hasCategory("Extension(F2008)")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasMessage("NUM_IMAGES intrinsic procedure")
+                    .hasDescription("")
+                    .hasPackageName("-")
+                    .hasLineStart(4)
+                    .hasLineEnd(4)
+                    .hasColumnStart(0)
+                    .hasColumnEnd(0);
+        }
+    }
+
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(10);
-        assertThatReportHasSeverities(report, 0, 4, 5, 1);
+        softly.assertThat(report).hasSize(14);
+        assertThatReportHasSeverities(report, 0, 4, 9, 1);
 
         softly.assertThat(report.get(0))
                 .hasFileName("C:/file1.inc")
@@ -393,6 +493,54 @@ class NagFortranParserTest extends AbstractParserTest {
                 .hasPackageName("-")
                 .hasLineStart(1)
                 .hasLineEnd(1)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(report.get(10))
+                .hasFileName("msgs71.f90")
+                .hasCategory("Non-standard(Obsolete)")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasMessage("Byte count on numeric data type detected at *@8")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(2)
+                .hasLineEnd(2)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(report.get(11))
+                .hasFileName("msgs71.f90")
+                .hasCategory("Extension(NAG)")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasMessage("FORALL statement detected at 42@<end-of-statement>")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(8)
+                .hasLineEnd(8)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(report.get(12))
+                .hasFileName("msgs71.f90")
+                .hasCategory("Extension(F2018)")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasMessage("NON_RECURSIVE attribute detected at <end-of-statement>@NON_RECURSIVE")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(5)
+                .hasLineEnd(5)
+                .hasColumnStart(0)
+                .hasColumnEnd(0);
+
+        softly.assertThat(report.get(13))
+                .hasFileName("msgs71.f90")
+                .hasCategory("Extension(F2008)")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasMessage("NUM_IMAGES intrinsic procedure")
+                .hasDescription("")
+                .hasPackageName("-")
+                .hasLineStart(4)
+                .hasLineEnd(4)
                 .hasColumnStart(0)
                 .hasColumnEnd(0);
     }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/NagFortran.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/NagFortran.txt
@@ -10,4 +10,8 @@ Runtime Error: file8.f90, line 7: Reference to undefined POINTER P
 Fatal Error: file9.f90, line 5: SAME_NAME is not a derived type
              detected at ::@N
 Panic: file10.f90, line 1: User requested panic
+Non-standard(Obsolete): msgs71.f90, line 2: Byte count on numeric data type detected at *@8
+Extension(NAG): msgs71.f90, line 8: FORALL statement detected at 42@<end-of-statement>
+Extension(F2018): msgs71.f90, line 5: NON_RECURSIVE attribute detected at <end-of-statement>@NON_RECURSIVE
+Extension(F2008): msgs71.f90, line 4: NUM_IMAGES intrinsic procedure
 [NAG Fortran Compiler - not a message line]

--- a/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranExtensionF2008.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranExtensionF2008.txt
@@ -1,0 +1,3 @@
+nagfor file.f90 > not_a_message_line
+Extension(F2008): msgs71.f90, line 4: NUM_IMAGES intrinsic procedure
+[NAG Fortran Compiler - not a message line]

--- a/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranExtensionF2018.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranExtensionF2018.txt
@@ -1,0 +1,3 @@
+nagfor file.f90 > not_a_message_line
+Extension(F2018): msgs71.f90, line 5: NON_RECURSIVE attribute detected at <end-of-statement>@NON_RECURSIVE
+[NAG Fortran Compiler - not a message line]

--- a/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranExtensionNAG.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranExtensionNAG.txt
@@ -1,0 +1,3 @@
+nagfor file.f90 > not_a_message_line
+Extension(NAG): msgs71.f90, line 8: FORALL statement detected at 42@<end-of-statement>
+[NAG Fortran Compiler - not a message line]

--- a/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranNonStandardObsolete.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/NagFortranNonStandardObsolete.txt
@@ -1,0 +1,3 @@
+nagfor file.f90 > not_a_message_line
+Non-standard(Obsolete): msgs71.f90, line 2: Byte count on numeric data type detected at *@8
+[NAG Fortran Compiler - not a message line]


### PR DESCRIPTION
Remove assertions on unset properties. This is already checked in the `IssueBuilder` tests.

Followup on #552 