### PR TITLE
Add UNSPECIFIED and STYLE as a output from CodeChecker

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
@@ -21,7 +21,7 @@ import edu.hm.hafner.util.LookaheadStream;
 public class CodeCheckerParser extends LookaheadParser {
     private static final long serialVersionUID = -3015592762345283582L;
     private static final String CODE_CHECKER_DEFECT_PATTERN =
-            "^\\[(?<severity>UNSPECIFIED|CRITICAL|HIGH|MEDIUM|LOW)\\] (?<path>.+):(?<line>\\d+):(?<column>\\d+): (?<message>.*?) \\[(?<category>[^\\s]*?)\\]$";
+            "^\\[(?<severity>UNSPECIFIED|STYLE|CRITICAL|HIGH|MEDIUM|LOW)\\] (?<path>.+):(?<line>\\d+):(?<column>\\d+): (?<message>.*?) \\[(?<category>[^\\s]*?)\\]$";
 
     /**
      * Creates a new instance of {@link CodeCheckerParser}.

--- a/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
@@ -21,7 +21,7 @@ import edu.hm.hafner.util.LookaheadStream;
 public class CodeCheckerParser extends LookaheadParser {
     private static final long serialVersionUID = -3015592762345283582L;
     private static final String CODE_CHECKER_DEFECT_PATTERN =
-            "^\\[(?<severity>UNSPECIFIED|STYLE|CRITICAL|HIGH|MEDIUM|LOW)\\] (?<path>.+):(?<line>\\d+):(?<column>\\d+): (?<message>.*?) \\[(?<category>[^\\s]*?)\\]$";
+            "^\\[(?<severity>CRITICAL|HIGH|MEDIUM|LOW|UNSPECIFIED|STYLE)\\] (?<path>.+):(?<line>\\d+):(?<column>\\d+): (?<message>.*?) \\[(?<category>[^\\s]*?)\\]$";
 
     /**
      * Creates a new instance of {@link CodeCheckerParser}.

--- a/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CodeCheckerParser.java
@@ -21,7 +21,7 @@ import edu.hm.hafner.util.LookaheadStream;
 public class CodeCheckerParser extends LookaheadParser {
     private static final long serialVersionUID = -3015592762345283582L;
     private static final String CODE_CHECKER_DEFECT_PATTERN =
-            "^\\[(?<severity>CRITICAL|HIGH|MEDIUM|LOW)\\] (?<path>.+):(?<line>\\d+):(?<column>\\d+): (?<message>.*?) \\[(?<category>[^\\s]*?)\\]$";
+            "^\\[(?<severity>UNSPECIFIED|CRITICAL|HIGH|MEDIUM|LOW)\\] (?<path>.+):(?<line>\\d+):(?<column>\\d+): (?<message>.*?) \\[(?<category>[^\\s]*?)\\]$";
 
     /**
      * Creates a new instance of {@link CodeCheckerParser}.

--- a/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
@@ -48,6 +48,22 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasCategory("bugprone-signed-char-misuse")
                 .hasSeverity(Severity.WARNING_NORMAL);
 
+        softly.assertThat(report.get(3))
+                .hasLineStart(1778)
+                .hasColumnStart(7)
+                .hasFileName("/path/to/projrct/extern/lib/dem.c")
+                .hasMessage("misra violation (use --rule-texts=<file> to get proper output)")
+                .hasCategory("cppcheck-misra-c2012-15.5")
+                .hasSeverity(Severity.WARNING_LOW);
+
+        softly.assertThat(report.get(4))
+                .hasLineStart(96)
+                .hasColumnStart(25)
+                .hasFileName("/path/to/projrct/extern/lib/control.c")
+                .hasMessage("misra violation (use --rule-texts=<file> to get proper output)")
+                .hasCategory("cppcheck-misra-c2012-15.5")
+                .hasSeverity(Severity.WARNING_LOW);
+
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
@@ -22,7 +22,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(3);
+        assertThat(report).hasSize(5);
 
         softly.assertThat(report.get(0))
                 .hasLineStart(17)

--- a/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CodeCheckerParserTest.java
@@ -61,7 +61,7 @@ class CodeCheckerParserTest extends AbstractParserTest {
                 .hasColumnStart(25)
                 .hasFileName("/path/to/projrct/extern/lib/control.c")
                 .hasMessage("misra violation (use --rule-texts=<file> to get proper output)")
-                .hasCategory("cppcheck-misra-c2012-15.5")
+                .hasCategory("cppcheck-misra-c2012-11.3")
                 .hasSeverity(Severity.WARNING_LOW);
 
     }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/CodeChecker_with_linux_paths.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/CodeChecker_with_linux_paths.txt
@@ -24,6 +24,16 @@ Found 1 defect(s) in workbook.cpp
 
 Found 1 defect(s) in HPSF.cpp
 
+[UNSPECIFIED] /path/to/projrct/extern/lib/dem.c:1778:7: misra violation (use --rule-texts=<file> to get proper output) [cppcheck-misra-c2012-15.5]
+      return E_NOT_OK;
+      ^
+
+[STYLE] /path/to/projrct/extern/lib/control.c:96:25: misra violation (use --rule-texts=<file> to get proper output) [cppcheck-misra-c2012-11.3]
+         "CommunicationControl: %s (%d) is not supported\n",
+
+Found 2 defect(s) in dem.c
+
+
 Found 485 defect(s) in formula.cpp
 
 


### PR DESCRIPTION

<!-- Please describe your pull request here. -->
CodeChecker can output UNSPECIFIED as a warning level when it does not know the level fully. For example here: https://github.com/Ericsson/codechecker/blob/36e6ad8c9a7381545983e89ebe756f6493bcd503/web/client/codechecker_client/report_type_converter.py#L86

This extends what was added here: https://github.com/jenkinsci/analysis-model/pull/706


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
