### PR TITLE
[JENKINS-67245] Do not escape tool names anymore

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/TrivyParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/TrivyParser.java
@@ -34,7 +34,10 @@ public class TrivyParser extends JsonIssueParser {
      */
     @Override
     protected void parseJsonObject(final Report report, final JSONObject jsonReport, final IssueBuilder issueBuilder) {
-        parseResults(report, jsonReport.optJSONArray("Results"), issueBuilder);
+        JSONArray results = jsonReport.optJSONArray("Results");
+        if (results != null) {
+            parseResults(report, results, issueBuilder);
+        }
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/parser/TrivyParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/TrivyParserTest.java
@@ -1,7 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.AbstractParserTest;
@@ -9,14 +7,14 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
-import edu.hm.hafner.analysis.assertions.Assertions;
 import edu.hm.hafner.analysis.assertions.SoftAssertions;
+
+import static edu.hm.hafner.analysis.assertions.Assertions.*;
 
 /**
  * Tests the class {@link TrivyParser}.
  */
 class TrivyParserTest extends AbstractParserTest {
-
     TrivyParserTest() {
         super("trivy_result.json");
     }
@@ -36,13 +34,20 @@ class TrivyParserTest extends AbstractParserTest {
     void parseResultsForSchemaVersion2() {
         Report report = parse("trivy_result_0.20.0.json");
 
-        Assertions.assertThat(report).hasSize(4);
+        assertThat(report).hasSize(4);
 
-        Assertions.assertThat(report.get(0))
+        assertThat(report.get(0))
                 .hasSeverity(Severity.WARNING_LOW)
                 .hasType("CVE-2017-6519")
                 .hasCategory("redhat")
                 .hasMessage("avahi: Multicast DNS responds to unicast queries outside of local network");
+    }
+
+    @Test
+    void shouldHandleEmptyResultsJenkins67296() {
+        Report report = parse("issue67296.json");
+
+        assertThat(report).isEmpty();
     }
 
     @Test

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue67296.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue67296.json
@@ -1,0 +1,17 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "/tmp/tmp.1F2RFo3ny4",
+  "ArtifactType": "filesystem",
+  "Metadata": {
+    "ImageConfig": {
+      "architecture": "",
+      "created": "0001-01-01T00:00:00Z",
+      "os": "",
+      "rootfs": {
+        "type": "",
+        "diff_ids": null
+      },
+      "config": {}
+    }
+  }
+}


### PR DESCRIPTION
See [JENKINS-67296](https://issues.jenkins.io/browse/JENKINS-67296).