### PR TITLE
Add valgrind parser

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -2091,6 +2091,25 @@ analyze - iccxxxxcompiler_opts cstat2.c</pre></code>For details check the IAR C-
         </tr>
         <tr>
             <td>
+                valgrind
+            </td>
+            <td>
+                -
+            </td>
+            <td>
+                Valgrind
+            </td>
+            <td>
+                -
+            </td>
+        </tr>
+        <tr>
+            <td colspan="4">
+                :bulb: Use option --xml=yes
+            </td>
+        </tr>
+        <tr>
+            <td>
                 veracode-pipeline-scanner
             </td>
             <td>

--- a/etc/Jenkinsfile.valgrind
+++ b/etc/Jenkinsfile.valgrind
@@ -1,0 +1,9 @@
+node('java11-agent') {
+    stage ('Checkout') {
+        checkout scm
+    }
+
+    stage ('Build, Test, and Static Analysis') {
+        recordIssues tool: analysisParser(analysisModelId: 'valgrind', pattern: '**/valgrind.xml')
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapter.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapter.java
@@ -16,7 +16,6 @@ import edu.hm.hafner.analysis.Report;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import j2html.tags.ContainerTag;
-import j2html.tags.Tag;
 import static j2html.TagCreator.*;
 
 import se.bjurr.violations.lib.model.Violation;
@@ -67,7 +66,7 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
                 ).render();
     }
 
-    private Tag generateGeneralTableHtml(final String executable, final String uniqueId, @CheckForNull final String threadId, @CheckForNull final String threadName, @CheckForNull final JSONArray auxWhats) {
+    private ContainerTag generateGeneralTableHtml(final String executable, final String uniqueId, @CheckForNull final String threadId, @CheckForNull final String threadName, @CheckForNull final JSONArray auxWhats) {
         ContainerTag generalTable =
                 table(
                         attrs(".table.table-striped"),
@@ -86,9 +85,9 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
         return generalTable;
     }
 
-    private Tag maybeGenerateStackTracesHtml(@CheckForNull final String stacksJson, final String message, @CheckForNull final JSONArray auxWhats) {
+    private @CheckForNull ContainerTag maybeGenerateStackTracesHtml(@CheckForNull final String stacksJson, final String message, @CheckForNull final JSONArray auxWhats) {
         if (StringUtils.isBlank(stacksJson)) {
-            return iff(false, null);
+            return null;
         }
 
         final JSONArray stacks = new JSONArray(new JSONTokener(stacksJson));
@@ -117,10 +116,10 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
             return stackTraces;
         }
 
-        return iff(false, null);
+        return null;
     }
 
-    private Tag generateStackTraceHtml(final String title, @CheckForNull final String message, final JSONArray frames) {
+    private ContainerTag generateStackTraceHtml(final String title, @CheckForNull final String message, final JSONArray frames) {
         ContainerTag stackTraceContainer =
                 div(
                         br(),
@@ -141,29 +140,28 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
         return stackTraceContainer;
     }
 
-    private Tag generateStackFrameHtml(final JSONObject frame) {
+    private ContainerTag generateStackFrameHtml(final JSONObject frame) {
         return
                 table(
-                        attrs(".table.table-striped"),
                         maybeGenerateTableRowHtml("Object", frame.optString("obj")),
                         maybeGenerateTableRowHtml("Function", frame.optString("fn")),
                         maybeGenerateStackFrameFileTableRowHtml(frame)
                 );
     }
 
-    private Tag maybeGenerateSuppressionHtml(@CheckForNull final String suppression) {
+    private ContainerTag maybeGenerateSuppressionHtml(@CheckForNull final String suppression) {
         return
                 iff(
                         StringUtils.isNotBlank(suppression),
-                        div(br(), h4("Suppression"), table(attrs(".table.table-striped"), tr(td(pre(suppression)))))
+                        div(br(), h4("Suppression"), table(tr(td(pre(suppression)))))
                 );
     }
 
-    private Tag maybeGenerateTableRowHtml(final String name, @CheckForNull final String value) {
+    private ContainerTag maybeGenerateTableRowHtml(final String name, @CheckForNull final String value) {
         return iff(StringUtils.isNotBlank(value), tr(td(text(name), td(text(value)))));
     }
 
-    private Tag maybeGenerateStackFrameFileTableRowHtml(final JSONObject frame) throws JSONException {
+    private @CheckForNull ContainerTag maybeGenerateStackFrameFileTableRowHtml(final JSONObject frame) throws JSONException {
         final String file = frame.optString("file");
 
         if (StringUtils.isNotBlank(file)) {
@@ -184,7 +182,7 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
             return maybeGenerateTableRowHtml("File", fileBuilder.toString());
         }
 
-        return iff(false, null);
+        return null;
     }
 
     @CheckForNull

--- a/src/main/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapter.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapter.java
@@ -1,0 +1,194 @@
+package edu.hm.hafner.analysis.parser.violations;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.text.StringEscapeUtils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Report;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import se.bjurr.violations.lib.model.Violation;
+import se.bjurr.violations.lib.parsers.ValgrindParser;
+
+/**
+ * Parses Valgrind XML report files.
+ *
+ * @author Tony Ciavarella
+ */
+public class ValgrindAdapter extends AbstractViolationAdapter {
+    private static final long serialVersionUID = -6117336551972081612L;
+    private static final int NUMBERED_STACK_THRESHOLD = 2;
+
+    @Override
+    ValgrindParser createParser() {
+        return new ValgrindParser();
+    }
+
+    @Override
+    Report convertToReport(final Set<Violation> violations) {
+        try (IssueBuilder issueBuilder = new IssueBuilder()) {
+            Report report = new Report();
+
+            for (Violation violation: violations) {
+                updateIssueBuilder(violation, issueBuilder);
+                issueBuilder.setCategory("valgrind:" + violation.getReporter());
+                issueBuilder.setMessage(violation.getMessage());
+                issueBuilder.setDescription(generateDescriptionHtml(violation));
+                report.add(issueBuilder.buildAndClean());
+            }
+
+            return report;
+        }
+    }
+
+    private String generateDescriptionHtml(final Violation violation) {
+        final StringBuilder description = new StringBuilder(1024);
+
+        final Map<String, String> specifics = violation.getSpecifics();
+        final JSONArray auxWhats = getAuxWhatsArray(specifics);
+
+        appendGeneralTable(description, violation.getSource(), violation.getGroup(), specifics.get("tid"), specifics.get("threadname"), auxWhats);
+        maybeAppendStackTraces(description, specifics.get("stacks"), violation.getMessage(), auxWhats);
+        maybeAppendSuppression(description, specifics.get("suppression"));
+
+        return description.toString();
+    }
+
+    private void appendGeneralTable(final StringBuilder html, final String executable, final String uniqueId, @CheckForNull final String threadId, @CheckForNull final String threadName, @CheckForNull final JSONArray auxWhats) {
+        html.append("<table>");
+
+        maybeAppendTableRow(html, "Executable", executable);
+        maybeAppendTableRow(html, "Unique Id", uniqueId);
+        maybeAppendTableRow(html, "Thread Id", threadId);
+        maybeAppendTableRow(html, "Thread Name", threadName);
+
+        if (auxWhats != null && !auxWhats.isEmpty()) {
+            for (int auxwhatIndex = 0; auxwhatIndex < auxWhats.length(); ++auxwhatIndex) {
+                maybeAppendTableRow(html, "Auxiliary", auxWhats.getString(auxwhatIndex));
+            }
+        }
+
+        html.append("</table>");
+    }
+
+    private void maybeAppendStackTraces(final StringBuilder html, @CheckForNull final String stacksJson, final String message, @CheckForNull final JSONArray auxWhats) {
+        if (stacksJson == null || stacksJson.isEmpty()) {
+            return;
+        }
+
+        final JSONArray stacks = new JSONArray(new JSONTokener(stacksJson));
+
+        if (!stacks.isEmpty()) {
+            appendStackTrace(html, "Primary Stack Trace", message, stacks.getJSONArray(0));
+
+            for (int stackIndex = 1; stackIndex < stacks.length(); ++stackIndex) {
+                String msg = null;
+
+                if (auxWhats != null && auxWhats.length() >= stackIndex) {
+                    msg = auxWhats.getString(stackIndex - 1);
+                }
+
+                String title = "Auxiliary Stack Trace";
+
+                if (stacks.length() > NUMBERED_STACK_THRESHOLD) {
+                    title = "Auxiliary Stack Trace #" + stackIndex;
+                }
+
+                appendStackTrace(html, title, msg, stacks.getJSONArray(stackIndex));
+            }
+        }
+    }
+
+    private void appendStackTrace(final StringBuilder html, final String title, @CheckForNull final String message, final JSONArray frames) {
+        html
+                .append("<br><h5>")
+                .append(title)
+                .append("</h5>");
+
+        if (message != null && !message.isEmpty()) {
+            html
+                    .append("<p>")
+                    .append(message)
+                    .append("</p>");
+        }
+
+        for (int frameIndex = 0; frameIndex < frames.length(); ++frameIndex) {
+            final JSONObject frame = frames.getJSONObject(frameIndex);
+
+            if (frameIndex > 0) {
+                html.append("<br>");
+            }
+
+            appendStackFrame(html, frame);
+        }
+    }
+
+    private void appendStackFrame(final StringBuilder html, final JSONObject frame) {
+        html.append("<table>");
+        maybeAppendTableRow(html, "Object", frame.optString("obj"));
+        maybeAppendTableRow(html, "Function", frame.optString("fn"));
+        maybeAppendStackFrameFileTableRow(html, frame);
+        html.append("</table>");
+    }
+
+    private void maybeAppendSuppression(final StringBuilder html, @CheckForNull final String suppression) {
+        if (suppression != null && !suppression.isEmpty()) {
+            html
+                    .append("<p>Suppression</p><table><tr><td><pre>")
+                    .append(StringEscapeUtils.escapeHtml4(suppression))
+                    .append("</pre></td></tr></table>");
+        }
+    }
+
+    private void maybeAppendTableRow(final StringBuilder html, final String name, @CheckForNull final String value) {
+        if (value != null && !value.isEmpty()) {
+            html
+                    .append("<tr><td>")
+                    .append(name)
+                    .append("</td><td>")
+                    .append(value)
+                    .append("</td></tr>");
+        }
+    }
+
+    private void maybeAppendStackFrameFileTableRow(final StringBuilder html, final JSONObject frame) throws JSONException {
+        String dir = frame.optString("dir");
+        final String file = frame.optString("file");
+        final int line = frame.optInt("line", -1);
+
+        if (!file.isEmpty()) {
+            html.append("<tr><td>File</td><td>");
+
+            if (!dir.isEmpty()) {
+                html.append(dir).append('/');
+            }
+
+            html.append(file);
+
+            if (line != -1) {
+                html.append(':').append(line);
+            }
+
+            html.append("</td></tr>");
+        }
+    }
+
+    @CheckForNull
+    private JSONArray getAuxWhatsArray(final Map<String, String> specifics) {
+        final String auxWhatsJson = specifics.get("auxwhats");
+
+        if (auxWhatsJson != null && !auxWhatsJson.isEmpty()) {
+            return new JSONArray(new JSONTokener(auxWhatsJson));
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapter.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapter.java
@@ -87,35 +87,37 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
     }
 
     private Tag maybeGenerateStackTracesHtml(@CheckForNull final String stacksJson, final String message, @CheckForNull final JSONArray auxWhats) {
-        ContainerTag stackTraces = null;
-
-        if (StringUtils.isNotBlank(stacksJson)) {
-            final JSONArray stacks = new JSONArray(new JSONTokener(stacksJson));
-
-            if (!stacks.isEmpty()) {
-                stackTraces = div();
-
-                stackTraces.with(generateStackTraceHtml("Primary Stack Trace", message, stacks.getJSONArray(0)));
-
-                for (int stackIndex = 1; stackIndex < stacks.length(); ++stackIndex) {
-                    String msg = null;
-
-                    if (auxWhats != null && auxWhats.length() >= stackIndex) {
-                        msg = auxWhats.getString(stackIndex - 1);
-                    }
-
-                    String title = "Auxiliary Stack Trace";
-
-                    if (stacks.length() > NUMBERED_STACK_THRESHOLD) {
-                        title += " #" + stackIndex;
-                    }
-
-                    stackTraces.with(generateStackTraceHtml(title, msg, stacks.getJSONArray(stackIndex)));
-                }
-            }
+        if (StringUtils.isBlank(stacksJson)) {
+            return iff(false, null);
         }
 
-        return stackTraces;
+        final JSONArray stacks = new JSONArray(new JSONTokener(stacksJson));
+
+        if (!stacks.isEmpty()) {
+            ContainerTag stackTraces = div();
+
+            stackTraces.with(generateStackTraceHtml("Primary Stack Trace", message, stacks.getJSONArray(0)));
+
+            for (int stackIndex = 1; stackIndex < stacks.length(); ++stackIndex) {
+                String msg = null;
+
+                if (auxWhats != null && auxWhats.length() >= stackIndex) {
+                    msg = auxWhats.getString(stackIndex - 1);
+                }
+
+                String title = "Auxiliary Stack Trace";
+
+                if (stacks.length() > NUMBERED_STACK_THRESHOLD) {
+                    title += " #" + stackIndex;
+                }
+
+                stackTraces.with(generateStackTraceHtml(title, msg, stacks.getJSONArray(stackIndex)));
+            }
+
+            return stackTraces;
+        }
+
+        return iff(false, null);
     }
 
     private Tag generateStackTraceHtml(final String title, @CheckForNull final String message, final JSONArray frames) {
@@ -162,7 +164,6 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
     }
 
     private Tag maybeGenerateStackFrameFileTableRowHtml(final JSONObject frame) throws JSONException {
-        Tag row = null;
         final String file = frame.optString("file");
 
         if (StringUtils.isNotBlank(file)) {
@@ -180,10 +181,10 @@ public class ValgrindAdapter extends AbstractViolationAdapter {
                 fileBuilder.append(':').append(line);
             }
 
-            row = maybeGenerateTableRowHtml("File", fileBuilder.toString());
+            return maybeGenerateTableRowHtml("File", fileBuilder.toString());
         }
 
-        return row;
+        return iff(false, null);
     }
 
     @CheckForNull

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -163,6 +163,7 @@ public class ParserRegistry {
             new TnsdlDescriptor(),
             new TrivyDescriptor(),
             new TsLintDescriptor(),
+            new ValgrindDescriptor(),
             new VeraCodePipelineScannerDescriptor(),
             new XlcDescriptor(),
             new YamlLintDescriptor(),

--- a/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
@@ -3,9 +3,10 @@ package edu.hm.hafner.analysis.registry;
 import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.parser.violations.ValgrindAdapter;
 
+import static j2html.TagCreator.*;
+
 /**
  * A descriptor for Valgrind.
- * See https://valgrind.org for more information about Valgrind.
  */
 public class ValgrindDescriptor extends ParserDescriptor {
     private static final String ID = "valgrind";
@@ -22,6 +23,16 @@ public class ValgrindDescriptor extends ParserDescriptor {
 
     @Override
     public String getHelp() {
-        return "Use option --xml=yes";
+        return join(text("Use options"),
+                code("--xml=yes --xml-file=valgrind_report.xml --child-silent-after-fork=yes"),
+                text(", see the"),
+                a("Valgrind User Manual").withHref("https://valgrind.org/docs/manual/manual-core.html"),
+                text("for usage details.")).render();
     }
+
+    @Override
+    public String getUrl() { return "https://valgrind.org"; }
+
+    @Override
+    public String getIconUrl() { return "https://valgrind.org/images/valgrind-link3.png"; }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
@@ -5,6 +5,7 @@ import edu.hm.hafner.analysis.parser.violations.ValgrindAdapter;
 
 /**
  * A descriptor for Valgrind.
+ * See https://valgrind.org for more information about Valgrind.
  */
 public class ValgrindDescriptor extends ParserDescriptor {
     private static final String ID = "valgrind";

--- a/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
@@ -31,8 +31,12 @@ public class ValgrindDescriptor extends ParserDescriptor {
     }
 
     @Override
-    public String getUrl() { return "https://valgrind.org"; }
+    public String getUrl() {
+        return "https://valgrind.org";
+    }
 
     @Override
-    public String getIconUrl() { return "https://valgrind.org/images/valgrind-link3.png"; }
+    public String getIconUrl() {
+        return "https://valgrind.org/images/valgrind-link3.png";
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
@@ -1,0 +1,26 @@
+package edu.hm.hafner.analysis.registry;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.parser.violations.ValgrindAdapter;
+
+/**
+ * A descriptor for Valgrind.
+ */
+public class ValgrindDescriptor extends ParserDescriptor {
+    private static final String ID = "valgrind";
+    private static final String NAME = "Valgrind";
+
+    ValgrindDescriptor() {
+        super(ID, NAME);
+    }
+
+    @Override
+    public IssueParser createParser(final Option... options) {
+        return new ValgrindAdapter();
+    }
+
+    @Override
+    public String getHelp() {
+        return "Use option --xml=yes";
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
@@ -7,8 +7,6 @@ import edu.hm.hafner.analysis.assertions.SoftAssertions;
 
 import se.bjurr.violations.lib.model.Violation;
 
-import static org.assertj.core.api.Assertions.*;
-
 /**
  * Tests the class {@link ValgrindAdapter}.
  *
@@ -62,11 +60,10 @@ class ValgrindAdapterTest extends AbstractParserTest {
                 issue -> {
                     final String description = issue.getDescription();
                     if (Violation.NO_FILE.equals(issue.getFileName())) {
-                        assertThat(!description.contains("Primary Stack Trace"));
+                        softly.assertThat(description).doesNotContain("Primary Stack Trace");
                     }
                     else {
-                        assertThat(description.contains("Primary Stack Trace"));
-                        assertThat(description.contains("&lt;insert_a_suppression_name_here&gt;"));
+                        softly.assertThat(description).contains("Primary Stack Trace", "&lt;insert_a_suppression_name_here&gt;");
                     }
                 }
         );

--- a/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
@@ -1,0 +1,64 @@
+package edu.hm.hafner.analysis.parser.violations;
+
+import edu.hm.hafner.analysis.AbstractParserTest;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+
+import se.bjurr.violations.lib.model.Violation;
+
+/**
+ * Tests the class {@link ValgrindAdapter}.
+ *
+ * @author Tony Ciavarella
+ */
+class ValgrindAdapterTest extends AbstractParserTest {
+    ValgrindAdapterTest() {
+        super("valgrind.xml");
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        softly.assertThat(report).hasSize(5);
+        softly.assertThat(report.get(3))
+                .hasCategory("valgrind:memcheck")
+                .hasMessage("Conditional jump or move depends on uninitialised value(s)")
+                .hasFileName("/home/some_user/terrible_program/terrible_program.cpp")
+                .hasType("UninitCondition")
+                .hasLineStart(5)
+                .hasSeverity(Severity.WARNING_HIGH);
+        softly.assertThat(report.get(2))
+                .hasCategory("valgrind:memcheck")
+                .hasMessage("Invalid write of size 4")
+                .hasFileName("/home/some_user/terrible_program/terrible_program.cpp")
+                .hasType("InvalidWrite")
+                .hasLineStart(10)
+                .hasSeverity(Severity.WARNING_HIGH);
+        softly.assertThat(report.get(4))
+                .hasCategory("valgrind:memcheck")
+                .hasMessage("16 bytes in 1 blocks are definitely lost in loss record 1 of 1")
+                .hasFileName("/home/some_user/terrible_program/terrible_program.cpp")
+                .hasType("Leak_DefinitelyLost")
+                .hasLineStart(3)
+                .hasSeverity(Severity.WARNING_HIGH);
+        softly.assertThat(report.get(1))
+                .hasCategory("valgrind:memcheck")
+                .hasMessage("Syscall param write(buf) points to uninitialised byte(s)")
+                .hasFileName("/home/buildozer/aports/main/musl/src/1.2.4/src/thread/x86_64/syscall_cp.s")
+                .hasType("SyscallParam")
+                .hasLineStart(29)
+                .hasSeverity(Severity.WARNING_HIGH);
+        softly.assertThat(report.get(0))
+                .hasCategory("valgrind:memcheck")
+                .hasMessage("Some type of error without a stack trace")
+                .hasFileName(Violation.NO_FILE)
+                .hasType("Not_A_Real_Error")
+                .hasLineStart(0)
+                .hasSeverity(Severity.WARNING_HIGH);
+    }
+
+    @Override
+    protected ValgrindAdapter createParser() {
+        return new ValgrindAdapter();
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
@@ -7,6 +7,8 @@ import edu.hm.hafner.analysis.assertions.SoftAssertions;
 
 import se.bjurr.violations.lib.model.Violation;
 
+import static org.assertj.core.api.Assertions.*;
+
 /**
  * Tests the class {@link ValgrindAdapter}.
  *
@@ -53,8 +55,21 @@ class ValgrindAdapterTest extends AbstractParserTest {
                 .hasMessage("Some type of error without a stack trace")
                 .hasFileName(Violation.NO_FILE)
                 .hasType("Not_A_Real_Error")
-                .hasLineStart(0)
+                .hasLineStart(Violation.NO_LINE)
                 .hasSeverity(Severity.WARNING_HIGH);
+
+        report.forEach(
+                issue -> {
+                    final String description = issue.getDescription();
+
+                    if (!issue.getFileName().equals(Violation.NO_FILE)) {
+                        assertThat(description.contains("Primary Stack Trace"));
+                        assertThat(description.contains("&lt;insert_a_suppression_name_here&gt;"));
+                    } else {
+                        assertThat(!description.contains("Primary Stack Trace"));
+                    }
+                }
+        );
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/violations/ValgrindAdapterTest.java
@@ -61,12 +61,12 @@ class ValgrindAdapterTest extends AbstractParserTest {
         report.forEach(
                 issue -> {
                     final String description = issue.getDescription();
-
-                    if (!issue.getFileName().equals(Violation.NO_FILE)) {
+                    if (Violation.NO_FILE.equals(issue.getFileName())) {
+                        assertThat(!description.contains("Primary Stack Trace"));
+                    }
+                    else {
                         assertThat(description.contains("Primary Stack Trace"));
                         assertThat(description.contains("&lt;insert_a_suppression_name_here&gt;"));
-                    } else {
-                        assertThat(!description.contains("Primary Stack Trace"));
                     }
                 }
         );

--- a/src/test/resources/edu/hm/hafner/analysis/parser/violations/valgrind.xml
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/violations/valgrind.xml
@@ -253,7 +253,6 @@
         <ip>0x40550FD</ip>
         <obj>/lib/ld-musl-x86_64.so.1</obj>
         <fn>__syscall_cp_c</fn>
-        <dir>/home/buildozer/aports/main/musl/src/1.2.4/src/thread</dir>
         <file>pthread_cancel.c</file>
         <line>33</line>
       </frame>
@@ -383,7 +382,6 @@
         <fn>make_spaghetti(int)</fn>
         <dir>/workspace/awful project</dir>
         <file>spaghetti.cpp</file>
-        <line>6</line>
       </frame>
       <frame>
         <ip>0x1091F2</ip>
@@ -497,4 +495,3 @@
   </suppcounts>
 
 </valgrindoutput>
-

--- a/src/test/resources/edu/hm/hafner/analysis/parser/violations/valgrind.xml
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/violations/valgrind.xml
@@ -1,0 +1,500 @@
+<?xml version="1.0"?>
+
+<valgrindoutput>
+
+  <protocolversion>4</protocolversion>
+  <protocoltool>memcheck</protocoltool>
+
+  <preamble>
+    <line>Memcheck, a memory error detector</line>
+    <line>Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.</line>
+    <line>Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info</line>
+    <line>Command: ./terrible_program</line>
+  </preamble>
+
+  <pid>36556</pid>
+  <ppid>26175</ppid>
+  <tool>memcheck</tool>
+
+  <args>
+    <vargv>
+      <exe>/usr/bin/valgrind.bin</exe>
+      <arg>--gen-suppressions=all</arg>
+      <arg>--xml=yes</arg>
+      <arg>--xml-file=valgrind.xml</arg>
+      <arg>--track-origins=yes</arg>
+      <arg>--leak-check=full</arg>
+      <arg>--show-leak-kinds=all</arg>
+    </vargv>
+    <argv>
+      <exe>./terrible_program</exe>
+    </argv>
+  </args>
+
+  <status>
+    <state>RUNNING</state>
+    <time>00:00:00:00.146 </time>
+  </status>
+
+  <error>
+    <unique>0x0</unique>
+    <tid>1</tid>
+    <threadname>worst thread ever</threadname>
+    <kind>UninitCondition</kind>
+    <what>Conditional jump or move depends on uninitialised value(s)</what>
+    <stack>
+      <frame>
+        <ip>0x109163</ip>
+        <obj>/home/some_user/terrible_program/terrible_program</obj>
+        <fn>main</fn>
+        <dir>/home/some_user/terrible_program</dir>
+        <file>terrible_program.cpp</file>
+        <line>5</line>
+      </frame>
+    </stack>
+    <auxwhat>Uninitialised value was created by a heap allocation</auxwhat>
+    <stack>
+      <frame>
+        <ip>0x483B20F</ip>
+        <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+        <fn>operator new[](unsigned long)</fn>
+        <dir>./coregrind/m_replacemalloc</dir>
+        <file>vg_replace_malloc.c</file>
+        <line>640</line>
+      </frame>
+      <frame>
+        <ip>0x109151</ip>
+        <obj>/home/some_user/terrible_program/terrible_program</obj>
+        <fn>main</fn>
+        <dir>/home/some_user/terrible_program</dir>
+        <file>terrible_program.cpp</file>
+        <line>3</line>
+      </frame>
+    </stack>
+    <suppression>
+      <sname>insert_a_suppression_name_here</sname>
+      <skind>Memcheck:Cond</skind>
+      <sframe> <fun>main</fun> </sframe>
+      <rawtext>
+        <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:main
+}
+]]>
+      </rawtext>
+    </suppression>
+  </error>
+
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Cond</skind>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+      <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+  <error>
+    <unique>0x1</unique>
+    <tid>1</tid>
+    <kind>InvalidWrite</kind>
+    <what>Invalid write of size 4</what>
+    <stack>
+      <frame>
+        <ip>0x109177</ip>
+        <obj>/home/some_user/terrible_program/terrible_program</obj>
+        <fn>main</fn>
+        <dir>/home/some_user/terrible_program</dir>
+        <file>terrible_program.cpp</file>
+        <line>10</line>
+      </frame>
+    </stack>
+    <auxwhat>Address 0x4dd0c90 is 0 bytes after a block of size 16 alloc'd</auxwhat>
+    <stack>
+      <frame>
+        <ip>0x483B20F</ip>
+        <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+        <fn>operator new[](unsigned long)</fn>
+        <dir>./coregrind/m_replacemalloc</dir>
+        <file>vg_replace_malloc.c</file>
+        <line>640</line>
+      </frame>
+      <frame>
+        <ip>0x109151</ip>
+        <obj>/home/some_user/terrible_program/terrible_program</obj>
+        <fn>main</fn>
+        <dir>/home/some_user/terrible_program</dir>
+        <file>terrible_program.cpp</file>
+        <line>3</line>
+      </frame>
+    </stack>
+    <suppression>
+      <sname>insert_a_suppression_name_here</sname>
+      <skind>Memcheck:Addr4</skind>
+      <sframe> <fun>main</fun> </sframe>
+      <rawtext>
+        <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:main
+}
+]]>
+      </rawtext>
+    </suppression>
+  </error>
+
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Addr4</skind>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+      <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr4
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+
+  <status>
+    <state>FINISHED</state>
+    <time>00:00:00:00.693 </time>
+  </status>
+
+  <error>
+    <unique>0x2</unique>
+    <tid>1</tid>
+    <kind>Leak_DefinitelyLost</kind>
+    <xwhat>
+      <text>16 bytes in 1 blocks are definitely lost in loss record 1 of 1</text>
+      <leakedbytes>16</leakedbytes>
+      <leakedblocks>1</leakedblocks>
+    </xwhat>
+    <stack>
+      <frame>
+        <ip>0x483B20F</ip>
+        <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+        <fn>operator new[](unsigned long)</fn>
+        <dir>./coregrind/m_replacemalloc</dir>
+        <file>vg_replace_malloc.c</file>
+        <line>640</line>
+      </frame>
+      <frame>
+        <ip>0x109151</ip>
+        <obj>/home/some_user/terrible_program/terrible_program</obj>
+        <fn>main</fn>
+        <dir>/home/some_user/terrible_program</dir>
+        <file>terrible_program.cpp</file>
+        <line>3</line>
+      </frame>
+    </stack>
+    <suppression>
+      <sname>insert_a_suppression_name_here</sname>
+      <skind>Memcheck:Leak</skind>
+      <skaux>match-leak-kinds: definite</skaux>
+      <sframe> <fun>_Znam</fun> </sframe>
+      <sframe> <fun>main</fun> </sframe>
+      <rawtext>
+        <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znam
+   fun:main
+}
+]]>
+      </rawtext>
+    </suppression>
+  </error>
+
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Leak</skind>
+    <skaux>match-leak-kinds: definite</skaux>
+    <sframe> <fun>_Znam</fun> </sframe>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+      <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:_Znam
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+  <error>
+    <unique>0x3</unique>
+    <tid>1</tid>
+    <kind>SyscallParam</kind>
+    <what>Syscall param write(buf) points to uninitialised byte(s)</what>
+    <stack>
+      <frame>
+        <ip>0x4057F73</ip>
+        <obj>/lib/ld-musl-x86_64.so.1</obj>
+        <dir>/home/buildozer/aports/main/musl/src/1.2.4/src/thread/x86_64</dir>
+        <file>syscall_cp.s</file>
+        <line>29</line>
+      </frame>
+      <frame>
+        <ip>0x40550FD</ip>
+        <obj>/lib/ld-musl-x86_64.so.1</obj>
+        <fn>__syscall_cp_c</fn>
+        <dir>/home/buildozer/aports/main/musl/src/1.2.4/src/thread</dir>
+        <file>pthread_cancel.c</file>
+        <line>33</line>
+      </frame>
+      <frame>
+        <ip>0x405B67F</ip>
+        <obj>/lib/ld-musl-x86_64.so.1</obj>
+        <fn>write</fn>
+        <dir>/home/buildozer/aports/main/musl/src/1.2.4/src/unistd</dir>
+        <file>write.c</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x109226</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>11</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x109283</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>main</fn>
+        <dir>/workspace/awful project</dir>
+        <file>awful_program.cpp</file>
+        <line>14</line>
+      </frame>
+    </stack>
+    <auxwhat>Address 0x4b31cd0 is 0 bytes inside a block of size 10 alloc'd</auxwhat>
+    <stack>
+      <frame>
+        <ip>0x48A5733</ip>
+        <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+        <fn>malloc</fn>
+      </frame>
+      <frame>
+        <ip>0x1091FE</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>9</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x109283</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>main</fn>
+        <dir>/workspace/awful project</dir>
+        <file>awful_program.cpp</file>
+        <line>14</line>
+      </frame>
+    </stack>
+    <auxwhat>Uninitialised value was created by a heap allocation</auxwhat>
+    <stack>
+      <frame>
+        <ip>0x48A5733</ip>
+        <obj>/usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
+        <fn>malloc</fn>
+      </frame>
+      <frame>
+        <ip>0x1091FE</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>9</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x1091F2</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>make_spaghetti(int)</fn>
+        <dir>/workspace/awful project</dir>
+        <file>spaghetti.cpp</file>
+        <line>6</line>
+      </frame>
+      <frame>
+        <ip>0x109283</ip>
+        <obj>/workspace/awful project/awful_program</obj>
+        <fn>main</fn>
+        <dir>/workspace/awful project</dir>
+        <file>awful_program.cpp</file>
+        <line>14</line>
+      </frame>
+    </stack>
+    <suppression>
+      <sname>insert_a_suppression_name_here</sname>
+      <skind>Memcheck:Param</skind>
+      <skaux>write(buf)</skaux>
+      <sframe> <obj>/lib/ld-musl-x86_64.so.1</obj> </sframe>
+      <sframe> <fun>__syscall_cp_c</fun> </sframe>
+      <sframe> <fun>write</fun> </sframe>
+      <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+      <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+      <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+      <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+      <sframe> <fun>main</fun> </sframe>
+      <rawtext>
+        <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   write(buf)
+   obj:/lib/ld-musl-x86_64.so.1
+   fun:__syscall_cp_c
+   fun:write
+   fun:_Z14make_spaghettii
+   fun:_Z14make_spaghettii
+   fun:_Z14make_spaghettii
+   fun:_Z14make_spaghettii
+   fun:main
+}
+]]>
+      </rawtext>
+    </suppression>
+  </error>
+
+  <suppression>
+    <sname>insert_a_suppression_name_here</sname>
+    <skind>Memcheck:Param</skind>
+    <skaux>write(buf)</skaux>
+    <sframe> <obj>/lib/ld-musl-x86_64.so.1</obj> </sframe>
+    <sframe> <fun>__syscall_cp_c</fun> </sframe>
+    <sframe> <fun>write</fun> </sframe>
+    <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+    <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+    <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+    <sframe> <fun>_Z14make_spaghettii</fun> </sframe>
+    <sframe> <fun>main</fun> </sframe>
+    <rawtext>
+      <![CDATA[
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Param
+   write(buf)
+   obj:/lib/ld-musl-x86_64.so.1
+   fun:__syscall_cp_c
+   fun:write
+   fun:_Z14make_spaghettii
+   fun:_Z14make_spaghettii
+   fun:_Z14make_spaghettii
+   fun:_Z14make_spaghettii
+   fun:main
+}
+]]>
+    </rawtext>
+  </suppression>
+  <error>
+    <unique>0x4</unique>
+    <tid>1</tid>
+    <kind>Not_A_Real_Error</kind>
+    <what>Some type of error without a stack trace</what>
+  </error>
+  <errorcounts>
+    <pair>
+      <count>1</count>
+      <unique>0x4</unique>
+    </pair>
+    <pair>
+      <count>1</count>
+      <unique>0x3</unique>
+    </pair>
+    <pair>
+      <count>1</count>
+      <unique>0x2</unique>
+    </pair>
+    <pair>
+      <count>1</count>
+      <unique>0x1</unique>
+    </pair>
+    <pair>
+      <count>1</count>
+      <unique>0x0</unique>
+    </pair>
+  </errorcounts>
+
+  <suppcounts>
+  </suppcounts>
+
+</valgrindoutput>
+


### PR DESCRIPTION
This is the beginning of a [valgrind](https://valgrind.org) report parser.  It is a work-in-progress based on the [recent addition](https://github.com/tomasbjerre/violations-lib/pull/138) of a valgrind parser to [violations-lib](https://github.com/tomasbjerre/violations-lib) so it depends upon #735 and will fail CI until that is merged because I didn't want to conflict the pom.xml changes for that here.  The eventual goal of this pull request is to provide valgrind support in warnings-ng as a replacement for the broken, vulnerable, and unmaintained jenkins [valgrind-plugin](https://github.com/jenkinsci/valgrind-plugin).

There are a few known problems/open questions with this that I could use some advice/help with to move this forward.  I'm willing to work this through whatever needs to be done to achieve the goal of providing a warnings-ng alternative to the valgrind-plugin.

1. Valgrind analyzes running programs for memory related problems so it provides a lot of important details about findings in the form of stack traces.  I tried to capture these details in the `description` field of issues as HTML tables similar to how they were reported by the existing valgrind-plugin.  I haven't been able to wire this up successfully through warnings-ng to see what this looks like on the warnings-ng Jenkins UI, so this might be a terrible strategy or otherwise need to be revised to fit existing design paradigms.
2. It's difficult to get a parser to identify the right file where the issue root cause is because there are often multiple files to choose from in the stack trace and simple rules would not always identify the correct one.  Is there an established pattern for dealing with this kind of ambiguity?  Right now, the violations-lib valgrind parser uses the file that is closest to the top of the stack that isn't valgrind's replacement for malloc.  That behavior is echoed in analysis-model in this initial pull request.  That might not be ideal.
3. There's some text in the suppression part of the description HTML that contains a special character, `<`, that needs to be escaped.  A simple String.replace("<","&amp;lt;") would suffice, but is there a more robust way to escape such strings that may contain special HTML characters?  Will this escaping be handled in warnings-ng or further downstream of analysis-model for the `description` field?
4. Both the `origin` and `category` fields are set to "valgrind:[tool]" where [tool] is the actual valgrind tool that detected the problem (ex. memcheck).  It seems important to identify these problems as coming from valgrind and its subtool, but I couldn't find a reference elsewhere in the code for similar handling so this may need some refinement.
5. IntelliJ reports static analysis findings that seem in conflict with javac.  For example, IntelliJ wants "final" keywords on method parameters but javac complains that is unnecessary and discouraged since Java 8.  Is there a preference for what to make happy for these types of things?  I've been going with the compiler, but it seems like IntelliJ cleanliness might be preferred.
6. There is some embedded JSON in the Violation structure that can generate some exceptions when parsed in the `convertToReport` function of the `ValgrindAdapter` in analysis-model.  I resorted to catching and ignoring them because an alternative was unclear to me.  Is there a better way to deal with that?
7. Is it best to work on analysis-model in isolation or should it be worked in conjunction with whatever needs to be done to warnings-ng to support this new valgrind tool?  I've found it difficult to align all the moving parts to get this to work end-to-end coming at this from a place of complete ignorance.  Is there some guidance on adding new tools somewhere?

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue