### PR TITLE
Fix regular expression for ansible-lint to support rule names containing square brackets

### DIFF
--- a/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
@@ -20,7 +20,7 @@ class AnsibleLintParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(10);
+        assertThat(report).hasSize(12);
 
         Iterator<Issue> iterator = report.iterator();
         softly.assertThat(iterator.next())
@@ -94,6 +94,21 @@ class AnsibleLintParserTest extends AbstractParserTest {
                 .hasLineEnd(41)
                 .hasMessage("Commands should not change things if nothing needs doing.")
                 .hasFileName("/workspace/roles/create_service/tasks/main.yml");
+
+        softly.assertThat(iterator.next())
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("fqcn[action]")
+                .hasLineStart(79)
+                .hasLineEnd(79)
+                .hasMessage("Use FQCN for module actions, such `<namespace>.<collection>.apache2_conf`. (warning)")
+                .hasFileName("roles/apache2/tasks/main.yml");
+        softly.assertThat(iterator.next())
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("literal-compare")
+                .hasLineStart(45)
+                .hasLineEnd(45)
+                .hasMessage("Don't compare to literal True/False.")
+                .hasFileName("roles/bitbucket_srv/tasks/main.yml");
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -627,10 +627,10 @@ class ParsersTest extends ResourceTest {
         findIssuesOfTool(9, "aspectj", "ajc.txt");
     }
 
-    /** Runs the AnsibleLint parser on an output file that contains 9 issues. */
+    /** Runs the AnsibleLint parser on an output file that contains 12 issues. */
     @Test
     void shouldFindAllAnsibleLintIssues() {
-        findIssuesOfTool(10, "ansiblelint", "ansibleLint.txt");
+        findIssuesOfTool(12, "ansiblelint", "ansibleLint.txt");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
@@ -11,3 +11,6 @@
 /workspace/templates.yml:11: risky-file-permissions File permissions unset or incorrect
 
 /workspace/roles/create_service/tasks/main.yml:41: no-changed-when: Commands should not change things if nothing needs doing.
+
+roles/apache2/tasks/main.yml:79: fqcn[action]: Use FQCN for module actions, such `<namespace>.<collection>.apache2_conf`. (warning)
+roles/bitbucket_srv/tasks/main.yml:45: literal-compare: Don't compare to literal True/False.


### PR DESCRIPTION
Ansible-lint now (tested with version 6.8.2) has rule names containing square brackets, like e.g. `fqcn[action]`. Updated the regular expression to support square brackets in rule names. Result output generated with the `--parseable` option can now again be parsed with the updated regular expression.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Related to the unmarked points above:
- I do not know any related issues, I have detected the issue on my system
- No relevant pull requests, upstream or downstream changes are known