### PR TITLE
[JENKINS-70658] Update maven goal detection for Maven 3.9.0 

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -1,4 +1,4 @@
-<!--- DO NOT EDIT -- Generated at 2023-02-16T14:25:13.065416 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
+<!--- DO NOT EDIT -- Generated at 2023-02-25T20:47:50.473344898 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
 # Supported Report Formats
 
 The static analysis model supports the following report formats.

--- a/src/main/java/edu/hm/hafner/analysis/parser/MavenConsoleParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MavenConsoleParser.java
@@ -85,7 +85,7 @@ public class MavenConsoleParser extends AbstractMavenLogParser {
 
     private boolean isValidGoal() {
         return !(goal.contains("maven-compiler-plugin")
-                || goal.contains("maven-javadoc-plugin")); // will be captured by another parser already
+                || goal.contains("maven-javadoc-plugin") || goal.contains("compiler")); // will be captured by another parser already
     }
 
     @Override


### PR DESCRIPTION
Maven 3.9.0 changed the logging format of goals and maven plugins, see [JENKINS-70658](https://issues.jenkins.io/browse/JENKINS-70658). The PR updates all parsers that work on Maven logs.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira


