### PR TITLE
Rename "C++ Lint" to Cpplint

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -187,7 +187,7 @@ If your tool is supported, but some properties are missing (icon, URL, etc.), pl
                 -
             </td>
             <td>
-                C++ Lint
+                Cpplint
             </td>
             <td>
                 -

--- a/src/main/java/edu/hm/hafner/analysis/parser/CppLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CppLintParser.java
@@ -12,7 +12,7 @@ import edu.hm.hafner.util.LookaheadStream;
 import static edu.hm.hafner.util.IntegerParser.*;
 
 /**
- * A parser for C++ Lint compiler warnings.
+ * A parser for Cpplint static code checker warnings.
  *
  * @author Ullrich Hafner
  */

--- a/src/main/java/edu/hm/hafner/analysis/registry/CppLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CppLintDescriptor.java
@@ -4,13 +4,13 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.parser.CppLintParser;
 
 /**
- * A descriptor for C++ Lint.
+ * A descriptor for Cpplint.
  *
  * @author Lorenz Munsch
  */
 class CppLintDescriptor extends ParserDescriptor {
     private static final String ID = "cpplint";
-    private static final String NAME = "C++ Lint";
+    private static final String NAME = "Cpplint";
 
     CppLintDescriptor() {
         super(ID, NAME);


### PR DESCRIPTION
Switch all occurrences of "C++ Lint" to Cpplint.

In the documentation, the tool is only mentioned by the name cpplint.

Source:
https://github.com/google/styleguide/tree/gh-pages/cpplint
https://pypi.org/project/cpplint

It solves (works around) issue [JENKINS-67101](https://issues.jenkins.io/browse/JENKINS-67101)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
