### PR TITLE
Inline incrementals URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.analysis.model</module.name>
-    <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
 
     <!-- Project Dependencies Configuration -->
     <jmh.version>1.36</jmh.version>
@@ -525,7 +524,7 @@
       <distributionManagement>
         <repository>
           <id>incrementals</id>
-          <url>${incrementals.url}</url>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
         </repository>
       </distributionManagement>
       <build>


### PR DESCRIPTION
Property interpolation for the `<url>` tag in the `<repository>` tag has been banned in maven 4. This PR inlines the incrementals URL to comply with the upcoming restriction.