### PR TITLE
JENKINS-68740: Support ansible-lint >=6.1.0 warning format

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AnsibleLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnsibleLintParser.java
@@ -21,7 +21,7 @@ import edu.hm.hafner.util.LookaheadStream;
 public class AnsibleLintParser extends LookaheadParser {
     private static final long serialVersionUID = 8481090596321427484L;
 
-    private static final String ANSIBLE_LINT_WARNING_PATTERN = "(.*)\\:([0-9]*)\\:\\s*\\[?([a-zA-Z0-9\\-]+)\\]?\\s(.*)";
+    private static final String ANSIBLE_LINT_WARNING_PATTERN = "(.*)\\:([0-9]*)\\:\\s*\\[?([a-zA-Z0-9\\-]+)\\]?:?\\s(.*)";
 
     /**
      * Creates a new instance of {@link AnsibleLintParser}.

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
@@ -20,7 +20,7 @@ class AnsibleLintParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(9);
+        assertThat(report).hasSize(10);
 
         Iterator<Issue> iterator = report.iterator();
         softly.assertThat(iterator.next())
@@ -86,6 +86,14 @@ class AnsibleLintParserTest extends AbstractParserTest {
                 .hasLineEnd(11)
                 .hasMessage("File permissions unset or incorrect")
                 .hasFileName("/workspace/templates.yml");
+
+        softly.assertThat(iterator.next())
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("no-changed-when")
+                .hasLineStart(41)
+                .hasLineEnd(41)
+                .hasMessage("Commands should not change things if nothing needs doing.")
+                .hasFileName("/workspace/roles/create_service/tasks/main.yml");
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -624,7 +624,7 @@ class ParsersTest extends ResourceTest {
     /** Runs the AnsibleLint parser on an output file that contains 9 issues. */
     @Test
     void shouldFindAllAnsibleLintIssues() {
-        findIssuesOfTool(9, "ansiblelint", "ansibleLint.txt");
+        findIssuesOfTool(10, "ansiblelint", "ansibleLint.txt");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
@@ -9,3 +9,5 @@
 /workspace/system.yml:20: risky-file-permissions File permissions unset or incorrect
 /workspace/upgrade.yml:38: no-handler Tasks that run when changed should likely be handlers
 /workspace/templates.yml:11: risky-file-permissions File permissions unset or incorrect
+
+/workspace/roles/create_service/tasks/main.yml:41: no-changed-when: Commands should not change things if nothing needs doing.


### PR DESCRIPTION
Hi, 

this pull request adds support for the new ansible-lint (version >= 6.1.0) PEP8 warning format. Further details can be found in https://issues.jenkins.io/browse/JENKINS-68740.

### Changes
- Edited regex to support additional colon in warning
- Colon is marked as optional (older ansible-lint version (<6.1.0) does not have this colon)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
