### PR TITLE
Improve ErrorProne regexp to catch also warnings without column numbers

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/ErrorProneParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ErrorProneParser.java
@@ -28,7 +28,7 @@ public class ErrorProneParser extends LookaheadParser {
             = "^(?:\\[\\p{Alnum}*\\]\\s+)?"
             + "\\[(?<severity>WARNING|ERROR)\\]\\s+"
             + "(?<file>.+):"
-            + "\\[(?<line>\\d+),(?<column>\\d+)\\]\\s+"
+            + "\\[(?<line>\\d+)(?:,(?<column>\\d+))?\\]\\s+"
             + "\\[(?<type>\\w+)\\]\\s+"
             + "(?<message>.*)";
     private static final String SEE_ERROR_PRONE_DOCUMENTATION = "See ErrorProne documentation.";
@@ -95,6 +95,6 @@ public class ErrorProneParser extends LookaheadParser {
             }
         }
 
-        return description.toString() + url.toString();
+        return description.toString() + url;
     }
 }

--- a/src/test/java/edu/hm/hafner/analysis/parser/ErrorProneParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/ErrorProneParserTest.java
@@ -58,6 +58,19 @@ class ErrorProneParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldFindAllNewWarnings() {
+        Report report = parse("maven-error-prone.log");
+
+        assertThat(report).hasSize(37);
+        assertThat(report.get(0))
+                .hasFileName("/Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment04.java")
+                .hasLineStart(1)
+                .hasType("DefaultPackage")
+                .hasMessage("Java classes shouldn't use default package.")
+                .hasDescription("<p><a href=\"https://errorprone.info/bugpattern/DefaultPackage\">See ErrorProne documentation.</a></p>");
+    }
+
+    @Test
     void shouldSkipJavacWarnings() {
         Report report = parse("javac.log");
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/maven-error-prone.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/maven-error-prone.log
@@ -1,0 +1,87 @@
+[INFO] --- maven-compiler-plugin:3.10.1:compile (default-compile) @ karalight-assignment ---
+[INFO] Changes detected - recompiling the module!
+[INFO] Compiling 17 source files to /Users/hafner/git/hochschule/karalight-assignment/target/classes
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment04.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment12.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment07.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment15.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment11.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment08.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment02.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment00.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment13.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment05.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment09.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment06.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment10.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment16.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment03.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment14.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/main/java/Assignment01.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[INFO]
+[INFO] --- maven-resources-plugin:3.3.0:testResources (default-testResources) @ karalight-assignment ---
+[INFO] Copying 49 resources
+[INFO]
+[INFO] --- maven-compiler-plugin:3.10.1:testCompile (default-testCompile) @ karalight-assignment ---
+[INFO] Changes detected - recompiling the module!
+[INFO] Compiling 18 source files to /Users/hafner/git/hochschule/karalight-assignment/target/test-classes
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment09Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/AbstractKaraTest.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment00Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment16Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment16Test.java:[4] [RemoveUnusedImports] Unused imports: de.i8k.karalight.world.World
+    (see https://errorprone.info/bugpattern/RemoveUnusedImports)
+  Did you mean to remove this line?
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment03Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment10Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment13Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment04Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment08Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment14Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment11Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment01Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment05Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment07Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment02Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment15Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment12Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment12Test.java:[1] [RemoveUnusedImports] Unused imports: de.i8k.karalight.Kara, de.i8k.karalight.test.TestKaraController
+    (see https://errorprone.info/bugpattern/RemoveUnusedImports)
+  Did you mean to remove this line?
+[WARNING] /Users/hafner/git/hochschule/karalight-assignment/src/test/java/Assignment06Test.java:[1] [DefaultPackage] Java classes shouldn't use default package
+    (see https://errorprone.info/bugpattern/DefaultPackage)
+[INFO]


### PR DESCRIPTION
Currently the parser ignores those warnings.