### PR TITLE
[JENKINS-63216] Sphinx parser misses warnings without line number

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/SphinxBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SphinxBuildParser.java
@@ -19,7 +19,7 @@ import static edu.hm.hafner.analysis.Categories.*;
 public class SphinxBuildParser extends LookaheadParser {
     private static final long serialVersionUID = 1483050615340274588L;
 
-    private static final String SPHINX_BUILD_WARNING_PATTERN = "^([a-zA-Z]:\\\\.*?|/.*?|[^\\/].*?):(?:.* of .*:)?(\\d+|None|): (ERROR|WARNING): (.*)";
+    private static final String SPHINX_BUILD_WARNING_PATTERN = "^([a-zA-Z]:\\\\.*?|/.*?|[^\\/].*?):(?:|(?:.* of .*:)?(\\d+|None|):) (ERROR|WARNING): (.*)";
 
     /**
      * Creates a new instance of {@link SphinxBuildParser}.

--- a/src/test/java/edu/hm/hafner/analysis/parser/SphinxBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/SphinxBuildParserTest.java
@@ -33,6 +33,14 @@ class SphinxBuildParserTest extends AbstractParserTest {
         assertThat(warnings.getFiles()).containsExactly("C:/path/to/prj/foo/legacy.py");
     }
 
+    @Test
+    void issue63216() {
+        Report warnings = parse("issue63216.txt");
+
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.getAbsolutePaths()).containsExactly("/src/be/doc/_sub/_classTest/05_test.rst");
+    }
+
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
         assertThat(report).hasSize(7);

--- a/src/test/java/edu/hm/hafner/analysis/parser/SphinxBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/SphinxBuildParserTest.java
@@ -38,7 +38,17 @@ class SphinxBuildParserTest extends AbstractParserTest {
         Report warnings = parse("issue63216.txt");
 
         assertThat(warnings).hasSize(1);
-        assertThat(warnings.getAbsolutePaths()).containsExactly("/src/be/doc/_sub/_classTest/05_test.rst");
+        assertThat(warnings).hasOnlyAbsolutePaths("/src/be/doc/_sub/_classTest/05_test.rst");
+        assertThat(warnings).hasId("-");
+        assertThat(warnings).hasName("-");
+        assertThat(warnings.get(0))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory(SPHINX_BUILD_WARNING)
+                .hasLineStart(0)
+                .hasLineEnd(0)
+                .hasMessage("document isn't included in any toctree")
+                .hasFileName("/src/be/doc/_sub/_classTest/05_test.rst");
+
     }
 
     @Override

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue63216.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue63216.txt
@@ -1,0 +1,1 @@
+/src/be/doc/_sub/_classTest/05_test.rst: WARNING: document isn't included in any toctree


### PR DESCRIPTION
Add tests to `SphinxBuildParserTest.java`  and modify warning-pattern in `SphinxBuildParser.java`