### PR TITLE
[JENKINS-70498] Correctly handle line ranges in the JSONParser

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -1,4 +1,4 @@
-<!--- DO NOT EDIT -- Generated at 2023-01-31T16:04:29.723221 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
+<!--- DO NOT EDIT -- Generated at 2023-02-16T14:25:13.065416 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
 # Supported Report Formats
 
 The static analysis model supports the following report formats.

--- a/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
@@ -29,7 +29,7 @@ import static edu.hm.hafner.util.IntegerParser.*;
  *
  * @author Ullrich Hafner
  */
-@SuppressWarnings({"InstanceVariableMayNotBeInitialized", "JavaDocMethod", "PMD.TooManyFields"})
+@SuppressWarnings({"InstanceVariableMayNotBeInitialized", "JavaDocMethod", "PMD.TooManyFields", "PMD.GodClass"})
 public class IssueBuilder implements AutoCloseable {
     private static final String EMPTY = StringUtils.EMPTY;
     private static final String UNDEFINED = "-";
@@ -498,10 +498,7 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue build() {
-        cleanupLineRanges();
-        Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
-                category, type, packageName, moduleName, severity, message, description,
-                origin, originName, reference, fingerprint, additionalProperties, id);
+        Issue issue = buildWithConstructor();
         id = UUID.randomUUID(); // make sure that multiple invocations will create different IDs
         return issue;
     }
@@ -513,12 +510,17 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue buildAndClean() {
-        cleanupLineRanges();
-        Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
-                category, type, packageName, moduleName, severity, message, description,
-                origin, originName, reference, fingerprint, additionalProperties, id);
+        Issue issue = buildWithConstructor();
         clean();
         return issue;
+    }
+
+    private Issue buildWithConstructor() {
+        cleanupLineRanges();
+
+        return new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
+                category, type, packageName, moduleName, severity, message, description,
+                origin, originName, reference, fingerprint, additionalProperties, id);
     }
 
     /**
@@ -526,16 +528,15 @@ public class IssueBuilder implements AutoCloseable {
      * lineRanges if its start and end are the same as lineStart and lineEnd.
      */
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "False positive, `lineRanges != null` avoids a NullPointerException")
-    public void cleanupLineRanges() {
-        if (lineRanges != null && lineRanges.size() > 1) {
+    private void cleanupLineRanges() {
+        if (lineRanges != null && !lineRanges.isEmpty()) {
             LineRange firstRange = lineRanges.get(0);
             if (lineStart == 0) {
-                setLineStart(firstRange.getStart());
+                this.lineStart = firstRange.getStart();
+                this.lineEnd = firstRange.getEnd();
             }
-            if (lineEnd == 0) {
-                setLineEnd(firstRange.getEnd());
-            }
-            if (firstRange.getStart() == lineStart && firstRange.getEnd() == lineEnd) {
+            if (firstRange.getStart() == lineStart
+                    && firstRange.getEnd() == lineEnd) {
                 lineRanges.remove(0);
             }
         }

--- a/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
@@ -497,7 +497,7 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue build() {
-        lineRangeChecks();
+        cleanupLineRanges();
         Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
                 category, type, packageName, moduleName, severity, message, description,
                 origin, originName, reference, fingerprint, additionalProperties, id);
@@ -512,7 +512,7 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue buildAndClean() {
-        lineRangeChecks();
+        cleanupLineRanges();
         Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
                 category, type, packageName, moduleName, severity, message, description,
                 origin, originName, reference, fingerprint, additionalProperties, id);
@@ -524,7 +524,7 @@ public class IssueBuilder implements AutoCloseable {
      * Sets lineStart and lineEnd if they are not set, and then removes the first element of
      * lineRanges if its start and end are the same as lineStart and lineEnd.
      */
-    public void lineRangeChecks() {
+    public void cleanupLineRanges() {
         if (lineRanges != null && lineRanges.size() > 1) {
             LineRange firstRange = lineRanges.get(0);
             if (lineStart == 0) {

--- a/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
@@ -497,12 +497,7 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue build() {
-        if (lineRanges != null && lineRanges.size()>1) {
-            LineRange firstRange = lineRanges.get(0);
-            if (firstRange.getStart() == lineStart && firstRange.getEnd() == lineEnd) {
-                lineRanges.remove(0);
-            }
-        }
+        lineRangeChecks();
         Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
                 category, type, packageName, moduleName, severity, message, description,
                 origin, originName, reference, fingerprint, additionalProperties, id);
@@ -517,17 +512,31 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue buildAndClean() {
-        if (lineRanges != null && lineRanges.size()>1) {
-            LineRange firstRange = lineRanges.get(0);
-            if (firstRange.getStart() == lineStart && firstRange.getEnd() == lineEnd) {
-                lineRanges.remove(0);
-            }
-        }
+        lineRangeChecks();
         Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
                 category, type, packageName, moduleName, severity, message, description,
                 origin, originName, reference, fingerprint, additionalProperties, id);
         clean();
         return issue;
+    }
+
+    /**
+     * Sets lineStart and lineEnd if they are not set, and then removes the first element of
+     * lineRanges if its start and end are the same as lineStart and lineEnd.
+     */
+    public void lineRangeChecks() {
+        if (lineRanges != null && lineRanges.size() > 1) {
+            LineRange firstRange = lineRanges.get(0);
+            if (lineStart == 0) {
+                setLineStart(firstRange.getStart());
+            }
+            if (lineEnd == 0) {
+                setLineEnd(firstRange.getEnd());
+            }
+            if (firstRange.getStart() == lineStart && firstRange.getEnd() == lineEnd) {
+                lineRanges.remove(0);
+            }
+        }
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
@@ -497,6 +497,12 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue build() {
+        if (lineRanges != null && lineRanges.size()>1) {
+            LineRange firstRange = lineRanges.get(0);
+            if (firstRange.getStart() == lineStart && firstRange.getEnd() == lineEnd) {
+                lineRanges.remove(0);
+            }
+        }
         Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
                 category, type, packageName, moduleName, severity, message, description,
                 origin, originName, reference, fingerprint, additionalProperties, id);
@@ -511,6 +517,12 @@ public class IssueBuilder implements AutoCloseable {
      * @return the created issue
      */
     public Issue buildAndClean() {
+        if (lineRanges != null && lineRanges.size()>1) {
+            LineRange firstRange = lineRanges.get(0);
+            if (firstRange.getStart() == lineStart && firstRange.getEnd() == lineEnd) {
+                lineRanges.remove(0);
+            }
+        }
         Issue issue = new Issue(pathName, fileName, lineStart, lineEnd, columnStart, columnEnd, lineRanges,
                 category, type, packageName, moduleName, severity, message, description,
                 origin, originName, reference, fingerprint, additionalProperties, id);

--- a/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
@@ -10,6 +10,7 @@ import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.TreeString;
 import edu.hm.hafner.util.TreeStringBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static edu.hm.hafner.util.IntegerParser.*;
 
@@ -524,6 +525,7 @@ public class IssueBuilder implements AutoCloseable {
      * Sets lineStart and lineEnd if they are not set, and then removes the first element of
      * lineRanges if its start and end are the same as lineStart and lineEnd.
      */
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "False positive, `lineRanges != null` avoids a NullPointerException")
     public void cleanupLineRanges() {
         if (lineRanges != null && lineRanges.size() > 1) {
             LineRange firstRange = lineRanges.get(0);

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
@@ -78,6 +78,9 @@ abstract class JsonBaseParser extends IssuePropertiesParser {
             JSONArray jsonRanges = jsonIssue.getJSONArray(LINE_RANGES);
             LineRangeList lineRanges = convertToLineRangeList(jsonRanges);
             builder.setLineRanges(lineRanges);
+            LineRange firstRange = lineRanges.get(0);
+            builder.setLineStart(firstRange.getStart());
+            builder.setLineEnd(firstRange.getEnd());
         }
         if (jsonIssue.has(LINE_START)) {
             builder.setLineStart(jsonIssue.getInt(LINE_START));

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
@@ -78,11 +78,6 @@ abstract class JsonBaseParser extends IssuePropertiesParser {
             JSONArray jsonRanges = jsonIssue.getJSONArray(LINE_RANGES);
             LineRangeList lineRanges = convertToLineRangeList(jsonRanges);
             builder.setLineRanges(lineRanges);
-            if (!lineRanges.isEmpty()) {
-                LineRange firstRange = lineRanges.get(0);
-                builder.setLineStart(firstRange.getStart());
-                builder.setLineEnd(firstRange.getEnd());
-            }
         }
         if (jsonIssue.has(LINE_START)) {
             builder.setLineStart(jsonIssue.getInt(LINE_START));

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonBaseParser.java
@@ -78,9 +78,11 @@ abstract class JsonBaseParser extends IssuePropertiesParser {
             JSONArray jsonRanges = jsonIssue.getJSONArray(LINE_RANGES);
             LineRangeList lineRanges = convertToLineRangeList(jsonRanges);
             builder.setLineRanges(lineRanges);
-            LineRange firstRange = lineRanges.get(0);
-            builder.setLineStart(firstRange.getStart());
-            builder.setLineEnd(firstRange.getEnd());
+            if (!lineRanges.isEmpty()) {
+                LineRange firstRange = lineRanges.get(0);
+                builder.setLineStart(firstRange.getStart());
+                builder.setLineEnd(firstRange.getEnd());
+            }
         }
         if (jsonIssue.has(LINE_START)) {
             builder.setLineStart(jsonIssue.getInt(LINE_START));

--- a/src/test/java/edu/hm/hafner/analysis/IssueBuilderTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/IssueBuilderTest.java
@@ -237,7 +237,6 @@ class IssueBuilderTest {
     @Test
     void shouldCollectLineRanges() {
         try (IssueBuilder builder = new IssueBuilder()) {
-
             builder.setLineStart(1).setLineEnd(2);
             LineRangeList lineRanges = new LineRangeList();
             lineRanges.add(new LineRange(3, 4));
@@ -252,6 +251,61 @@ class IssueBuilderTest {
                 copy.copy(issue);
                 assertThat(copy.build()).hasOnlyLineRanges(new LineRange(3, 4), new LineRange(5, 6));
             }
+        }
+    }
+
+    @Test
+    void shouldMoveLineRangeToAttributes() {
+        try (IssueBuilder builder = new IssueBuilder()) {
+            LineRangeList lineRanges = new LineRangeList();
+            lineRanges.add(new LineRange(1, 2));
+            builder.setLineRanges(lineRanges);
+
+            Issue issue = builder.build();
+            assertThat(issue).hasLineStart(1).hasLineEnd(2);
+            assertThat(issue).hasNoLineRanges();
+        }
+    }
+
+    @Test
+    void shouldMoveLineRangeToAttributesEvenIfLineEndIsSet() {
+        try (IssueBuilder builder = new IssueBuilder()) {
+            builder.setLineEnd(2);
+            LineRangeList lineRanges = new LineRangeList();
+            lineRanges.add(new LineRange(1, 2));
+            builder.setLineRanges(lineRanges);
+
+            Issue issue = builder.build();
+            assertThat(issue).hasLineStart(1).hasLineEnd(2);
+            assertThat(issue).hasNoLineRanges();
+        }
+    }
+
+    @Test
+    void shouldCleanupLineRanges() {
+        try (IssueBuilder builder = new IssueBuilder()) {
+            builder.setLineStart(1).setLineEnd(2);
+            LineRangeList lineRanges = new LineRangeList();
+            lineRanges.add(new LineRange(1, 2));
+            builder.setLineRanges(lineRanges);
+
+            Issue issue = builder.build();
+            assertThat(issue).hasLineStart(1).hasLineEnd(2);
+            assertThat(issue).hasNoLineRanges();
+        }
+    }
+
+    @Test
+    void shouldNotCleanupDifferentLineRanges() {
+        try (IssueBuilder builder = new IssueBuilder()) {
+            builder.setLineStart(1).setLineEnd(2);
+            LineRangeList lineRanges = new LineRangeList();
+            lineRanges.add(new LineRange(1, 3));
+            builder.setLineRanges(lineRanges);
+
+            Issue issue = builder.build();
+            assertThat(issue).hasLineStart(1).hasLineEnd(2);
+            assertThat(issue).hasOnlyLineRanges(new LineRange(1, 3));
         }
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonLogParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonLogParserTest.java
@@ -27,7 +27,9 @@ class JsonLogParserTest extends AbstractParserTest {
 
         softly.assertThat(report.get(0))
                 .hasFileName("file.txt")
-                .hasOnlyLineRanges(new LineRange(10, 11), new LineRange(20, 21))
+                .hasOnlyLineRanges(new LineRange(20, 21))
+                .hasLineStart(10)
+                .hasLineEnd(11)
                 .hasCategory("c")
                 .hasDescription("d")
                 .hasType("t")
@@ -52,7 +54,9 @@ class JsonLogParserTest extends AbstractParserTest {
 
         softly.assertThat(report.get(2))
                 .hasFileName("test.txt")
-                .hasOnlyLineRanges(new LineRange(10, 10), new LineRange(220, 220))
+                .hasOnlyLineRanges(new LineRange(220, 220))
+                .hasLineStart(10)
+                .hasLineEnd(10)
                 .hasDescription("an \"important\" description")
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasMessage("an \"important\" message");
@@ -64,7 +68,9 @@ class JsonLogParserTest extends AbstractParserTest {
 
         softly.assertThat(report.get(4))
                 .hasFileName("file.xml")
-                .hasOnlyLineRanges(new LineRange(11, 12), new LineRange(21, 22))
+                .hasOnlyLineRanges(new LineRange(21, 22))
+                .hasLineStart(11)
+                .hasLineEnd(12)
                 .hasSeverity(Severity.WARNING_NORMAL);
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
@@ -24,7 +24,7 @@ class JsonParserTest extends StructuredFileParserTest {
 
         softly.assertThat(report.get(0))
                 .hasFileName("test-file.txt")
-                .hasOnlyLineRanges(new LineRange(110, 111), new LineRange(120, 121))
+                .hasOnlyLineRanges(new LineRange(120, 121))
                 .hasLineStart(110)
                 .hasLineEnd(111)
                 .hasCategory("category")
@@ -51,7 +51,9 @@ class JsonParserTest extends StructuredFileParserTest {
 
         softly.assertThat(report.get(2))
                 .hasFileName("test.txt")
-                .hasOnlyLineRanges(new LineRange(110, 110), new LineRange(320, 320))
+                .hasOnlyLineRanges(new LineRange(320, 320))
+                .hasLineStart(110)
+                .hasLineEnd(110)
                 .hasDescription("an \"important\" description")
                 .hasSeverity(Severity.WARNING_HIGH)
                 .hasMessage("an \"important\" message");
@@ -63,7 +65,9 @@ class JsonParserTest extends StructuredFileParserTest {
 
         softly.assertThat(report.get(4))
                 .hasFileName("file.xml")
-                .hasOnlyLineRanges(new LineRange(11, 12), new LineRange(21, 22))
+                .hasOnlyLineRanges(new LineRange(21, 22))
+                .hasLineStart(11)
+                .hasLineEnd(12)
                 .hasSeverity(Severity.WARNING_NORMAL);
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
@@ -24,7 +24,8 @@ class JsonParserTest extends StructuredFileParserTest {
 
         softly.assertThat(report.get(0))
                 .hasFileName("test-file.txt")
-                .hasOnlyLineRanges(new LineRange(110, 111), new LineRange(120, 121))
+                .hasLineStart(110)
+                .hasLineEnd(111)
                 .hasCategory("category")
                 .hasDescription("description")
                 .hasType("type")
@@ -44,7 +45,7 @@ class JsonParserTest extends StructuredFileParserTest {
                 .hasColumnStart(210)
                 .hasColumnEnd(220)
                 .hasDescription("some description")
-                .hasSeverity(Severity.ERROR)
+//                .hasSeverity(Severity.ERROR)
                 .hasMessage("some message");
 
         softly.assertThat(report.get(2))

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
@@ -45,7 +45,7 @@ class JsonParserTest extends StructuredFileParserTest {
                 .hasColumnStart(210)
                 .hasColumnEnd(220)
                 .hasDescription("some description")
-//                .hasSeverity(Severity.ERROR)
+                .hasSeverity(Severity.ERROR)
                 .hasMessage("some message");
 
         softly.assertThat(report.get(2))

--- a/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JsonParserTest.java
@@ -24,6 +24,7 @@ class JsonParserTest extends StructuredFileParserTest {
 
         softly.assertThat(report.get(0))
                 .hasFileName("test-file.txt")
+                .hasOnlyLineRanges(new LineRange(110, 111), new LineRange(120, 121))
                 .hasLineStart(110)
                 .hasLineEnd(111)
                 .hasCategory("category")

--- a/src/test/java/edu/hm/hafner/analysis/parser/XmlParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/XmlParserTest.java
@@ -121,8 +121,8 @@ class XmlParserTest extends StructuredFileParserTest {
                     .hasSize(1);
             softly.assertThat(iterator.next())
                     .hasFileName("-")
-                    .hasLineStart(0)
-                    .hasLineEnd(0)
+                    .hasLineStart(1)
+                    .hasLineEnd(2)
                     .hasColumnStart(0)
                     .hasColumnEnd(0)
                     .hasCategory("")
@@ -136,7 +136,7 @@ class XmlParserTest extends StructuredFileParserTest {
                     .hasReference("")
                     .hasFingerprint("-")
                     .hasAdditionalProperties("")
-                    .hasOnlyLineRanges(new LineRange(1, 2));
+                    .hasNoLineRanges();
         }
     }
 }


### PR DESCRIPTION
Fix for [#70498](https://issues.jenkins.io/browse/JENKINS-70498)

Changed the test case in `JSONParserTest` class to read the first element of `lineRanges` list, which initially failed the test. Changed the `JSONBaseParser` to initialise `lineStart` and `lineEnd` of the `IssueBuilder` by reading the first element of `lineRanges` list.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

