### PR TITLE
[JENKINS-56613] Ignore warnings with a tool as source (e.g., exe files)

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -2,6 +2,7 @@ package edu.hm.hafner.analysis.parser;
 
 import java.util.Optional;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -37,7 +38,19 @@ public class MsBuildParser extends LookaheadParser {
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
             final IssueBuilder builder) {
-        builder.setFileName(determineFileName(matcher));
+        //builder.setFileName(determineFileName(matcher));
+
+        //-------
+        String fileName = determineFileName(matcher);
+
+        Pattern fileExtensionPattern = Pattern.compile("(?!.exe)(\\.[^.]+)$");
+        Matcher fileExtensionMatcher = fileExtensionPattern.matcher(fileName);
+        if (!fileExtensionMatcher.find()) {
+            return Optional.empty();
+        }
+
+        builder.setFileName(fileName);
+        //-------
 
         if (StringUtils.isNotBlank(matcher.group(2))) {
             return builder.setLineStart(0)

--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -28,6 +28,9 @@ public class MsBuildParser extends LookaheadParser {
             + "\\s*:\\s(?:\\s*([A-Za-z0-9.]+)\\s*:)?\\s*(.*?)(?: \\[([^\\]]*)[/\\\\][^\\]\\\\]+\\])?"
             + "|(.*)\\s*:.*error\\s*(LNK[0-9]+):\\s*(.*)))$";
 
+    private static final String MS_BUILD_IGNORE_TOOLS_PATTERN
+            = "(?!.exe)(\\.[^.]+)$";
+
     /**
      * Creates a new instance of {@link MsBuildParser}.
      */
@@ -38,19 +41,15 @@ public class MsBuildParser extends LookaheadParser {
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
             final IssueBuilder builder) {
-        //builder.setFileName(determineFileName(matcher));
-
-        //-------
         String fileName = determineFileName(matcher);
 
-        Pattern fileExtensionPattern = Pattern.compile("(?!.exe)(\\.[^.]+)$");
+        Pattern fileExtensionPattern = Pattern.compile(MS_BUILD_IGNORE_TOOLS_PATTERN);
         Matcher fileExtensionMatcher = fileExtensionPattern.matcher(fileName);
         if (!fileExtensionMatcher.find()) {
             return Optional.empty();
         }
 
         builder.setFileName(fileName);
-        //-------
 
         if (StringUtils.isNotBlank(matcher.group(2))) {
             return builder.setLineStart(0)

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -50,6 +50,18 @@ class MsBuildParserTest extends AbstractParserTest {
     }
 
     /**
+     * Parse a file with false positive message.
+     *
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-56613">Issue 56613</a>
+     */
+    @Test
+    void issue56613() {
+        MsBuildParser parser = new MsBuildParser();
+        Report warnings = parser.parseFile(createReaderFactory("issue56613.txt"));
+        assertThat(warnings).isEmpty();
+    }
+
+    /**
      * Parses a file with false positive message.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-42823">Issue 42823</a>

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -307,24 +307,11 @@ class MsBuildParserTest extends AbstractParserTest {
     void issue20154() {
         Report warnings = parse("issue20154.txt");
 
-        assertThat(warnings).hasSize(3).hasDuplicatesSize(5);
-        assertThatReportHasSeverities(warnings, 0, 0, 3, 0);
+        assertThat(warnings).hasSize(2).hasDuplicatesSize(2);
+        assertThatReportHasSeverities(warnings, 0, 0, 2, 0);
 
         try (SoftAssertions softly = new SoftAssertions()) {
             softly.assertThat(warnings.get(0))
-                    .hasCategory("CA2210")
-                    .hasType("Microsoft.Design")
-                    .hasSeverity(Severity.WARNING_NORMAL)
-                    .hasMessage("Sign 'SampleCodeAnalysis.exe' with a strong name key.")
-                    .hasDescription("")
-                    .hasFileName("-")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineStart(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            softly.assertThat(warnings.get(1))
                     .hasFileName("I:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
                     .hasCategory("CA1801")
                     .hasType("Microsoft.Usage")
@@ -338,7 +325,7 @@ class MsBuildParserTest extends AbstractParserTest {
                     .hasColumnStart(0)
                     .hasColumnEnd(0);
 
-            softly.assertThat(warnings.get(2))
+            softly.assertThat(warnings.get(1))
                     .hasFileName("I:/devel/projects/SampleCodeAnalysis/SampleCodeAnalysis/Program.cs")
                     .hasCategory("CA1801")
                     .hasType("Microsoft.Usage")
@@ -611,8 +598,8 @@ class MsBuildParserTest extends AbstractParserTest {
     void issue4932() {
         Report warnings = parse("issue4932.txt");
 
-        assertThat(warnings).hasSize(2);
-        assertThatReportHasSeverities(warnings, 2, 0, 0, 0);
+        assertThat(warnings).hasSize(1);
+        assertThatReportHasSeverities(warnings, 1, 0, 0, 0);
 
         try (SoftAssertions softly = new SoftAssertions()) {
             softly.assertThat(warnings.get(0))
@@ -620,18 +607,6 @@ class MsBuildParserTest extends AbstractParserTest {
                     .hasCategory("LNK2001")
                     .hasSeverity(Severity.ERROR)
                     .hasMessage("unresolved external symbol \"public:")
-                    .hasDescription("")
-                    .hasPackageName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
-                    .hasColumnStart(0)
-                    .hasColumnEnd(0);
-
-            softly.assertThat(warnings.get(1))
-                    .hasFileName("Release/Navineo.exe")
-                    .hasCategory("LNK1120")
-                    .hasSeverity(Severity.ERROR)
-                    .hasMessage("1 unresolved externals")
                     .hasDescription("")
                     .hasPackageName("-")
                     .hasLineStart(0)

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -56,8 +56,7 @@ class MsBuildParserTest extends AbstractParserTest {
      */
     @Test
     void issue56613() {
-        MsBuildParser parser = new MsBuildParser();
-        Report warnings = parser.parseFile(createReaderFactory("issue56613.txt"));
+        parse("issue56613.txt");
         assertThat(warnings).isEmpty();
     }
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue56613.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue56613.txt
@@ -1,0 +1,5 @@
+EXEC : warning : Project file C:\J\ws\project@2\src\website\ cannot be found. [C:\J\ws\project@2\ci.msbuildproj]
+16:43:02 \\INTRANET\Releases\SmartTranslator\ConsoleTranslator.exe: Warning ST: Could not translate string 'Expand f&olders larger than:'.
+17:19:23 NMAKE : fatal error U1077: '.\Tests.exe' : return code '0x1'
+17:19:23 NMAKE : fatal error U1077: '"C:\Program Files (x86)\Utils\NMAKE.EXE"' : return code '0x2'
+16:55:11 rs: error 002: Renaming the File  was not possible. Message: The process cannot access the file '...' because it is being used by another process.


### PR DESCRIPTION
Fixed [55613](https://issues.jenkins.io/browse/JENKINS-56613): MSBuildParser is able to handle tool messages.
Added new test file.
Fixed tests.