### PR TITLE
Fix GhsMultiParser log issue without cursor

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/GhsMultiParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/GhsMultiParser.java
@@ -43,17 +43,25 @@ public class GhsMultiParser extends LookaheadParser {
         String type = StringUtils.capitalize(matcher.group("severity"));
         String messageStart = matcher.group("message");
 
-        String message = extractMessage(messageStart, lookahead);
+        String message;
+
+        /*
+         * If a column is set in the issue, there will be no cursor ('^')
+         * And the MESSAGE_END_REGEX will never be matched until the next issue
+         */
+        if (StringUtils.isNotBlank(matcher.group("column"))) {
+            builder.setColumnStart(matcher.group("column"));
+            message = messageStart;
+        }
+        else {
+            message = extractMessage(messageStart, lookahead);
+        }
 
         builder.setFileName(matcher.group("file"))
                 .setLineStart(matcher.group("line"))
                 .setCategory(matcher.group("category"))
                 .setMessage(message)
                 .setSeverity(Severity.guessFromString(type));
-
-        if (StringUtils.isNotBlank(matcher.group("column"))) {
-            builder.setColumnStart(matcher.group("column"));
-        }
 
         return builder.buildOptional();
     }

--- a/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GhsMultiParserTest.java
@@ -19,7 +19,7 @@ class GhsMultiParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(6);
+        softly.assertThat(report).hasSize(7);
         softly.assertThat(report.get(0))
                 .hasSeverity(Severity.ERROR)
                 .hasCategory("#5")
@@ -53,17 +53,24 @@ class GhsMultiParserTest extends AbstractParserTest {
 
         softly.assertThat(report.get(4))
                 .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("#11-D")
+                .hasLineStart(639)
+                .hasColumnStart(10)
+                .hasMessage("unrecognized preprocessing directive")
+                .hasFileName("D:/workspace/TEST/mytest.c");
+
+        softly.assertThat(report.get(5))
+                .hasSeverity(Severity.WARNING_NORMAL)
                 .hasCategory("#177-D")
                 .hasLineStart(23)
                 .hasMessage("variable \"myvar\" was declared but never referenced\n  static const uint32 myvar")
                 .hasFileName("D:/workspace/TEST/mytest.c");
 
-        softly.assertThat(report.get(5))
+        softly.assertThat(report.get(6))
                 .hasSeverity(Severity.WARNING_NORMAL)
-                .hasCategory("#11-D")
-                .hasLineStart(639)
-                .hasColumnStart(10)
-                .hasMessage("unrecognized preprocessing directive")
+                .hasCategory("#42-D")
+                .hasLineStart(42)
+                .hasMessage("warning at the end of the file")
                 .hasFileName("D:/workspace/TEST/mytest.c");
 
     }

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -544,7 +544,7 @@ class ParsersTest extends ResourceTest {
     /** Runs the GhsMulti parser on an output file that contains 3 issues. */
     @Test
     void shouldFindAllGhsMultiIssues() {
-        findIssuesOfTool(6, "ghs-multi", "ghsmulti.txt");
+        findIssuesOfTool(7, "ghs-multi", "ghsmulti.txt");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ghsmulti.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ghsmulti.txt
@@ -23,8 +23,10 @@ Compiling TestCase_1601.cpp because TestCase_1601.o does not exist
 Integrating TestExec1601 because it does not exist
 Done
 
+"D:/workspace/TEST/mytest.c", line 639 (col. 10): warning #11-D: unrecognized preprocessing directive
+
 "D:/workspace/TEST/mytest.c", line 23: warning #177-D: variable "myvar" was declared but never referenced
   static const uint32 myvar
                       ^
 
-"D:/workspace/TEST/mytest.c", line 639 (col. 10): warning #11-D: unrecognized preprocessing directive
+"D:/workspace/TEST/mytest.c", line 42: warning #42-D: warning at the end of the file


### PR DESCRIPTION
When a log issue has a column set, there is no cursor ('^') at the end of the message.
The current behavior was to set the end of the message issue when a line had only spaces and the char ^ (MESSAGE_END_REGEX)
Therefore, when a message issue like below append, it took has a message everything until the end of the next log issue 
`"D:/workspace/TEST/mytest.c", line 639 (col. 10): warning #11-D: unrecognized preprocessing directive`

GhsMultiParserTest were green only because this specific message used has an example was at the end of the message

Solution : 
- Only extract the rest of the message if there is no column set
- And move the specific message above in the ghsmulti.txt with the test (GhsMultiParserTest) modifications due to this log movement
For the moment all logs containing a column had only one line so it should resolve the problem

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
