### PR TITLE
[JENKINS-70804] Do not use format method when simply copying log messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>edu.hm.hafner</groupId>
     <artifactId>codingstyle-pom</artifactId>
-    <version>3.10.0</version>
+    <version>3.18.0</version>
     <relativePath />
   </parent>
 
@@ -54,7 +54,7 @@
 
   <properties>
     <scmTag>HEAD</scmTag>
-    <revision>11.1.0</revision>
+    <revision>11.0.1</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.analysis.model</module.name>

--- a/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
+++ b/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
@@ -37,10 +37,9 @@ public class FingerprintGenerator {
                 sum += computeFingerprint(issue, algorithm, charset, log);
             }
         }
-        log.getInfoMessages().forEach(report::logInfo);
-        log.getErrorMessages().forEach(report::logError);
-        report.logInfo("-> created fingerprints for %d issues (skipped %d issues)", sum, report.size() - sum);
         log.logSummary();
+        report.mergeLogMessages(log);
+        report.logInfo("-> created fingerprints for %d issues (skipped %d issues)", sum, report.size() - sum);
     }
 
     private int computeFingerprint(final Issue issue, final FullTextFingerprint algorithm, final Charset charset,

--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import com.google.errorprone.annotations.FormatMethod;
 
 import edu.hm.hafner.util.Ensure;
+import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.TreeString;
 import edu.hm.hafner.util.TreeStringBuilder;
@@ -872,6 +873,17 @@ public class Report implements Iterable<Issue>, Serializable {
         Report empty = new Report();
         copyProperties(this, empty);
         return empty;
+    }
+
+    /**
+     * Merge all log messages from the specified log into the log of this report.
+     *
+     * @param log
+     *         the log messages to merge
+     */
+    public void mergeLogMessages(final FilteredLog log) {
+        infoMessages.addAll(log.getInfoMessages());
+        errorMessages.addAll(log.getErrorMessages());
     }
 
     /**

--- a/src/test/java/edu/hm/hafner/analysis/ReportTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/ReportTest.java
@@ -24,6 +24,7 @@ import edu.hm.hafner.analysis.Report.IssuePrinter;
 import edu.hm.hafner.analysis.Report.StandardOutputPrinter;
 import edu.hm.hafner.analysis.assertions.SoftAssertions;
 import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
+import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
 import edu.hm.hafner.util.SerializableTest;
 import edu.hm.hafner.util.TreeString;
@@ -41,7 +42,7 @@ import static org.mockito.Mockito.*;
  * @author Marcel Binder
  * @author Ullrich Hafner
  */
-@SuppressWarnings({"PMD.GodClass", "PMD.ExcessiveImports", "PMD.ExcessiveClassLength"})
+@SuppressWarnings({"PMD.GodClass", "PMD.ExcessiveImports", "PMD.ExcessiveClassLength", "checkstyle:ClassDataAbstractionCoupling"})
 class ReportTest extends SerializableTest<Report> {
     private static final String SERIALIZATION_NAME = "report.ser";
 
@@ -85,6 +86,26 @@ class ReportTest extends SerializableTest<Report> {
     static void beforeAll() {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
+    }
+
+    @Test
+    void shouldMergeLog() {
+        var issues = new Report();
+
+        issues.logInfo("info");
+        issues.logError("error");
+
+        assertThat(issues).hasOnlyInfoMessages("info");
+        assertThat(issues).hasOnlyErrorMessages("error");
+
+        var log = new FilteredLog("title");
+        log.logInfo("filtered info");
+        log.logError("filtered error");
+
+        issues.mergeLogMessages(log);
+
+        assertThat(issues).hasOnlyInfoMessages("info", "filtered info");
+        assertThat(issues).hasOnlyErrorMessages("error", "title", "filtered error");
     }
 
     @Test


### PR DESCRIPTION
Do not use format method when simply copying log messages.

Fixes [JENKINS-70804](https://issues.jenkins.io/browse/JENKINS-70804)

