### PR TITLE
RuboCop Parser: Parse lines with '[Correctable]' addition

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/RuboCopParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/RuboCopParser.java
@@ -18,7 +18,7 @@ public class RuboCopParser extends RegexpLineParser {
     private static final long serialVersionUID = 7199325311690082783L;
 
     private static final String RUBOCOP_WARNING_PATTERN =
-            "^(?<file>.[^:]+):(?<line>\\d+):(?<column>\\d+): (?<severity>[RCWEF]): (?<category>\\S+): (?<message>.*)$";
+            "^(?<file>.[^:]+):(?<line>\\d+):(?<column>\\d+): (?<severity>[RCWEF]): (\\[Correctable\\] )?(?<category>\\S+): (?<message>.*)$";
     private static final String ERROR = "E";
     private static final String FATAL = "F";
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/RuboCopParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/RuboCopParserTest.java
@@ -22,7 +22,7 @@ class RuboCopParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(2);
+        softly.assertThat(report).hasSize(3);
         softly.assertThat(report.get(0))
                 .hasFileName("config.ru")
                 .hasLineStart(1)
@@ -37,5 +37,12 @@ class RuboCopParserTest extends AbstractParserTest {
                 .hasMessage("Prefer single-quoted strings when you don't need string interpolation or special symbols.")
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasColumnStart(7);
+        softly.assertThat(report.get(2))
+                .hasFileName("lib/tasks/generate_version.rake")
+                .hasLineStart(21)
+                .hasCategory("Layout/SpaceBeforeBlockBraces")
+                .hasMessage("Space missing to the left of {.")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasColumnStart(24);
     }
 }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/rubocop.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/rubocop.log
@@ -10,5 +10,11 @@ config.ru:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # froz
 spec/rails_helper.rb:6:7: E: Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
 abort("The Rails environment is running in production mode!") if Rails.env.production?
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+lib/tasks/generate_version.rake:21:24: C: [Correctable] Layout/SpaceBeforeBlockBraces: Space missing to the left of {.
+  File.open(fname, 'w'){|f| f.write(version_src) }
+                       ^
+lib/tasks/generate_version.rake:3:5: C: [Corrected] Layout/SpaceBeforeBlockBraces: Space missing to the left of {.
+  File.open(fname, 'w'){|f| f.write(version_src) }
+                       ^
 
 33 files inspected, 2 offenses detected


### PR DESCRIPTION
RuboCop 1.6.0 introduced the "[Correctable]" notation in it's standard output (https://github.com/rubocop-hq/rubocop/pull/9187).
As a result of this change, the parser now doesn't recognize these lines as issues anymore, but only lists non-correctable issues.

This PR fixes this direct problem.
The discussion on the issue linked above mentioned, that the "progress" format is not meant to be stable for machine parsing. It might be a good idea to switch to the XML/JSON formatters in the long run...