### PR TITLE
Add missing info messages of sub reports

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -821,20 +821,20 @@ public class Report implements Iterable<Issue>, Serializable {
     }
 
     private void copyIssuesAndProperties(final Report source, final Report destination) {
+        copyProperties(source, destination);
         destination.addAll(source.elements);
         for (Report subReport : subReports) {
             destination.addAll(subReport.copy());
         }
-        copyProperties(source, destination);
     }
 
     private void copyProperties(final Report source, final Report destination) {
-        destination.id = source.id;
-        destination.name = source.name;
-        destination.originReportFile = source.originReportFile;
-        destination.duplicatesSize += source.duplicatesSize;
-        destination.infoMessages.addAll(source.infoMessages);
-        destination.errorMessages.addAll(source.errorMessages);
+        destination.id = source.getId();
+        destination.name = source.getName();
+        destination.originReportFile = source.getOriginReportFile();
+        destination.duplicatesSize += source.duplicatesSize; // not recursively
+        destination.infoMessages.addAll(source.getInfoMessages());
+        destination.errorMessages.addAll(source.getErrorMessages());
         destination.countersByKey = Stream.concat(
                 destination.countersByKey.entrySet().stream(), source.countersByKey.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Integer::sum));

--- a/src/test/java/edu/hm/hafner/analysis/ReportTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/ReportTest.java
@@ -898,6 +898,31 @@ class ReportTest extends SerializableTest<Report> {
     }
 
     @Test
+    void shouldCopyMessagesRecursively() {
+        Report checkStyle = new Report(CHECKSTYLE_ID, CHECKSTYLE_NAME, "checkstyle.xml");
+        checkStyle.logInfo("Info message from %s", CHECKSTYLE_NAME);
+        checkStyle.logError("Error message from %s", CHECKSTYLE_NAME);
+
+        Report spotBugs = new Report(SPOTBUGS_ID, SPOTBUGS_NAME, "spotbugs.xml");
+        spotBugs.logInfo("Info message from %s", SPOTBUGS_NAME);
+        spotBugs.logError("Error message from %s", SPOTBUGS_NAME);
+
+        Report wrappedCheckStyle = new Report();
+        wrappedCheckStyle.addAll(checkStyle);
+
+        Report wrappedSpotBugs = new Report();
+        wrappedSpotBugs.addAll(spotBugs);
+
+        Report aggregated = new Report();
+        aggregated.addAll(wrappedCheckStyle, wrappedSpotBugs);
+
+        assertThat(aggregated.getInfoMessages()).contains(
+                "Info message from CheckStyle", "Info message from SpotBugs");
+        assertThat(aggregated.getErrorMessages()).contains(
+                "Error message from CheckStyle", "Error message from SpotBugs");
+    }
+
+    @Test
     void shouldAddSubReports() {
         try (IssueBuilder builder = new IssueBuilder()) {
             Report checkStyle = new Report(CHECKSTYLE_ID, CHECKSTYLE_NAME, "checkstyle.xml");

--- a/src/test/java/edu/hm/hafner/analysis/ReportTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/ReportTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.*;
  * @author Marcel Binder
  * @author Ullrich Hafner
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.ExcessiveImports"})
+@SuppressWarnings({"PMD.GodClass", "PMD.ExcessiveImports", "PMD.ExcessiveClassLength"})
 class ReportTest extends SerializableTest<Report> {
     private static final String SERIALIZATION_NAME = "report.ser";
 


### PR DESCRIPTION
When copying the properties of a report the messages of the whole report tree must be copied into the new report.