### PR TITLE
Fixed JENKINS-56815: Made note-lines available

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParser.java
@@ -20,7 +20,7 @@ public class Gcc4CompilerParser extends LookaheadParser {
     private static final long serialVersionUID = 5490211629355204910L;
 
     private static final String GCC_WARNING_PATTERN =
-            ANT_TASK + "(.+?):(\\d+):(?:(\\d+):)? ?([wW]arning|.*[Ee]rror): (.*)$";
+            ANT_TASK + "(.+?):(\\d+):(?:(\\d+):)? ?([wW]arning|.*[Ee]rror|.*[Nn]ote): (.*)$";
     private static final Pattern CLASS_PATTERN = Pattern.compile("\\[-W(.+)]$");
 
     /**
@@ -40,7 +40,7 @@ public class Gcc4CompilerParser extends LookaheadParser {
 
     @Override
     protected boolean isLineInteresting(final String line) {
-        return line.contains("arning") || line.contains("rror");
+        return line.contains("arning") || line.contains("rror") || line.contains("ote");
     }
 
     @Override
@@ -81,6 +81,6 @@ public class Gcc4CompilerParser extends LookaheadParser {
         if (peek.charAt(2) == '/' || peek.charAt(0) == '\\') {
             return false;
         }
-        return !StringContainsUtils.containsAnyIgnoreCase(peek, "arning", "rror", "make");
+        return !StringContainsUtils.containsAnyIgnoreCase(peek, "arning", "rror", "ote", "make");
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -23,7 +23,7 @@ public class MsBuildParser extends LookaheadParser {
     private static final String MS_BUILD_WARNING_PATTERN
             = "(?:^(?:.*)Command line warning ([A-Za-z0-9]+):\\s*(.*)\\s*\\[(.*)\\])|"
             + ANT_TASK + "(?:(?:\\s*(?:\\d+|\\d+:\\d+)>)?(?:(?:(?:(.*?)\\((\\d*)(?:,(\\d+))?[a-zA-Z]*?\\)|.*LINK)\\s*:|"
-            + "(.*):)\\s*([A-z-_]*\\s(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))[^A-Za-z0-9]\\s*:?\\s*([A-Za-z0-9\\-_]+)?"
+            + "(.*):)\\s*([A-z-_]*\\s(?:[Nn]ote|[Ii]nfo|[Ww]arning|(?:fatal\\s*)?[Ee]rror))[^A-Za-z0-9]?\\s*:?\\s*([A-Za-z0-9\\-_]+)?"
             + "\\s*:\\s(?:\\s*([A-Za-z0-9.]+)\\s*:)?\\s*(.*?)(?: \\[([^\\]]*)[/\\\\][^\\]\\\\]+\\])?"
             + "|(.*)\\s*:.*error\\s*(LNK[0-9]+):\\s*(.*)))$";
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParserTest.java
@@ -32,6 +32,29 @@ class Gcc4CompilerParserTest extends AbstractParserTest {
         return new Gcc4CompilerParser();
     }
 
+    @Test
+    void shouldIncludeNote() {
+        Report report = parse("GccNoteIssue.txt");
+
+        assertThat(report).hasSize(2);
+
+        assertThat(report.get(0))
+                .hasLineStart(2)
+                .hasColumnStart(19)
+                .hasFileName("tt.cpp")
+                .hasMessage("invalid conversion from 'int' to 'A*' [-fpermissive]\n"
+                        + " void bar() { foo(1); }\n"
+                        + "                   ^");
+
+        assertThat(report.get(1))
+                .hasLineStart(1)
+                .hasColumnStart(6)
+                .hasFileName("tt.cpp")
+                .hasMessage("initializing argument 1 of 'void foo(A*)'\n"
+                        + " void foo(struct A *);\n"
+                        + "      ^~~");
+    }
+
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
         softly.assertThat(report).hasSize(14);

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -20,6 +20,26 @@ class MsBuildParserTest extends AbstractParserTest {
         super("msbuild.txt");
     }
 
+
+    @Test
+    void shouldIncludeNote() {
+        Report report = parse("MSBuildNoteIssue.txt");
+
+        assertThat(report).hasSize(2);
+
+        assertThat(report.get(0))
+                .hasLineStart(2)
+                .hasCategory("C2664")
+                .hasFileName("tt.cpp")
+                .hasMessage("'void foo(A *)': cannot convert argument 1 from 'int' to 'A *'");
+
+        assertThat(report.get(1))
+                .hasLineStart(2)
+                .hasCategory("")
+                .hasFileName("tt.cpp")
+                .hasMessage("Conversion from integral type to pointer type requires reinterpret_cast, C-style cast or function-style cast");
+    }
+
     /**
      * Parses a file with ANSI colors.
      *

--- a/src/test/resources/edu/hm/hafner/analysis/parser/GccNoteIssue.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/GccNoteIssue.txt
@@ -1,0 +1,7 @@
+tt.cpp: In function 'void bar()':
+tt.cpp:2:19: error: invalid conversion from 'int' to 'A*' [-fpermissive]
+ void bar() { foo(1); }
+                   ^
+tt.cpp:1:6: note: initializing argument 1 of 'void foo(A*)'
+ void foo(struct A *);
+      ^~~

--- a/src/test/resources/edu/hm/hafner/analysis/parser/MSBuildNoteIssue.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/MSBuildNoteIssue.txt
@@ -1,0 +1,2 @@
+tt.cpp(2): error C2664: 'void foo(A *)': cannot convert argument 1 from 'int' to 'A *'
+tt.cpp(2): note: Conversion from integral type to pointer type requires reinterpret_cast, C-style cast or function-style cast


### PR DESCRIPTION
Solved the following issues in JENKINS-56815:
- MSBuildParser is now able to handle note-lines
- Gcc4CompilerParser is now able to handle note-lines

Issues not touched in this pull request (see corresponding Jenkins-Issue):
- The "annoying special rule" in gcc is 
- the "full error localization" issue
- The MP-flag

**Please note:**
- The regex of MSBuildParser was adjusted in a way where other tests fail (added a question mark to the regex). Before merging this, the failing tests or the implemented regex must be changed!
- For now, note-lines are handled as its own Issue - there is no connection between error/warning and note. This should be changed in a further step (new Jenkins-Issue?) Advice: Multiple notes for a error/warning are possible and must still be kept in mind when linking the notes to the error/warning (see Jenkins-Issue)
- I have noticed that the category in `Gcc4CompilerParser` is rarely used (compared to `GccParser`. Is this fine?

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
