### PR TITLE
Adding the '|' in the regex since even when tested not worked for armcl

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/ArmccCompilerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ArmccCompilerParser.java
@@ -19,7 +19,7 @@ import static edu.hm.hafner.util.IntegerParser.*;
 public class ArmccCompilerParser extends LookaheadParser {
     private static final long serialVersionUID = -2677728927938443703L;
 
-    private static final String ARMCC_WARNING_PATTERN = "^\"(.+)\", line (\\d+): ([A-Z][a-z]+):\\D*(\\d+)\\D*?:\\s+(.+)$";
+    private static final String ARMCC_WARNING_PATTERN = "^\"(.+)\", line (\\d+): ([A-Z]|[a-z]+):\\D*(\\d+)\\D*?:\\s+(.+)$";
 
     /**
      * Creates a new instance of {@link ArmccCompilerParser}.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I have faced an issue with the Armcc parser being unable to catch similar warnings generated by the Armcl compiler.
When we have done testing using things the regex tool '|' pattern addition is only able to catch the lines so, I am requesting this change for My side.
I have created an issue in the Jira [JENKINS-70065](https://issues.jenkins.io/browse/JENKINS-70065)
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
