### PR TITLE
Remap Aqua scanner severities

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AquaScannerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AquaScannerParser.java
@@ -70,10 +70,10 @@ public class AquaScannerParser extends JsonIssueParser {
         if (StringUtils.containsAnyIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_LOW, AQUA_VULNERABILITY_LEVEL_TAG_NEGLIGIBLE)) {
             return Severity.WARNING_LOW;
         }
-        else if (StringUtils.containsAnyIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_MEDIUM)) {
+        else if (StringUtils.equalsIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_MEDIUM)) {
             return Severity.WARNING_NORMAL;
         }
-        else if (StringUtils.containsAnyIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_HIGH)) {
+        else if (StringUtils.equalsIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_HIGH)) {
             return Severity.WARNING_HIGH;
         }
         else {

--- a/src/main/java/edu/hm/hafner/analysis/parser/AquaScannerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AquaScannerParser.java
@@ -18,9 +18,6 @@ import static j2html.TagCreator.*;
  */
 public class AquaScannerParser extends JsonIssueParser {
     private static final String VALUE_NOT_SET = "-";
-    private static final String AQUA_VULNERABILITY_LEVEL_TAG_SENSITIVE = "sensitive";
-    private static final String AQUA_VULNERABILITY_LEVEL_TAG_MALWARE = "malware";
-    private static final String AQUA_VULNERABILITY_LEVEL_TAG_CRITICAL = "critical";
     private static final String AQUA_VULNERABILITY_LEVEL_TAG_HIGH = "high";
     private static final String AQUA_VULNERABILITY_LEVEL_TAG_MEDIUM = "medium";
     private static final String AQUA_VULNERABILITY_LEVEL_TAG_LOW = "low";
@@ -76,12 +73,11 @@ public class AquaScannerParser extends JsonIssueParser {
         else if (StringUtils.containsAnyIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_MEDIUM)) {
             return Severity.WARNING_NORMAL;
         }
-        else if (StringUtils.containsAnyIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_HIGH, AQUA_VULNERABILITY_LEVEL_TAG_CRITICAL,
-                AQUA_VULNERABILITY_LEVEL_TAG_MALWARE, AQUA_VULNERABILITY_LEVEL_TAG_SENSITIVE)) {
+        else if (StringUtils.containsAnyIgnoreCase(string, AQUA_VULNERABILITY_LEVEL_TAG_HIGH)) {
             return Severity.WARNING_HIGH;
         }
         else {
-            return Severity.WARNING_HIGH;
+            return Severity.ERROR;
         }
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/AquaScannerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AquaScannerParserTest.java
@@ -35,15 +35,15 @@ class AquaScannerParserTest extends AbstractParserTest {
                 .hasFileName(EXPECTED_FILENAME)
                 .hasMessage("CVE-1111-1234");
         softly.assertThat(report.get(9))
-                .hasSeverity(Severity.WARNING_HIGH)
+                .hasSeverity(Severity.ERROR)
                 .hasFileName(EXPECTED_FILENAME)
                 .hasMessage("CVE-1112-1234");
         softly.assertThat(report.get(10))
-                .hasSeverity(Severity.WARNING_HIGH)
+                .hasSeverity(Severity.ERROR)
                 .hasFileName(EXPECTED_FILENAME)
                 .hasMessage("CVE-1113-1234");
         softly.assertThat(report.get(11))
-                .hasSeverity(Severity.WARNING_HIGH)
+                .hasSeverity(Severity.ERROR)
                 .hasFileName(EXPECTED_FILENAME)
                 .hasMessage("CVE-1114-1234");
         softly.assertThat(report.get(12))
@@ -51,7 +51,7 @@ class AquaScannerParserTest extends AbstractParserTest {
                 .hasFileName(EXPECTED_FILENAME)
                 .hasMessage("CVE-1115-1234");
         softly.assertThat(report.get(13))
-                .hasSeverity(Severity.WARNING_HIGH)
+                .hasSeverity(Severity.ERROR)
                 .hasFileName(EXPECTED_FILENAME)
                 .hasMessage("CVE-1116-1234");
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR introduces severity remapping for Aqua scanner as severities became inconsistent with Trivy scanner severities following [this pr](https://github.com/jenkinsci/analysis-model/pull/823).

Note that Aqua has additional severities like malware and sensitive (exposed credentials) which are now mapped to ERROR severity as I think that they need to be distinguished in a similar way as critical severity. 

Old mapping:
 -   Critical -> High
 -   Malware -> High
 -   Sensitive -> High
 -   High -> High
 -   Medium -> Normal
 -   Low -> Low
 -   Negligible -> Low

New mapping
 -   Critical -> Error
 -   Malware -> Error
 -   Sensitive -> Error
 -   High -> High
 -   Medium -> Normal
 -   Low -> Low
 -   Negligible -> Low


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
