### PR TITLE
Updating regexp pattern for Tasking VX Toolset C166

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParser.java
@@ -18,7 +18,7 @@ public class TaskingVxCompilerParser extends LookaheadParser {
     private static final long serialVersionUID = -5225265084645449716L;
 
     /** Pattern of TASKING VX compiler warnings. */
-    private static final String TASKING_VX_COMPILER_WARNING_PATTERN = "^[a-z]+? (I|W|E|F)(\\d+): (?:\\[\"(.*?)\" (\\d+)"
+    private static final String TASKING_VX_COMPILER_WARNING_PATTERN = "^[a-z0-9]+? (I|W|E|F)(\\d+): (?:\\[\"(.*?)\" (\\d+)"
             + "\\/(\\d+)\\] )?(.*)$";
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParserTest.java
@@ -24,7 +24,7 @@ class TaskingVxCompilerParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report warnings, final SoftAssertions softly) {
-        softly.assertThat(warnings).hasSize(9);
+        softly.assertThat(warnings).hasSize(10);
 
         softly.assertThat(warnings.get(0))
                 .hasSeverity(Severity.WARNING_NORMAL)
@@ -75,14 +75,14 @@ class TaskingVxCompilerParserTest extends AbstractParserTest {
                 .hasLineEnd(42)
                 .hasMessage("start of current function definition")
                 .hasFileName("BswM_UserCallouts.c");
-        softly.assertThat(warnings.get(7))
+        softly.assertThat(warnings.get(8))
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasCategory(ERROR_CATEGORY)
                 .hasLineStart(242)
                 .hasLineEnd(242)
                 .hasMessage("invalid conversion from \"struct const *\" to \"signed int *\"")
                 .hasFileName("C:/Projects/a/b/c/BRBL.c");
-        softly.assertThat(warnings.get(8))
+        softly.assertThat(warnings.get(9))
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasCategory(WARNING_CATEGORY)
                 .hasLineStart(242)

--- a/src/test/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/TaskingVxCompilerParserTest.java
@@ -24,7 +24,7 @@ class TaskingVxCompilerParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report warnings, final SoftAssertions softly) {
-        softly.assertThat(warnings).hasSize(8);
+        softly.assertThat(warnings).hasSize(9);
 
         softly.assertThat(warnings.get(0))
                 .hasSeverity(Severity.WARNING_NORMAL)
@@ -75,6 +75,20 @@ class TaskingVxCompilerParserTest extends AbstractParserTest {
                 .hasLineEnd(42)
                 .hasMessage("start of current function definition")
                 .hasFileName("BswM_UserCallouts.c");
+        softly.assertThat(warnings.get(7))
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasCategory(ERROR_CATEGORY)
+                .hasLineStart(242)
+                .hasLineEnd(242)
+                .hasMessage("invalid conversion from \"struct const *\" to \"signed int *\"")
+                .hasFileName("C:/Projects/a/b/c/BRBL.c");
+        softly.assertThat(warnings.get(8))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory(WARNING_CATEGORY)
+                .hasLineStart(242)
+                .hasLineEnd(242)
+                .hasMessage("conversion of integer to pointer at assignment")
+                .hasFileName("C:/Projects/a/b/c/BRBL.c");
     }
 }
 

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -475,10 +475,10 @@ class ParsersTest extends ResourceTest {
         findIssuesOfTool(5, "stylecop", "stylecop.xml");
     }
 
-    /** Runs the Tasking VX parser on an output file that contains 8 issues. */
+    /** Runs the Tasking VX parser on an output file that contains 10 issues. */
     @Test
     void shouldFindAllTaskingVxIssues() {
-        findIssuesOfTool(8, "tasking-vx", "tasking-vx.txt");
+        findIssuesOfTool(10, "tasking-vx", "tasking-vx.txt");
     }
 
     /** Runs the tnsdl translator parser on an output file that contains 4 issues. */

--- a/src/test/resources/edu/hm/hafner/analysis/parser/tasking-vx.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/tasking-vx.txt
@@ -6,3 +6,5 @@ ctc W536: ["C:\Projects\a\b\c\d\e\f\g\TcpIp_Tcp.c" 860/41] unused static functio
 ctc E208: ["C:\Projects\a\b\c\DmaLib.h" 380/1] syntax error - token ";" inserted before "{"
 ctc I805: ["BswM_UserCallouts.c" 42/1] start of current function definition
 ctc F104: protection error: No license key found for product code SW160800
+c166 E241: ["C:\Projects\a\b\c\BRBL.c" 242/48] invalid conversion from "struct const *" to "signed int *"
+c166 W524: ["C:\Projects\a\b\c\BRBL.c" 242/36] conversion of integer to pointer at assignment


### PR DESCRIPTION
Updating regexp pattern for Tasking VX Toolset to include C166 compiler (e. g. Infineon XC2000) which start with

c166 (I|W|E|F):

Detection broke with commit 79f4bcf, which switched from any character to a-z.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira -> No issue created
- [x] Link to relevant pull requests, esp. upstream and downstream changes -> None
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue -> 
Test with regex101.com and console outputs from c166 compiler. 
Example:
c166 E272: ["../IoDriver/src/IO_BRBL.c" 79/33] undeclared identifier "BL_AUTH_SEED"

Detection works as expected.
