### PR TITLE
clang-tidy: Allow white spaces in a path

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/ClangTidyParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ClangTidyParser.java
@@ -18,8 +18,8 @@ import edu.hm.hafner.util.LookaheadStream;
  */
 public class ClangTidyParser extends LookaheadParser {
     private static final long serialVersionUID = -3015592762345283182L;
-    private static final String CLANG_TIDY_WARNING_PATTERN =
-            "(([^\\s]+):(\\d+):(\\d+): |)(warning|error): (.*?) \\[([^\\s]*?)\\]$";
+    private static final String CLANG_TIDY_WARNING_PATTERN = "(?:clang-tidy\\S* (?:-\\S+ )*|)"
+            + "((.+):(\\d+):(\\d+): |)(warning|error): (.*?) \\[([^\\s]*?)\\]$";
 
     /**
      * Creates a new instance of {@link ClangTidyParser}.

--- a/src/test/java/edu/hm/hafner/analysis/parser/ClangTidyParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/ClangTidyParserTest.java
@@ -28,7 +28,7 @@ class ClangTidyParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report annotation, final SoftAssertions softly) {
-        assertThat(annotation).hasSize(8);
+        assertThat(annotation).hasSize(9);
 
         softly.assertThat(annotation.get(0))
                 .hasLineStart(1)
@@ -96,6 +96,14 @@ class ClangTidyParserTest extends AbstractParserTest {
                 .hasMessage("/path/to/project/tools/yocto-toolchain/sysroots/core2-64-fslc-linux/usr/include/qt5/QtQml: 'linker' input unused")
                 .hasType(WARNING_TYPE)
                 .hasCategory("clang-diagnostic-unused-command-line-argument")
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        softly.assertThat(annotation.get(8))
+                .hasLineStart(24)
+                .hasColumnStart(5)
+                .hasFileName("/path with space/to/project/src/path_with_space.cpp")
+                .hasType(WARNING_TYPE)
+                .hasCategory("google-explicit-constructor")
                 .hasSeverity(Severity.WARNING_NORMAL);
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -424,7 +424,7 @@ class ParsersTest extends ResourceTest {
     /** Runs the Clang-Tidy parser on an output file that contains 8 issues. */
     @Test
     void shouldFindAllClangTidyIssues() {
-        findIssuesOfTool(8, "clang-tidy", "ClangTidy.txt");
+        findIssuesOfTool(9, "clang-tidy", "ClangTidy.txt");
     }
 
     /** Runs the Clang parser on an output file that contains 9 issues. */

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ClangTidy.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ClangTidy.txt
@@ -115,3 +115,5 @@ clang-tidy-5.0 -header-filter=src/,include/ -p=/path/to/project /path/to/project
 # Warnings to not match
 warning: /path/to/project/tools/yocto-toolchain/sysroots/core2-64-fslc-linux/usr/include/qt5/QtQml: 'linker' input unused [clang-diagnostic-unused-command-line-argument]
 
+# Path with spaces
+/path with space/to/project/src/path_with_space.cpp:24:5: warning: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]


### PR DESCRIPTION
Current implementation fails to parse a path which contains white
spaces. Jenkins UI fails to link a file position.

<!-- Please describe your pull request here. -->

There were many edge cases dealt already. So I have no choice but to make a workaround.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
