### PR TITLE
Add support for Maven 3.9.x log messages

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/Issue.java
+++ b/src/main/java/edu/hm/hafner/analysis/Issue.java
@@ -932,7 +932,7 @@ public class Issue implements Serializable {
 
     @Override
     public String toString() {
-        return String.format("%s(%d,%d): %s: %s: %s", fileName, lineStart, columnStart, type, category, message);
+        return String.format("%s(%d,%d): %s: %s: %s", getBaseName(), lineStart, columnStart, type, category, message);
     }
 
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
@@ -22,7 +22,11 @@ public abstract class AbstractMavenLogParser extends LookaheadParser {
     private static final Pattern MAVEN_MODULE_START = Pattern.compile(
             "-+< (?<id>\\S+) >-+"
     );
-    static final String MAVEN_COMPILER_PLUGIN = "maven-compiler-plugin";
+    private static final String MAVEN_PLUGIN_PREFIX = "maven-";
+    private static final String MAVEN_PLUGIN_SUFFIX = "-plugin";
+    static final String MAVEN_COMPILER_PLUGIN = MAVEN_PLUGIN_PREFIX + "compiler" + MAVEN_PLUGIN_SUFFIX;
+    static final String MAVEN_JAVADOC_PLUGIN = MAVEN_PLUGIN_PREFIX + "javadoc" + MAVEN_PLUGIN_SUFFIX;
+    static final String MAVEN_ENFORCER_PLUGIN = MAVEN_PLUGIN_PREFIX + "enforcer" + MAVEN_PLUGIN_SUFFIX;
     private String goal = StringUtils.EMPTY;
     private String module = StringUtils.EMPTY;
 
@@ -60,5 +64,18 @@ public abstract class AbstractMavenLogParser extends LookaheadParser {
 
     boolean hasGoalOrModule() {
         return StringUtils.isNotBlank(goal) || StringUtils.isNotBlank(module);
+    }
+
+    protected boolean hasGoals(final String... goals) {
+        for (String searchGoal : goals) {
+            if (goal.contains(searchGoal)) {
+                return true;
+            }
+            if (goal.contains(StringUtils.removeEnd(
+                    StringUtils.removeStart(searchGoal, MAVEN_PLUGIN_PREFIX), MAVEN_PLUGIN_SUFFIX))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavaDocParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavaDocParser.java
@@ -33,7 +33,7 @@ public class JavaDocParser extends AbstractMavenLogParser {
     @Override
     protected boolean isLineInteresting(final String line) {
         return super.isLineInteresting(line)
-                && !getGoal().equals(MAVEN_COMPILER_PLUGIN)
+                && !hasGoals(MAVEN_COMPILER_PLUGIN)
                 && lineContainsKeywords(line);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -22,7 +22,7 @@ import static edu.hm.hafner.analysis.Categories.*;
 public class JavacParser extends AbstractMavenLogParser {
     private static final long serialVersionUID = 7199325311690082782L;
 
-    private static final String ERRORPRONE_URL_PATTERN = "\\s+\\(see https?://\\S+\\s*\\)";
+    private static final String ERROR_PRONE_URL_PATTERN = "\\s+\\(see https?://\\S+\\s*\\)";
 
     private static final String JAVAC_WARNING_PATTERN
             = "^(?:\\S+\\s+)?"                // optional preceding arbitrary number of characters that are not a
@@ -50,13 +50,14 @@ public class JavacParser extends AbstractMavenLogParser {
 
     @Override
     protected boolean isLineInteresting(final String line) {
-        return line.contains("[") || line.contains("w:") || line.contains("e:");
+        return (line.contains("[") || line.contains("w:") || line.contains("e:"))
+                && !hasGoals(MAVEN_JAVADOC_PLUGIN);
     }
 
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
             final IssueBuilder builder) throws ParsingException {
-        if (lookahead.hasNext(ERRORPRONE_URL_PATTERN)) {
+        if (lookahead.hasNext(ERROR_PRONE_URL_PATTERN)) {
             return Optional.empty();
         }
 

--- a/src/test/java/edu/hm/hafner/analysis/IssueTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/IssueTest.java
@@ -321,21 +321,6 @@ class IssueTest extends SerializableTest<Issue> {
     }
 
     @Test
-    void testToString() {
-        Issue issue = createFilledIssue();
-
-        try (SoftAssertions softly = new SoftAssertions()) {
-            softly.assertThat(issue.toString())
-                    .contains(FILE_NAME)
-                    .contains(Integer.toString(LINE_START))
-                    .contains(Integer.toString(COLUMN_START))
-                    .contains(CATEGORY)
-                    .contains(TYPE)
-                    .contains(MESSAGE);
-        }
-    }
-
-    @Test
     void shouldObeyEqualsContract() {
         LineRangeList filled = new LineRangeList(15);
         filled.add(new LineRange(15));

--- a/src/test/java/edu/hm/hafner/analysis/parser/AntJavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AntJavacParserTest.java
@@ -23,6 +23,13 @@ class AntJavacParserTest extends AbstractParserTest {
         super("ant-javac.txt");
     }
 
+    @Test
+    void issue67521IgnoreJavaDocWarnings() {
+        Report warnings = parse("javadoc-in-java.log");
+
+        assertThat(warnings).isEmpty();
+    }
+
     /**
      * Parses a warning log with a very long line that will take several seconds to parse.
      *

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavaDocParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavaDocParserTest.java
@@ -43,11 +43,30 @@ class JavaDocParserTest extends AbstractParserTest {
         return new JavaDocParser();
     }
 
+    @Test
+    void issue67521IgnoreJavaDocWarnings() {
+        Report warnings = parse("javadoc-in-java.log");
+
+        assertThat(warnings).hasSize(12);
+    }
+
+    @Test
+    void issue70658RemovePrefixAndSuffixFromMavenPlugins() {
+        Report warnings = parse("maven.3.9.1.log");
+        assertThat(warnings).hasSize(1);
+
+        assertThat(warnings.get(0))
+                .hasFileName("/Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/Ensure.java")
+                .hasLineStart(57)
+                .hasMessage("@param \"value\" has already been specified")
+                .hasSeverity(Severity.WARNING_NORMAL);
+    }
+
     /**
      * Parses a warning log with JavaDoc 1.8 warnings.
      */
     @Test
-    void shouldHaveACategory() {
+    void shouldHaveCategory() {
         Report warnings = parse("javadoc-category.txt");
 
         assertThat(warnings).hasSize(4);

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -28,6 +28,20 @@ class JavacParserTest extends AbstractParserTest {
         return new JavacParser();
     }
 
+    @Test
+    void issue70658RemovePrefixAndSuffixFromMavenPlugins() {
+        Report warnings = parse("maven.3.9.1.log");
+
+        assertThat(warnings).hasSize(1);
+    }
+
+    @Test
+    void issue67521IgnoreJavaDocWarnings() {
+        Report warnings = parse("javadoc-in-java.log");
+
+        assertThat(warnings).isEmpty();
+    }
+
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
         assertThat(report).hasSize(2);

--- a/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
@@ -26,6 +26,13 @@ class MavenConsoleParserTest extends AbstractParserTest {
     }
 
     @Test
+    void issue70658RemovePrefixAndSuffixFromMavenPlugins() {
+        Report warnings = parse("maven.3.9.1.log");
+
+        assertThat(warnings).hasSize(2);
+    }
+
+    @Test
     void shouldAssignTypesFromGoals() {
         Report warnings = parse("maven-goals.log");
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/javadoc-in-java.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/javadoc-in-java.log
@@ -1,0 +1,110 @@
+[INFO] --- maven-javadoc-plugin:3.3.1:jar (default-cli) @ foo-app ---
+[INFO] No previous run data found, generating javadoc.
+[WARNING] Javadoc Warnings
+[WARNING] Loading source files for package foo.app...
+[WARNING] Constructing Javadoc information...
+[WARNING] Building index for all the packages and classes...
+[WARNING] Standard Doclet version 17.0.1+12-LTS
+[WARNING] Building tree for all the packages and classes...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/ApplicationSettings.html...
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:38: warning: no comment
+[WARNING] public static class ServiceDetails
+[WARNING] ^
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/ApplicationSettings.ServiceDetails.html...
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:83: warning: no comment
+[WARNING] public enum Stage
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:88: warning: no comment
+[WARNING] public enum VersionCheck
+[WARNING] ^
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/ApplicationSettings.ServiceDetails.Stage.html...
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/ApplicationSettings.java:85: warning: no comment
+[WARNING] AN, EW, TE, TI, VP, VP2, PA, BT, PR, M1B, ED, MA
+[WARNING] ^
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/ApplicationSettings.ServiceDetails.VersionCheck.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/Application.html...
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/Application.java:14: warning: no comment
+[WARNING] public static void main(String... args)
+[WARNING] ^
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/AppController.html...
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/AppController.java:36: warning: no comment
+[WARNING] public AppController(final ApplicationSettings settings, final StatusResolver resolver)
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/AppController.java:43: warning: no comment
+[WARNING] public Mono<Rendering> index()
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/AppController.java:109: warning: no comment
+[WARNING] public Mono<ResponseEntity<StatusData>> serviceStatus(@PathVariable String mandant, @PathVariable String stage, @PathVariable String serviceId)
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/AppController.java:56: warning: no comment
+[WARNING] public Mono<Rendering> stages(@PathVariable String mandant)
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/AppController.java:82: warning: no comment
+[WARNING] public Mono<Rendering> status(@PathVariable String mandant, @PathVariable String stage)
+[WARNING] ^
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/StatusData.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/StatusResolver.html...
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/StatusResolver.java:35: warning: no comment
+[WARNING] public List<StatusData> getServiceResults(@NonNull final List<ApplicationSettings.ServiceDetails> services)
+[WARNING] ^
+[WARNING] /home/jenkins/workspace/foo-job/foo-app/src/main/java/foo/app/StatusResolver.java:40: warning: no comment
+[WARNING] public StatusData resolveStatus(final ApplicationSettings.ServiceDetails service)
+[WARNING] ^
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/WebConfig.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/package-summary.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/package-tree.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/WebConfig.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/StatusResolver.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/StatusData.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/AppController.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/Application.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/ApplicationSettings.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/ApplicationSettings.ServiceDetails.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/ApplicationSettings.ServiceDetails.VersionCheck.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/class-use/ApplicationSettings.ServiceDetails.Stage.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/foo/app/package-use.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/overview-tree.html...
+[WARNING] Building index for all classes...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/allclasses-index.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/allpackages-index.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/index-all.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/index.html...
+[WARNING] Generating /home/jenkins/workspace/foo-job/foo-app/target/apidocs/help-doc.html...
+[WARNING] 23 warnings
+[INFO] Building jar: /home/jenkins/workspace/foo-job/foo-app/target/foo-app-2.3.6-SNAPSHOT-javadoc.jar
+
+Fake: from javac
+[WARNING] /Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/Ensure.java:[107,64] [AvoidObjectArrays] Avoid accepting a Object[]; consider an Iterable<Object> instead

--- a/src/test/resources/edu/hm/hafner/analysis/parser/maven.3.9.1.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/maven.3.9.1.log
@@ -1,0 +1,62 @@
+[INFO] Scanning for projects...
+[INFO] Inspecting build with total of 1 modules...
+[INFO] Installing Nexus Staging features:
+[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
+[WARNING] The requested profile "no-ui-tests-on-mac" could not be activated because it does not exist.
+[WARNING] The requested profile "ui-tests-locally" could not be activated because it does not exist.
+[INFO]
+[INFO] ---------------------< edu.hm.hafner:codingstyle >----------------------
+[INFO] Building Java coding style 3.16.0-SNAPSHOT
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO]
+[INFO] --- compiler:3.11.0:compile (default-compile) @ codingstyle ---
+[INFO] Changes detected - recompiling the module! :source
+[INFO] Compiling 13 source files with javac [forked debug release 11 module-path] to target/classes
+[WARNING] /Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/Ensure.java:[107,64] [AvoidObjectArrays] Avoid accepting a Object[]; consider an Iterable<Object> instead
+    (see https://errorprone.info/bugpattern/AvoidObjectArrays)
+[WARNING] /Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/Ensure.java:[359,56] [AvoidObjectArrays] Avoid accepting a Object[]; consider an Iterable<Object> instead
+[INFO]
+[INFO] --- assertj:2.2.0:generate-assertions (default) @ codingstyle ---
+[INFO]
+[INFO] --- resources:3.3.1:testResources (default-testResources) @ codingstyle ---
+[INFO] Copying 4 resources from src/test/resources to target/test-classes
+[INFO]
+[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ codingstyle ---
+[INFO] Changes detected - recompiling the module! :dependency
+[INFO] Compiling 32 source files with javac [forked debug release 11 module-path] to target/test-classes
+[WARNING] /Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/test/java/edu/hm/hafner/util/ArchitectureRulesTest.java:[156,13] [DoNotCallSuggester] Methods that always throw an exception should be annotated with @DoNotCall to prevent calls at compilation time vs. at runtime (note that adding @DoNotCall will break any existing callers of this API).
+    (see https://errorprone.info/bugpattern/DoNotCallSuggester)
+  Did you mean '@DoNotCall("Always throws java.lang.IllegalArgumentException") @Test'?
+[INFO]
+[INFO] --- javadoc:3.5.0:javadoc (default-cli) @ codingstyle ---
+[INFO] Configuration changed, re-generating javadoc.
+[WARNING] Javadoc Warnings
+[WARNING] /Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/src/main/java/edu/hm/hafner/util/Ensure.java:57: warning: @param "value" has already been specified
+[WARNING] * @param value
+[WARNING] ^
+[WARNING] 1 warning
+[[INFO] >>> source:3.2.1:jar (attach-sources) > generate-sources @ codingstyle >>>
+[INFO]
+[INFO] --- enforcer:3.3.0:enforce (enforce-java) @ codingstyle ---
+[INFO] --- revapi:0.15.0:check (run-revapi) @ codingstyle ---
+Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/edu/hm/hafner/codingstyle/maven-metadata.xml
+Progress (1): 0.5/2.5 kB
+Progress (1): 1.9/2.5 kB
+Progress (1): 2.5 kB
+
+Downloaded from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/edu/hm/hafner/codingstyle/maven-metadata.xml (2.5 kB at 2.3 kB/s)
+[INFO] Comparing [edu.hm.hafner:codingstyle:jar:3.15.0] against [edu.hm.hafner:codingstyle:jar:3.16.0-SNAPSHOT] (including their transitive dependencies).
+[INFO] API checks completed without failures.
+[INFO]
+[INFO] --- jacoco:0.8.9:report (report) @ codingstyle ---
+[INFO] Loading execution data file /Users/hafner/git/warnings-ng-plugin-devenv/codingstyle/target/jacoco.exec
+[INFO] Analyzed bundle 'Java coding style' with 21 classes
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  40.152 s
+[INFO] Finished at: 2023-05-04T12:34:26+02:00
+[INFO] ------------------------------------------------------------------------
+[WARNING] The requested profile "no-ui-tests-on-mac" could not be activated because it does not exist.
+[WARNING] The requested profile "ui-tests-locally" could not be activated because it does not exist.


### PR DESCRIPTION
Since maven 3.9.0 log messages that log a plugin name in the style `maven-compiler-plugin` are now abbreviated with `compiler`. This PR allows both formats. Additionally, the parser has been improved so that JavaDoc warnings are skipped for the Java parser, and vice versa.

Fixes:
- https://issues.jenkins.io/browse/JENKINS-70658
- https://issues.jenkins.io/browse/JENKINS-67521
- https://issues.jenkins.io/browse/JENKINS-63346

Supersedes:
- #900
- #897 