### PR TITLE
Code checker shows position in code line

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
@@ -43,7 +43,7 @@ public class CodeCheckerParser extends LookaheadParser {
                 .setMessage(createLineWithPointerToColumn(Integer.parseInt(matcher.group("column"))) + matcher.group("message"))
                 .buildOptional();
     }
-    private String addSpaces(final int column) {
+    private String addUnderscores(final int column) {
         String result = "";
         for (int i = 0; i < column - 1; i++) {
             result = result.concat("_");
@@ -51,7 +51,7 @@ public class CodeCheckerParser extends LookaheadParser {
         return result;
     }
     private String createLineWithPointerToColumn(final int column) {
-        return addSpaces(column) + "^\n";
+        return addUnderscores(column) + "^\n    ";
     }
     private Severity getSeverity(final String severityText) {
         

--- a/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
@@ -40,10 +40,19 @@ public class CodeCheckerParser extends LookaheadParser {
                 .setLineStart(matcher.group("line"))
                 .setColumnStart(matcher.group("column"))
                 .setCategory(matcher.group("category"))
-                .setMessage(matcher.group("message"))
+                .setMessage(createLineWithPointerToColumn(Integer.parseInt(matcher.group("column"))) + matcher.group("message"))
                 .buildOptional();
     }
-
+    private String addSpaces(final int column) {
+        String result = "";
+        for (int i = 0; i < column - 1; i++) {
+            result = result.concat("_");
+        }
+        return result;
+    }
+    private String createLineWithPointerToColumn(final int column) {
+        return addSpaces(column) + "^\n";
+    }
     private Severity getSeverity(final String severityText) {
         
         if (severityText.contains("CRITICAL")) {

--- a/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
@@ -28,7 +28,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(17)
                 .hasColumnStart(8)
                 .hasFileName("/path/to/projrct/csv2xlslib.Test/parsecmdTest.cpp")
-                .hasMessage("_______^\nclass 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
+                .hasMessage("_______^\n    class 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
                 .hasCategory("cppcoreguidelines-special-member-functions")
                 .hasSeverity(Severity.WARNING_LOW);
 
@@ -36,7 +36,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(425)
                 .hasColumnStart(33)
                 .hasFileName("/path/to/projrct/extern/lib/workbook.cpp")
-                .hasMessage("________________________________^\nCalled C++ object pointer is null")
+                .hasMessage("________________________________^\n    Called C++ object pointer is null")
                 .hasCategory("core.CallAndMessage")
                 .hasSeverity(Severity.WARNING_HIGH);
 
@@ -44,7 +44,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(212)
                 .hasColumnStart(12)
                 .hasFileName("/path/to/projrct/extern/lib/HPSF.cpp")
-                .hasMessage("___________^\n'signed char' to 'int' conversion; consider casting to 'unsigned char' first.")
+                .hasMessage("___________^\n    'signed char' to 'int' conversion; consider casting to 'unsigned char' first.")
                 .hasCategory("bugprone-signed-char-misuse")
                 .hasSeverity(Severity.WARNING_NORMAL);
 
@@ -58,7 +58,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(15)
                 .hasColumnStart(22)
                 .hasFileName("C:/path/to/project/cmake-build-debug/_deps/checked_cmd-src/Tests/ArgumentsTest.cpp")
-                .hasMessage("_____________________^\n'strncpy' is deprecated: This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.")
+                .hasMessage("_____________________^\n    'strncpy' is deprecated: This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.")
                 .hasCategory("clang-diagnostic-deprecated-declarations")
                 .hasSeverity(Severity.WARNING_NORMAL);
 
@@ -66,7 +66,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(283)
                 .hasColumnStart(22)
                 .hasFileName("C:/Program Files (x86)/path/to/toolchain/include/abcddef")
-                .hasMessage("_____________________^\n'auto' return without trailing return type; deduced return types are a C++14 extension")
+                .hasMessage("_____________________^\n    'auto' return without trailing return type; deduced return types are a C++14 extension")
                 .hasCategory("clang-diagnostic-error")
                 .hasSeverity(Severity.ERROR);
 
@@ -74,7 +74,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(17)
                 .hasColumnStart(8)
                 .hasFileName("C:/path/to/project/csv2xlslib.Test/parsecmdTest.cpp")
-                .hasMessage("_______^\nclass 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
+                .hasMessage("_______^\n    class 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
                 .hasCategory("cppcoreguidelines-special-member-functions")
                 .hasSeverity(Severity.WARNING_LOW);
 
@@ -82,7 +82,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(49)
                 .hasColumnStart(8)
                 .hasFileName("C:/path/to/project/csv2xlslib.Test/parseCsvStreamTest.cpp")
-                .hasMessage("_______^\nclass 'Given_an_input_file_with_headline' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
+                .hasMessage("_______^\n    class 'Given_an_input_file_with_headline' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
                 .hasCategory("cppcoreguidelines-special-member-functions")
                 .hasSeverity(Severity.WARNING_LOW);
 
@@ -90,7 +90,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(924)
                 .hasColumnStart(49)
                 .hasFileName("C:/path/to/project/extern/lib/formula_expr.cpp")
-                .hasMessage("________________________________________________^\nsuspicious usage of 'sizeof(A*)'; pointer to aggregate")
+                .hasMessage("________________________________________________^\n    suspicious usage of 'sizeof(A*)'; pointer to aggregate")
                 .hasCategory("bugprone-sizeof-expression")
                 .hasSeverity(Severity.WARNING_HIGH);
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
@@ -28,7 +28,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(17)
                 .hasColumnStart(8)
                 .hasFileName("/path/to/projrct/csv2xlslib.Test/parsecmdTest.cpp")
-                .hasMessage("class 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
+                .hasMessage("_______^\nclass 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
                 .hasCategory("cppcoreguidelines-special-member-functions")
                 .hasSeverity(Severity.WARNING_LOW);
 
@@ -36,7 +36,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(425)
                 .hasColumnStart(33)
                 .hasFileName("/path/to/projrct/extern/lib/workbook.cpp")
-                .hasMessage("Called C++ object pointer is null")
+                .hasMessage("________________________________^\nCalled C++ object pointer is null")
                 .hasCategory("core.CallAndMessage")
                 .hasSeverity(Severity.WARNING_HIGH);
 
@@ -44,7 +44,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(212)
                 .hasColumnStart(12)
                 .hasFileName("/path/to/projrct/extern/lib/HPSF.cpp")
-                .hasMessage("'signed char' to 'int' conversion; consider casting to 'unsigned char' first.")
+                .hasMessage("___________^\n'signed char' to 'int' conversion; consider casting to 'unsigned char' first.")
                 .hasCategory("bugprone-signed-char-misuse")
                 .hasSeverity(Severity.WARNING_NORMAL);
 
@@ -58,7 +58,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(15)
                 .hasColumnStart(22)
                 .hasFileName("C:/path/to/project/cmake-build-debug/_deps/checked_cmd-src/Tests/ArgumentsTest.cpp")
-                .hasMessage("'strncpy' is deprecated: This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.")
+                .hasMessage("_____________________^\n'strncpy' is deprecated: This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.")
                 .hasCategory("clang-diagnostic-deprecated-declarations")
                 .hasSeverity(Severity.WARNING_NORMAL);
 
@@ -66,7 +66,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(283)
                 .hasColumnStart(22)
                 .hasFileName("C:/Program Files (x86)/path/to/toolchain/include/abcddef")
-                .hasMessage("'auto' return without trailing return type; deduced return types are a C++14 extension")
+                .hasMessage("_____________________^\n'auto' return without trailing return type; deduced return types are a C++14 extension")
                 .hasCategory("clang-diagnostic-error")
                 .hasSeverity(Severity.ERROR);
 
@@ -74,7 +74,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(17)
                 .hasColumnStart(8)
                 .hasFileName("C:/path/to/project/csv2xlslib.Test/parsecmdTest.cpp")
-                .hasMessage("class 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
+                .hasMessage("_______^\nclass 'TheFixture' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
                 .hasCategory("cppcoreguidelines-special-member-functions")
                 .hasSeverity(Severity.WARNING_LOW);
 
@@ -82,7 +82,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(49)
                 .hasColumnStart(8)
                 .hasFileName("C:/path/to/project/csv2xlslib.Test/parseCsvStreamTest.cpp")
-                .hasMessage("class 'Given_an_input_file_with_headline' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
+                .hasMessage("_______^\nclass 'Given_an_input_file_with_headline' defines a default destructor but does not define a copy constructor, a copy assignment operator, a move constructor or a move assignment operator")
                 .hasCategory("cppcoreguidelines-special-member-functions")
                 .hasSeverity(Severity.WARNING_LOW);
 
@@ -90,7 +90,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasLineStart(924)
                 .hasColumnStart(49)
                 .hasFileName("C:/path/to/project/extern/lib/formula_expr.cpp")
-                .hasMessage("suspicious usage of 'sizeof(A*)'; pointer to aggregate")
+                .hasMessage("________________________________________________^\nsuspicious usage of 'sizeof(A*)'; pointer to aggregate")
                 .hasCategory("bugprone-sizeof-expression")
                 .hasSeverity(Severity.WARNING_HIGH);
 


### PR DESCRIPTION
Some times there are several warnings in one code line.
If those warnings are of the same type, the webview of the code in question is not clear about the exact position.
In the following screenshot you see a warning that is created 3 times for the same line, but for different columns.
![webview1](https://user-images.githubusercontent.com/1757239/143425808-17fba29f-fbbb-4c05-9407-d1c2bb96b82c.png)

The easy fix is to construct a multi line message, with the first line containing a pointer on `column` of the warning.
the message could look like
![webview](https://user-images.githubusercontent.com/1757239/143418433-c6bc2e85-23c8-4b02-85fa-7f181ea22725.png)
This has some issues as you might notice in the screen shot:
- the `^` should be right below `b` in the code line
- the icon offsets the start of the line
- the message font does not have fixed width

A possible solution could be:
- the warning text should use a fixed width font. Maybe even the same as it is used to display the code
- the icon could be displayed at the end of the warning

This the result. in combination with https://github.com/jenkinsci/warnings-ng-plugin/pull/1128
![webview3](https://user-images.githubusercontent.com/1757239/143506655-cc002fde-4daf-4fd7-8df2-5402d0a2a646.png)

The icon disappeared when trying to put it after/on the right side next to the text.
Also any left padding needed to be removed to make it fit with the position in the code line



<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
