### PR TITLE
Copy origin ID and name recursively for sub-reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>10.3.0</revision>
+    <revision>10.2.3</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.analysis.model</module.name>

--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -158,7 +158,8 @@ public class Report implements Iterable<Issue>, Serializable {
         id = originId;
         name = originName;
 
-        stream().forEach(issue -> issue.setOrigin(originId, originName));
+        subReports.forEach(report -> report.setOrigin(originId, originName));
+        elements.forEach(issue -> issue.setOrigin(originId, originName));
     }
 
     /**
@@ -358,6 +359,10 @@ public class Report implements Iterable<Issue>, Serializable {
         return subReports.stream().map(r -> r.contains(issue)).reduce(Boolean::logicalOr).orElse(false);
     }
 
+    @VisibleForTesting
+    List<Report> getSubReports() {
+        return subReports;
+    }
 
     /**
      * Called after de-serialization to improve the memory usage and to initialize fields that have been introduced

--- a/src/test/java/edu/hm/hafner/analysis/ReportTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/ReportTest.java
@@ -934,17 +934,20 @@ class ReportTest extends SerializableTest<Report> {
     }
 
     @Test
-    void shouldStoreEitherInTopLevelOrSubReports() {
-        Report checkStyle = new Report(CHECKSTYLE_ID, CHECKSTYLE_NAME, "checkstyle.xml");
-        checkStyle.add(HIGH);
+    void shouldCopyIdRecursively() {
+        Report first = new Report();
+        Report second = new Report();
 
-        Report wrappedCheckStyle = new Report();
-        wrappedCheckStyle.addAll(checkStyle);
-        wrappedCheckStyle.add(LOW_2_A);
+        Report aggregated = new Report();
+        aggregated.addAll(first, second);
+        aggregated.setOrigin(ID, NAME);
 
-        assertThatIllegalArgumentException().isThrownBy(
-                () -> new Report().addAll(wrappedCheckStyle)
-        );
+        assertThat(aggregated).hasId(ID);
+        assertThat(aggregated).hasName(NAME);
+        assertThat(aggregated.getSubReports()).hasSize(2).allSatisfy(report -> {
+            assertThat(report).hasId(ID);
+            assertThat(report).hasName(NAME);
+        });
     }
 
     @Test


### PR DESCRIPTION
When the ID is set for a report aggregation the ID and name should be pushed down the hierarchy.