### PR TITLE
Fixing Trivy descriptions.

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/TrivyParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/TrivyParser.java
@@ -1,7 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.text.MessageFormat;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/TrivyParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/TrivyParser.java
@@ -11,6 +11,8 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import static j2html.TagCreator.*;
+
 /**
  * <p>
  * Parser for reports of aquasec trivy container vulnerability scanner.
@@ -50,11 +52,11 @@ public class TrivyParser extends JsonIssueParser {
 
     private void parseResults(final Report report, final JSONArray jsonReport, final IssueBuilder issueBuilder) {
         for (int i = 0; i < jsonReport.length(); i++) {
-            JSONObject component = (JSONObject)jsonReport.get(i);
+            JSONObject component = (JSONObject) jsonReport.get(i);
             if (!component.isNull("Vulnerabilities")) {
                 JSONArray vulnerabilities = component.getJSONArray("Vulnerabilities");
                 for (Object vulnerability : vulnerabilities) {
-                    report.add(convertToIssue((JSONObject)vulnerability, issueBuilder));
+                    report.add(convertToIssue((JSONObject) vulnerability, issueBuilder));
                 }
             }
         }
@@ -88,11 +90,15 @@ public class TrivyParser extends JsonIssueParser {
     }
 
     private String formatDescription(final JSONObject vulnerability) {
-        return MessageFormat.format(
-                "<p><div><b>File</b>: {0}</div><div><b>Installed Version:</b> {1}</div><div><b>Fixed Version:</b> {2}</div><div><b>Severity:</b> {3}</div>",
-                vulnerability.optString("PkgName", VALUE_NOT_SET),
-                vulnerability.optString("InstalledVersion", VALUE_NOT_SET),
-                vulnerability.optString("FixedVersion", "still open"), vulnerability.optString("Severity", "UNKOWN"))
-                + "<p>" + vulnerability.optString("Description", "") + "</p>";
+        final String fileName = vulnerability.optString("PkgName", VALUE_NOT_SET);
+        final String installedVersion = vulnerability.optString("InstalledVersion", VALUE_NOT_SET);
+        final String fixedVersion = vulnerability.optString("FixedVersion", "still open");
+        final String severity = vulnerability.optString("Severity", "UNKOWN");
+        final String description = vulnerability.optString("Description", "");
+        return join(p(div(b("File: "), text(fileName)),
+                div(b("Installed Version: "), text(installedVersion)),
+                div(b("Fixed Version: "), text(fixedVersion)),
+                div(b("Severity: "), text(severity)),
+                p(text(description)))).render();
     }
 }


### PR DESCRIPTION
I noticed that Trivy parser had the following issues with its `formatDescription` function:
- Unclosed `<p>` tag
- `<b>File</b>:` vs `<b>File :</b>`
- Unescaped characters


Based on the above, I have changed 'formatDescription' to use j2html.


#### Before HTML
```html
<p>
<div><b>File</b>: bind-export-libs</div>
<div><b>Installed Version:</b> 32:9.11.13-6.el8_2.1</div>
<div><b>Fixed Version:</b> 32:9.11.20-5.el8</div>
<div><b>Severity:</b> MEDIUM</div><p>In ISC BIND9 versions BIND 9.11.14 -> 9.11.19, BIND 9.14.9 -> 9.14.12, BIND 9.16.0
    -> 9.16.3, BIND Supported Preview Edition 9.11.14-S1 -> 9.11.19-S1: Unless a nameserver is providing authoritative
    service for one or more zones and at least one zone contains an empty non-terminal entry containing an asterisk
    ("*") character, this defect cannot be encountered. A would-be attacker who is allowed to change zone content could
    theoretically introduce such a record in order to exploit this condition to cause denial of service, though we
    consider the use of this vector unlikely because any such attack would require a significant privilege level and be
    easily traceable.</p>
```

#### After HTML
```html
<p>
<div><b>File: </b>bind-export-libs</div>
<div><b>Installed Version: </b>32:9.11.13-6.el8_2.1</div>
<div><b>Fixed Version: </b>32:9.11.20-5.el8</div>
<div><b>Severity: </b>MEDIUM</div><p>In ISC BIND9 versions BIND 9.11.14 -&gt; 9.11.19, BIND 9.14.9 -&gt; 9.14.12, BIND
    9.16.0 -&gt; 9.16.3, BIND Supported Preview Edition 9.11.14-S1 -&gt; 9.11.19-S1: Unless a nameserver is providing
    authoritative service for one or more zones and at least one zone contains an empty non-terminal entry containing an
    asterisk (&quot;*&quot;) character, this defect cannot be encountered. A would-be attacker who is allowed to change
    zone content could theoretically introduce such a record in order to exploit this condition to cause denial of
    service, though we consider the use of this vector unlikely because any such attack would require a significant
    privilege level and be easily traceable.</p></p>
```

#### Before:
![image](https://user-images.githubusercontent.com/27741935/181861475-0f9d011e-dfec-4b14-9373-3d0aca1969bd.png)


#### After:
![image](https://user-images.githubusercontent.com/27741935/181861507-a7aa4391-9a72-4def-86b5-d113b71eaace.png)



<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
