### PR TITLE
Move Plugin Description to index.jelly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,6 @@
   <packaging>jar</packaging>
 
   <name>Static Analysis Model and Parsers</name>
-  <description>This library provides a Java object model to read, aggregate, filter, and query static analysis reports.
-    It is used by Jenkins' warnings next generation plug-in to visualize the warnings of individual builds.
-    Additionally, this library is used by a GitHub action to autograde student software projects based on a given set of
-    metrics (unit tests, code and mutation coverage, static analysis warnings).
-  </description>
 
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/analysis-model.git</connection>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This library provides a Java object model to read, aggregate, filter, and query static analysis reports.
+    It is used by Jenkins' warnings next generation plug-in to visualize the warnings of individual builds.
+    Additionally, this library is used by a GitHub action to autograde student software projects based on a given set of
+    metrics (unit tests, code and mutation coverage, static analysis warnings).
+</div>


### PR DESCRIPTION
According to the [Google Document](https://docs.google.com/document/d/1PKYIpPlRVGsBqrz0Ob1Cv3cefOZ5j2xtGZdWs27kLuw/edit#) provided , <strong>I have created the src/main/resources/index.jelly file and removed the description tag from the pom file </strong> as specified under the <strong> Move plugin description to index.jelly </strong> topic

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes

