### PR TITLE
[JENKINS-69242] Improve path detection during subdirectory traversal

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.Stack;
 
+import org.apache.commons.lang3.StringUtils;
 import edu.hm.hafner.util.LookaheadStream;
 
 /**
@@ -151,13 +152,7 @@ public abstract class LookaheadParser extends IssueParser {
         }
         Matcher makeLineMatcher = makePath.matcher(line);
         if (makeLineMatcher.matches()) {
-            StringBuilder dir = new StringBuilder(makeLineMatcher.group("dir"));
-            if ((dir.charAt(0) == '\'' || dir.charAt(0) == '`') &&
-                    (dir.charAt(dir.length() - 1) == '\'' || dir.charAt(dir.length() - 1) == '`')) {
-                dir.deleteCharAt(0);
-                dir.deleteCharAt(dir.length() - 1);
-            }
-            return dir.toString();
+            return removeHyphen(makeLineMatcher.group("dir"));
         }
         throw new ParsingException(
                 "Unable to change directory using: %s to match %s", makePath.toString(), line);
@@ -206,5 +201,19 @@ public abstract class LookaheadParser extends IssueParser {
      */
     protected Report postProcess(final Report report) {
         return report;
+    }
+
+    /**
+     * Remove Hyphen from directory path if it starts and end with hyphen.
+     *
+     * @param dir
+     *          directory path to inspect
+     *
+     * @return directory path without leading or trailing hyphen
+     */
+    protected String removeHyphen(String dir) {
+        dir = StringUtils.stripStart(dir, "'`");
+        dir = StringUtils.stripEnd(dir, "'`");
+        return dir;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -30,6 +30,7 @@ public abstract class LookaheadParser extends IssueParser {
             = Pattern.compile(".*" + ENTERING_DIRECTORY + " (?<dir>.*)");
     private static final String CMAKE_PREFIX = "-- Build files have";
     private static final Pattern CMAKE_PATH = Pattern.compile(".*" + CMAKE_PREFIX + " been written to: (?<dir>.*)");
+    private static final String HYPHEN = "'`";
 
     private static final int MAX_LINE_LENGTH = 4000; // see JENKINS-55805
 
@@ -207,14 +208,14 @@ public abstract class LookaheadParser extends IssueParser {
      * Remove Hyphen from directory path if it starts or ends with hyphen.
      *
      * @param dir
-     *          directory path to inspect
+     *         directory path to inspect
      *
      * @return directory path without leading or trailing hyphen
      */
     private String removeHyphen(final String dir) {
         String path = dir;
-        path = StringUtils.stripStart(path, "'`");
-        path = StringUtils.stripEnd(path, "'`");
+        path = StringUtils.stripStart(path, HYPHEN);
+        path = StringUtils.stripEnd(path, HYPHEN);
         return path;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -204,7 +204,7 @@ public abstract class LookaheadParser extends IssueParser {
     }
 
     /**
-     * Remove Hyphen from directory path if it starts and end with hyphen.
+     * Remove Hyphen from directory path if it starts or ends with hyphen.
      *
      * @param dir
      *          directory path to inspect

--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -211,7 +211,7 @@ public abstract class LookaheadParser extends IssueParser {
      *
      * @return directory path without leading or trailing hyphen
      */
-    protected String removeHyphen(final String dir) {
+    private String removeHyphen(final String dir) {
         String path = dir;
         path = StringUtils.stripStart(path, "'`");
         path = StringUtils.stripEnd(path, "'`");

--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -212,8 +212,9 @@ public abstract class LookaheadParser extends IssueParser {
      * @return directory path without leading or trailing hyphen
      */
     protected String removeHyphen(String dir) {
-        dir = StringUtils.stripStart(dir, "'`");
-        dir = StringUtils.stripEnd(dir, "'`");
-        return dir;
+        String path = dir;
+        path = StringUtils.stripStart(path, "'`");
+        path = StringUtils.stripEnd(path, "'`");
+        return path;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -26,7 +26,7 @@ public abstract class LookaheadParser extends IssueParser {
     private static final String ENTERING_DIRECTORY = "Entering directory";
     private static final String LEAVING_DIRECTORY = "Leaving directory";
     private static final Pattern ENTERING_DIRECTORY_PATH
-            = Pattern.compile(".*" + ENTERING_DIRECTORY + " [`'](?<dir>.*)['`]");
+            = Pattern.compile(".*" + ENTERING_DIRECTORY + " (?<dir>.*)");
     private static final String CMAKE_PREFIX = "-- Build files have";
     private static final Pattern CMAKE_PATH = Pattern.compile(".*" + CMAKE_PREFIX + " been written to: (?<dir>.*)");
 
@@ -151,7 +151,13 @@ public abstract class LookaheadParser extends IssueParser {
         }
         Matcher makeLineMatcher = makePath.matcher(line);
         if (makeLineMatcher.matches()) {
-            return makeLineMatcher.group("dir");
+            StringBuilder dir = new StringBuilder(makeLineMatcher.group("dir"));
+            if ((dir.charAt(0) == '\'' || dir.charAt(0) == '`') &&
+                    (dir.charAt(dir.length() - 1) == '\'' || dir.charAt(dir.length() - 1) == '`')) {
+                dir.deleteCharAt(0);
+                dir.deleteCharAt(dir.length() - 1);
+            }
+            return dir.toString();
         }
         throw new ParsingException(
                 "Unable to change directory using: %s to match %s", makePath.toString(), line);

--- a/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/LookaheadParser.java
@@ -211,7 +211,7 @@ public abstract class LookaheadParser extends IssueParser {
      *
      * @return directory path without leading or trailing hyphen
      */
-    protected String removeHyphen(String dir) {
+    protected String removeHyphen(final String dir) {
         String path = dir;
         path = StringUtils.stripStart(path, "'`");
         path = StringUtils.stripEnd(path, "'`");

--- a/src/test/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParserTest.java
@@ -297,6 +297,20 @@ class Gcc4CompilerParserTest extends AbstractParserTest {
     }
 
     /**
+     * Parser should not throw errors when Entering directory and Leaving directory, if path does not start and end with
+     * ' or `
+     *
+     * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-69242">Issue 69242</a>
+     */
+    @Test
+    void issue69242() {
+        Report warnings = createParser().parse(createReaderFactory("issue69242.txt"));
+
+        assertThat(warnings).hasSize(0);
+        assertThat(warnings).doesNotHaveErrors();
+    }
+
+    /**
      * Parser should make relative paths absolute if cmake/ninja is used.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-56020">Issue 56020</a>

--- a/src/test/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/Gcc4CompilerParserTest.java
@@ -297,8 +297,7 @@ class Gcc4CompilerParserTest extends AbstractParserTest {
     }
 
     /**
-     * Parser should not throw errors when Entering directory and Leaving directory, if path does not start and end with
-     * ' or `
+     * Parser should not throw errors when path does not start and end with hyphen.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-69242">Issue 69242</a>
      */
@@ -306,8 +305,11 @@ class Gcc4CompilerParserTest extends AbstractParserTest {
     void issue69242() {
         Report warnings = createParser().parse(createReaderFactory("issue69242.txt"));
 
-        assertThat(warnings).hasSize(0);
+        assertThat(warnings).hasSize(2);
         assertThat(warnings).doesNotHaveErrors();
+        assertThat(warnings.get(0))
+                .hasFileName(
+                        "/path/to/workspace/daos-stack-org_daos_PR-13-centos7/_build.external/pmix/src/util/keyval/keyval_lex.c");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue69242.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue69242.txt
@@ -1,2 +1,14 @@
-Entering directory /tmp/testDir806422480360626789
-Leaving directory /tmp/testDir806422480360626789
+[Build on CentOS 7] make[2]: Entering directory /path/to/workspace/daos-stack-org_daos_PR-13-centos7/_build.external/pmix/src/util/keyval
+[Build on CentOS 7]   LEX      keyval_lex.c
+[Build on CentOS 7]   CC       keyval_lex.lo
+[Build on CentOS 7] keyval_lex.c: In function ‘pmix_util_keyval_yylex’:
+[Build on CentOS 7] keyval_lex.c:947:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
+[Build on CentOS 7]     for ( yyl = 0; yyl < pmix_util_keyval_yyleng; ++yyl )
+[Build on CentOS 7]                        ^
+[Build on CentOS 7] keyval_lex.c: In function ‘pmix_util_keyval_yy_scan_bytes’:
+[Build on CentOS 7] keyval_lex.c:1790:17: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
+[Build on CentOS 7]   for ( i = 0; i < _yybytes_len; ++i )
+[Build on CentOS 7]                  ^
+[Build on CentOS 7]   CCLD     libpmixutilkeyval.la
+[Build on CentOS 7] make[2]: Leaving directory /path/to/workspace/daos-stack-org_daos_PR-13-centos7/_build.external/pmix/src/util/keyval
+[Build on CentOS 7] Making all in mca/base

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue69242.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue69242.txt
@@ -1,0 +1,2 @@
+Entering directory /tmp/testDir806422480360626789
+Leaving directory /tmp/testDir806422480360626789


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Jira Issue :- [Issue 69242](https://issues.jenkins.io/browse/JENKINS-69242)

Currently regex detect directory path which starts and end with ' or `, so existing ENTERING_DIRECTORY_PATH regex was ignoring the path eg:- 
Entering directory /tmp/testDir806422480360626789 
Leaving directory /tmp/testDir806422480360626789
and accepting these:-
Entering directory '/tmp/testDir806422480360626789' 

Regex101:- [Old](https://regex101.com/r/v3rj9v/1) 
Regez101:- [New](https://regex101.com/r/EIXwbN/1)

Modified the regex now regex group <dir> removed start and end match for these two character( ' or ` )... pragmatically removing these character from dir string if it exists ... in extractDirectory() function. Added the test case for this case
