### PR TITLE
Do not throw UnknownFormatConversionException on encoded URLs when logging without arguments

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -702,7 +702,15 @@ public class Report implements Iterable<Issue>, Serializable {
      */
     @FormatMethod
     public void logInfo(final String format, final Object... args) {
-        infoMessages.add(String.format(format, args));
+        infoMessages.add(formatIfNeeded(format, args));
+    }
+
+    private String formatIfNeeded(final String format, final Object... args) {
+        String result = format;
+        if (args.length > 0) {
+            result = String.format(format, args);
+        }
+        return result;
     }
 
     /**
@@ -719,7 +727,7 @@ public class Report implements Iterable<Issue>, Serializable {
      */
     @FormatMethod
     public void logError(final String format, final Object... args) {
-        errorMessages.add(String.format(format, args));
+        errorMessages.add(formatIfNeeded(format, args));
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/ReportTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/ReportTest.java
@@ -828,6 +828,14 @@ class ReportTest extends SerializableTest<Report> {
         assertThat(other).hasDuplicatesSize(6);
     }
 
+    @Test
+    void shouldNotThrowOnLoggingEncodedURLs() {
+        Report report = new Report();
+
+        assertThatCode(() -> report.logInfo("localhost:9090/path%20with%20spaces"))
+                .doesNotThrowAnyException();
+    }
+
     /**
      * Serializes an issues to a file. Use this method in case the issue properties have been changed and the
      * readResolve method has been adapted accordingly so that the old serialization still can be read.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

`String.format` is always called even when logging is done without arguments.
This leads to the situation that urls can't be logged because `String.format` always searches for some `%` it wants to replace.

This fixes the error thrown in warnings-ng-plugin here: https://stackoverflow.com/questions/63152021/warnings-next-generation-axivion-tool-url-whitespaces

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
