### PR TITLE
Map RevApi Severity of `EQUIVALENT` to `WARNING_LOW`

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/RevApiParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/RevApiParser.java
@@ -91,13 +91,13 @@ public class RevApiParser extends JsonIssueParser {
 
     private Severity toSeverity(final String level) {
         switch (level) {
-            case "NON_BREAKING":
-                return Severity.WARNING_LOW;
             case "BREAKING":
                 return Severity.WARNING_HIGH;
             case "POTENTIALLY_BREAKING":
-            default:
                 return Severity.WARNING_NORMAL;
+            //case "EQUIVALENT" & "NON_BREAKING"
+            default:
+                return Severity.WARNING_LOW;
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Revapi severity "EQUIVALENT" which is no error got mapped to "WARNING_NORMAL" and not "WARNING_LOW"

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
