### PR TITLE
JENKINS-70801: use module information from IntelliJ IDEA's output file

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/IdeaInspectionParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/IdeaInspectionParser.java
@@ -46,6 +46,7 @@ public class IdeaInspectionParser extends IssueParser {
                             .setLineStart(Integer.parseInt(getChildValue(element, "line")))
                             .setCategory(StringEscapeUtils.unescapeXml(getValue(problem)))
                             .setMessage(StringEscapeUtils.unescapeXml(getChildValue(element, "description")))
+                            .setModuleName(StringEscapeUtils.unescapeXml(getChildValue(element, "module")))
                             .setSeverity(getPriority(problem.getAttribute("severity")));
                     problems.add(issueBuilder.buildAndClean());
                 }

--- a/src/test/java/edu/hm/hafner/analysis/parser/IdeaInspectionParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/IdeaInspectionParserTest.java
@@ -36,6 +36,7 @@ class IdeaInspectionParserTest extends AbstractParserTest {
                 .hasCategory("Unused method parameters")
                 .hasLineStart(42)
                 .hasLineEnd(42)
+                .hasModuleName("tests")
                 .hasMessage(
                         "Parameter <code>intentionallyUnusedString</code> is not used  in either this method or any of its derived methods")
                 .hasFileName("$PROJECT_DIR$/src/main/java/org/lopashev/Test.java");


### PR DESCRIPTION
based on the problem description in: https://issues.jenkins.io/browse/JENKINS-70801
IdeaInspectionParser now uses the module-information from IDEA's output file. 

As the information is already present, it is not needed to 'calculate' the  module-information afterwards based on file-names and build descriptors.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
