### PR TITLE
Fix for maven console output using 3.9.0

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
@@ -22,7 +22,7 @@ public abstract class AbstractMavenLogParser extends LookaheadParser {
     private static final Pattern MAVEN_MODULE_START = Pattern.compile(
             "-+< (?<id>\\S+) >-+"
     );
-    static final String MAVEN_COMPILER_PLUGIN = "maven-compiler-plugin";
+    static final String MAVEN_COMPILER_PLUGIN = "compiler";
     private String goal = StringUtils.EMPTY;
     private String module = StringUtils.EMPTY;
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/MavenConsoleParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MavenConsoleParser.java
@@ -84,7 +84,7 @@ public class MavenConsoleParser extends AbstractMavenLogParser {
     }
 
     private boolean isValidGoal() {
-        return !(goal.contains("maven-compiler-plugin")
+        return !(goal.contains("compiler")
                 || goal.contains("maven-javadoc-plugin")); // will be captured by another parser already
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

This change is to address the issue of chaning named from maven-compiler-plugin to compiler. With maven 3.8 and later, such naming conventions are being used. Since the logic is dependent upon maven-compiler-plugin, I have changed the clasess which are using 'maven-compiler-plugin' to 'compiler'.
