### PR TITLE
Fix parsing of line and column numbers in Polyspace parser

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
@@ -31,7 +31,7 @@ public class PolyspaceParser extends IssueParser {
 
     @Override
     public Report parse(final ReaderFactory reader) throws ParsingException {
-        try (Stream<String> lines = reader.readStream().skip(1)) {
+        try (Stream<String> lines = reader.readStream()) {
             return parse(lines);
         }
     }
@@ -44,18 +44,23 @@ public class PolyspaceParser extends IssueParser {
             Report report = new Report();
             Iterator<String> lineIterator = lines.iterator();
 
+            String header = "";
+            if (lineIterator.hasNext()) {
+                header = lineIterator.next();
+            }
+
             while (lineIterator.hasNext()) {
                 String line = lineIterator.next();
                 /* Checks whether "CWE" field is found, which defines the difference between
                  a BugFinder file and a CodeProver report */
-                if (line.contains("CWE")) {
+                if (header.contains("CWE ID")) {
                     // BugFinder result file has 16 columns
                     limit = 16;
                     lineNumber = 14;
                     colNumber = 15;
                 }
                 else {
-                    // CodePRover file has 15 columns
+                    // CodeProver file has 15 columns
                     limit = 15;
                     lineNumber = 13;
                     colNumber = 14;
@@ -68,8 +73,8 @@ public class PolyspaceParser extends IssueParser {
                     builder.setDescription(attributes[1]);
                     builder.setMessage("Check: " + attributes[5] + " " + attributes[6]);
                     builder.setModuleName(attributes[7]);
-                    builder.setColumnStart(attributes[colNumber]);
-                    builder.setLineStart(attributes[lineNumber]);
+                    builder.setColumnStart(Integer.valueOf(attributes[colNumber]));
+                    builder.setLineStart(Integer.valueOf(attributes[lineNumber]));
                     builder.setSeverity(mapPriority(attributes));
                     builder.setAdditionalProperties(attributes[0]);
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
@@ -88,7 +88,7 @@ public class PolyspaceParser extends IssueParser {
         if (lineIterator.hasNext()) {
             return lineIterator.next();
         }
-        return StringUtils.EMPTY;
+        return EMPTY;
     }
 
     @SuppressWarnings({"PMD.UseVarargs", "PMD.CyclomaticComplexity" })

--- a/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
@@ -9,6 +9,7 @@ import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.util.IntegerParser;
 
 import static org.apache.commons.lang3.StringUtils.*;
 
@@ -43,11 +44,7 @@ public class PolyspaceParser extends IssueParser {
             int limit;
             Report report = new Report();
             Iterator<String> lineIterator = lines.iterator();
-
-            String header = "";
-            if (lineIterator.hasNext()) {
-                header = lineIterator.next();
-            }
+            String header = readHeader(lineIterator);
 
             while (lineIterator.hasNext()) {
                 String line = lineIterator.next();
@@ -73,8 +70,8 @@ public class PolyspaceParser extends IssueParser {
                     builder.setDescription(attributes[1]);
                     builder.setMessage("Check: " + attributes[5] + " " + attributes[6]);
                     builder.setModuleName(attributes[7]);
-                    builder.setColumnStart(Integer.parseInt(attributes[colNumber]));
-                    builder.setLineStart(Integer.parseInt(attributes[lineNumber]));
+                    builder.setColumnStart(IntegerParser.parseInt(attributes[colNumber]));
+                    builder.setLineStart(IntegerParser.parseInt(attributes[lineNumber]));
                     builder.setSeverity(mapPriority(attributes));
                     builder.setAdditionalProperties(attributes[0]);
 
@@ -83,6 +80,14 @@ public class PolyspaceParser extends IssueParser {
             }
             return report;
         }
+    }
+
+    private String readHeader(final Iterator<String> lineIterator) {
+        String header = "";
+        if (lineIterator.hasNext()) {
+            header = lineIterator.next();
+        }
+        return header;
     }
 
     @SuppressWarnings({"PMD.UseVarargs", "PMD.CyclomaticComplexity" })

--- a/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
@@ -3,8 +3,6 @@ package edu.hm.hafner.analysis.parser;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-
 import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.ParsingException;

--- a/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
@@ -73,8 +73,8 @@ public class PolyspaceParser extends IssueParser {
                     builder.setDescription(attributes[1]);
                     builder.setMessage("Check: " + attributes[5] + " " + attributes[6]);
                     builder.setModuleName(attributes[7]);
-                    builder.setColumnStart(Integer.valueOf(attributes[colNumber]));
-                    builder.setLineStart(Integer.valueOf(attributes[lineNumber]));
+                    builder.setColumnStart(Integer.parseInt(attributes[colNumber]));
+                    builder.setLineStart(Integer.parseInt(attributes[lineNumber]));
                     builder.setSeverity(mapPriority(attributes));
                     builder.setAdditionalProperties(attributes[0]);
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PolyspaceParser.java
@@ -3,6 +3,8 @@ package edu.hm.hafner.analysis.parser;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.ParsingException;
@@ -83,11 +85,10 @@ public class PolyspaceParser extends IssueParser {
     }
 
     private String readHeader(final Iterator<String> lineIterator) {
-        String header = "";
         if (lineIterator.hasNext()) {
-            header = lineIterator.next();
+            return lineIterator.next();
         }
-        return header;
+        return StringUtils.EMPTY;
     }
 
     @SuppressWarnings({"PMD.UseVarargs", "PMD.CyclomaticComplexity" })

--- a/src/test/java/edu/hm/hafner/analysis/parser/PolyspaceParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PolyspaceParserTest.java
@@ -1,9 +1,12 @@
 package edu.hm.hafner.analysis.parser;
 
+import org.junit.jupiter.api.Test;
+
 import edu.hm.hafner.analysis.AbstractParserTest;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.assertions.SoftAssertions;
+import static edu.hm.hafner.analysis.assertions.Assertions.*;
 
 /**
  * Tests the class {@link PolyspaceParser}.
@@ -32,6 +35,7 @@ class PolyspaceParserTest extends AbstractParserTest {
                 .hasMessage("Check: Null pointer Impact: High")
                 .hasModuleName("calculate()")
                 .hasCategory("memory")
+                .hasColumnStart(49)
                 .hasDescription("Defect")
                 .hasSeverity(Severity.WARNING_HIGH);
         softly.assertThat(report.get(1))
@@ -52,6 +56,43 @@ class PolyspaceParserTest extends AbstractParserTest {
                 .hasMessage("Check: 11.1 Conversions shall not be performed between a pointer to a function and any other type. Category: Required")
                 .hasModuleName("tester()")
                 .hasSeverity(Severity.WARNING_NORMAL);
+    }
+
+    @Test
+    void polyspace_cp_test() {
+        Report warnings = parse("polyspace_cp.csv");
+        assertThat(warnings).hasSize(4);
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            softly.assertThat(warnings.get(0)).hasLineStart(30)
+                    .hasFileName("D:/workspace/math.c")
+                    .hasCategory("Data flow")
+                    .hasDescription("Run-time Check")
+                    .hasMessage("Check: Unreachable code")
+                    .hasModuleName("xinitialize()")
+                    .hasColumnStart(4)
+                    .hasSeverity(Severity.WARNING_HIGH);
+            softly.assertThat(warnings.get(1)).hasLineStart(34)
+                    .hasFileName("D:/sample.h")
+                    .hasCategory("Data flow")
+                    .hasDescription("Run-time Check")
+                    .hasModuleName("method_a()")
+                    .hasColumnStart(4)
+                    .hasSeverity(Severity.WARNING_NORMAL);
+            softly.assertThat(warnings.get(2)).hasLineStart(66)
+                    .hasDescription("Run-time Check")
+                    .hasModuleName("errorCheck()")
+                    .hasColumnStart(4)
+                    .hasSeverity(Severity.WARNING_HIGH);
+            softly.assertThat(warnings.get(3)).hasLineStart(217)
+                    .hasDescription("MISRA C:2012")
+                    .hasMessage("Check: 10.1 Operands shall not be of an inappropriate essential type. Category: Required")
+                    .hasFileName("/file/SERVICE.c")
+                    .hasModuleName("a_message()")
+                    .hasColumnStart(27)
+                    .hasCategory("10 The essential type model")
+                    .hasSeverity(Severity.WARNING_NORMAL);
+        }
     }
 }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/PolyspaceParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PolyspaceParserTest.java
@@ -59,7 +59,7 @@ class PolyspaceParserTest extends AbstractParserTest {
     }
 
     @Test
-    void polyspace_cp_test() {
+    void polyspaceCPTest() {
         Report warnings = parse("polyspace_cp.csv");
         assertThat(warnings).hasSize(4);
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/PolyspaceParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PolyspaceParserTest.java
@@ -6,6 +6,7 @@ import edu.hm.hafner.analysis.AbstractParserTest;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.assertions.SoftAssertions;
+
 import static edu.hm.hafner.analysis.assertions.Assertions.*;
 
 /**
@@ -14,10 +15,7 @@ import static edu.hm.hafner.analysis.assertions.Assertions.*;
  *  @author Eva Habeeb
  */
 class PolyspaceParserTest extends AbstractParserTest {
-    /**
-     * Creates a new instance of {@link PolyspaceParserTest}.
-     */
-    protected PolyspaceParserTest() {
+    PolyspaceParserTest() {
         super("polyspace.csv");
     }
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/polyspace.csv
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/polyspace.csv
@@ -1,10 +1,10 @@
 ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Comment	CWE ID	Key	Line	Col
 3547	Defect	memory	Red	yes	Null pointer	Impact: High	calculate()	D:\Jenkins\workspace\example.c	Unreviewed	Unset		CWE-476 CWE-690	123456789	222	49
 1320	Defect	Programming	Red	yes	Qualifier removed in conversion	Impact: Low		D:\example/test.c	Unreviewed	Unset		CWE-704	123456789	276	5
-184	Custom Rule	4 Structs	Not Applicable	yes	4.3 All struct fields must follow the specified pattern.		File()	D:\sample.h	Unreviewed	High		123456789	631	16
-5630	Run-time Check	memory	Red	yes	Out of bounds array index		tester()	/jenkins/example.c	Unreviewed	Medium		123456789	468	55
-15484	Run-time Check	Data flow	Gray	yes	Unreachable code		init()	/jenkins/example.c	Unreviewed	Low		123456789	27	4
-420	MISRA C:2012	11 Pointer type conversions	Not Applicable	yes	11.1 Conversions shall not be performed between a pointer to a function and any other type.	Category: Required	tester()	/example/myinit.c	Unreviewed	Unset		123456789	512	48
-421	MISRA C:2012	11 Pointer type conversions	Not Applicable	yes	11.8 A cast shall not remove any const or volatile qualification from the type pointed to by a pointer.	Category: Required	calculate()	/jenkins/main.c	Unreviewed	Unset		123456789	70	5
-3528	Guidelines	Software Complexity	Not Applicable	no	123 Depth of call nesting exceeds threshold	Category: HIS	init()	D:\workspace/math.c	Unreviewed	Unset		123456789	406	10
-3529	Guidelines	Software Complexity	Not Applicable	no	123 Number of calling functions exceeds threshold	Category: HIS	main()	D:\Jenkins\main.c	Unreviewed	Unset		123456789	131	10
+184	Custom Rule	4 Structs	Not Applicable	yes	4.3 All struct fields must follow the specified pattern.		File()	D:\sample.h	Unreviewed	High		CWE-74	123456789	631	16
+5630	Run-time Check	memory	Red	yes	Out of bounds array index		tester()	/jenkins/example.c	Unreviewed	Medium		CWE-864	1236789	468	55
+15484	Run-time Check	Data flow	Gray	yes	Unreachable code		init()	/jenkins/example.c	Unreviewed	Low		CWE-149	1236089	27	4
+420	MISRA C:2012	11 Pointer type conversions	Not Applicable	yes	11.1 Conversions shall not be performed between a pointer to a function and any other type.	Category: Required	tester()	/example/myinit.c	Unreviewed	Unset		CWE-4135	733913	512	48
+421	MISRA C:2012	11 Pointer type conversions	Not Applicable	yes	11.8 A cast shall not remove any const or volatile qualification from the type pointed to by a pointer.	Category: Required	calculate()	/jenkins/main.c	Unreviewed	Unset		CWE-317	013751	70	5
+3528	Guidelines	Software Complexity	Not Applicable	no	123 Depth of call nesting exceeds threshold	Category: HIS	init()	D:\workspace/math.c	Unreviewed	Unset		CWE-612	9155	406	10
+3529	Guidelines	Software Complexity	Not Applicable	no	123 Number of calling functions exceeds threshold	Category: HIS	main()	D:\Jenkins\main.c	Unreviewed	Unset		CWE-554	9991112	131	10

--- a/src/test/resources/edu/hm/hafner/analysis/parser/polyspace_cp.csv
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/polyspace_cp.csv
@@ -1,0 +1,5 @@
+ID	Family	Group	Color	New	Check	Information	Function	File	Status	Severity	Comment	Key	Line	Col
+16153	Run-time Check	Data flow	Red	yes	Unreachable code		xinitialize()	D:\workspace/math.c	Unreviewed	Unset		CC1849A44441	30	4
+16155	Run-time Check	Data flow	Gray	yes	Unreachable code		method_a()	D:\sample.h	Unreviewed	Medium		CC10009C49A1	34	4
+16144	Run-time Check	Data flow	Gray	yes	Unreachable code		errorCheck()	D:\Jenkins\main.c	Unreviewed	High		81111559C49A1	66	4
+2436	MISRA C:2012	10 The essential type model	Not Applicable	yes	10.1 Operands shall not be of an inappropriate essential type.	Category: Required	a_message()	/file/SERVICE.c	Unreviewed	Unset		844C182E62C8B9	217	27


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Updated the parser file with Integer.valueOf() function for column and line set, since line number was showing as 0 for all issues in the dashboard. 
Also updated the logic of checking whether it is a BugFinder or a CodeProver file to be based on the header. (Test file edited accordingly) 

Relevant pull request : https://github.com/jenkinsci/warnings-ng-plugin/pull/1412

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
