### PR TITLE
Copy messages recursively for sub-reports and their childs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>10.3.0</revision>
+    <revision>10.2.4</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.analysis.model</module.name>

--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -333,6 +333,8 @@ public class Report implements Iterable<Issue>, Serializable {
             }
             else {
                 reportsToAdd.addAll(report.subReports);
+                infoMessages.addAll(report.getInfoMessages());
+                errorMessages.addAll(report.getErrorMessages());
             }
         }
 

--- a/src/test/java/edu/hm/hafner/analysis/ReportTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/ReportTest.java
@@ -912,25 +912,39 @@ class ReportTest extends SerializableTest<Report> {
         assertThat(wrappedCheckStyle.getNameOfOrigin(CHECKSTYLE_ID)).isEqualTo(CHECKSTYLE_NAME);
         assertThat(wrappedCheckStyle.getEffectiveId()).isEqualTo(CHECKSTYLE_ID);
         assertThat(wrappedCheckStyle.getEffectiveName()).isEqualTo(CHECKSTYLE_NAME);
+        wrappedCheckStyle.logInfo("Info (Wrapped) message from %s", CHECKSTYLE_NAME);
+        wrappedCheckStyle.logError("Error (Wrapped) message from %s", CHECKSTYLE_NAME);
 
         Report wrappedSpotBugs = new Report();
         wrappedSpotBugs.addAll(spotBugs);
         assertThat(wrappedSpotBugs.getNameOfOrigin(SPOTBUGS_ID)).isEqualTo(SPOTBUGS_NAME);
         assertThat(wrappedSpotBugs.getEffectiveId()).isEqualTo(SPOTBUGS_ID);
         assertThat(wrappedSpotBugs.getEffectiveName()).isEqualTo(SPOTBUGS_NAME);
+        wrappedSpotBugs.logInfo("Info (Wrapped) message from %s", SPOTBUGS_NAME);
+        wrappedSpotBugs.logError("Error (Wrapped) message from %s", SPOTBUGS_NAME);
 
         Report aggregated = new Report();
         aggregated.addAll(wrappedCheckStyle, wrappedSpotBugs);
         assertThat(aggregated.getEffectiveId()).isEqualTo(Report.DEFAULT_ID);
         assertThat(aggregated.getEffectiveName()).isEqualTo(Report.DEFAULT_ID);
+        aggregated.logInfo("Info (Aggregated) message");
+        aggregated.logError("Error (Aggregated) message");
 
         assertThat(aggregated.getNameOfOrigin(CHECKSTYLE_ID)).isEqualTo(CHECKSTYLE_NAME);
         assertThat(aggregated.getNameOfOrigin(SPOTBUGS_ID)).isEqualTo(SPOTBUGS_NAME);
 
         assertThat(aggregated.getInfoMessages()).contains(
-                "Info message from CheckStyle", "Info message from SpotBugs");
+                "Info message from CheckStyle",
+                "Info message from SpotBugs",
+                "Info (Wrapped) message from CheckStyle",
+                "Info (Wrapped) message from SpotBugs",
+                "Info (Aggregated) message");
         assertThat(aggregated.getErrorMessages()).contains(
-                "Error message from CheckStyle", "Error message from SpotBugs");
+                "Error message from CheckStyle",
+                "Error message from SpotBugs",
+                "Error (Wrapped) message from CheckStyle",
+                "Error (Wrapped) message from SpotBugs",
+                "Error (Aggregated) message");
     }
 
     @Test


### PR DESCRIPTION
When a report is copied with `addAll` then the warning messages should be copies as well for the whole added structure.