### PR TITLE
IarParser - Map errors and fatal errors to severity ERROR

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/IarParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/IarParser.java
@@ -50,10 +50,10 @@ public class IarParser extends RegexpLineParser {
             priority = Severity.WARNING_LOW;
         }
         else if (equalsIgnoreCase(matcher.group(3), "Error")) {
-            priority = Severity.WARNING_HIGH;
+            priority = Severity.ERROR;
         }
         else if (equalsIgnoreCase(matcher.group(3), "Fatal error")) {
-            priority = Severity.WARNING_HIGH;
+            priority = Severity.ERROR;
         }
         else {
             priority = Severity.WARNING_NORMAL;

--- a/src/test/java/edu/hm/hafner/analysis/parser/IarParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/IarParserTest.java
@@ -50,7 +50,7 @@ class IarParserTest extends AbstractParserTest {
                 .hasFileName(
                         "D:/continuousIntegration/modifiedcomps/forcedproduct/MHSM-Cascade/Cascade-Config/config/src/RDR_Config.c");
         softly.assertThat(report.get(2))
-                .hasSeverity(Severity.WARNING_HIGH)
+                .hasSeverity(Severity.ERROR)
                 .hasCategory("Pe1696")
                 .hasLineStart(17)
                 .hasLineEnd(17)
@@ -64,7 +64,7 @@ class IarParserTest extends AbstractParserTest {
                 .hasMessage("variable \"pgMsgEnv\" was declared but never referenced")
                 .hasFileName("C:/dev/bsc/daqtask.c");
         softly.assertThat(report.get(4))
-                .hasSeverity(Severity.WARNING_HIGH)
+                .hasSeverity(Severity.ERROR)
                 .hasCategory("Pe1696")
                 .hasLineStart(0)
                 .hasLineEnd(0)
@@ -127,7 +127,7 @@ class IarParserTest extends AbstractParserTest {
                     .hasMessage("function \"memcpy\" declared implicitly")
                     .hasFileName("external/specific/wiced/WICED/platform/MCU/RTOS_STM32F4xx/platform_dct_external.c");
             softly.assertThat(warnings.get(3))
-                    .hasSeverity(Severity.WARNING_HIGH)
+                    .hasSeverity(Severity.ERROR)
                     .hasCategory("Pe018")
                     .hasLineStart(633)
                     .hasLineEnd(633)


### PR DESCRIPTION
Errors and fatal errors should be an Severity.ERROR, not Severity.Warning (even high) - code lead to mistakes by setting qaulity gates on unexistgin level i.e. "TOTAL_ERROR" in pipeline script.