### PR TITLE
[JENKINS-66950] Do not stop processing when parsing line that contains but does not start with CMake path change

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -28,7 +28,7 @@ public abstract class LookaheadParser extends IssueParser {
     private static final Pattern ENTERING_DIRECTORY_PATH
             = Pattern.compile(".*" + ENTERING_DIRECTORY + " [`'](?<dir>.*)['`]");
     private static final String CMAKE_PREFIX = "-- Build files have";
-    private static final Pattern CMAKE_PATH = Pattern.compile(CMAKE_PREFIX + " been written to: (?<dir>.*)");
+    private static final Pattern CMAKE_PATH = Pattern.compile(".*" + CMAKE_PREFIX + " been written to: (?<dir>.*)");
 
     private static final int MAX_LINE_LENGTH = 4000; // see JENKINS-55805
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -814,6 +814,23 @@ class MsBuildParserTest extends AbstractParserTest {
         assertThat(warnings).isEmpty();
     }
 
+    /**
+     * Parser should not stop processing when parsing CMake output that contains text before
+     * '-- Build files have been written to'.
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse//JENKINS-66950">Issue 66950</a>
+     */
+    @Test
+    void issue66950() {
+        Report report = parse("issue66950.txt");
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            Iterator<Issue> iterator = report.iterator();
+            softly.assertThat(report).hasSize(0);
+            softly.assertThat(report).doesNotHaveErrors();
+        }
+    }
+
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
         softly.assertThat(report).hasSize(8);

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue66950.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue66950.txt
@@ -1,0 +1,1 @@
+22>-- Build files have been written to: /mnt/Jenkins_Workspace/V4SW/V4_Software_F/CUDALibs/CUDAYolo/Release-TX2


### PR DESCRIPTION
JENKINS-66950

Created test with the log from the reported output. As expected, test failed.

Modified CMAKE_PATH regex to account for lines that contain but does not start with CMake path change '-- Build files have been written to'. Test of the same log passed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
