### PR TITLE
Fix kotlin 1.8 warnings not detected

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
@@ -26,7 +26,7 @@ public abstract class AbstractMavenLogParser extends LookaheadParser {
     private static final String MAVEN_PLUGIN_SUFFIX = "-plugin";
     static final String MAVEN_COMPILER_PLUGIN = MAVEN_PLUGIN_PREFIX + "compiler" + MAVEN_PLUGIN_SUFFIX;
     static final String MAVEN_JAVADOC_PLUGIN = MAVEN_PLUGIN_PREFIX + "javadoc" + MAVEN_PLUGIN_SUFFIX;
-        static final String MAVEN_HPI_PLUGIN = MAVEN_PLUGIN_PREFIX + "hpi" + MAVEN_PLUGIN_SUFFIX;
+    static final String MAVEN_HPI_PLUGIN = MAVEN_PLUGIN_PREFIX + "hpi" + MAVEN_PLUGIN_SUFFIX;
     static final String MAVEN_ENFORCER_PLUGIN = MAVEN_PLUGIN_PREFIX + "enforcer" + MAVEN_PLUGIN_SUFFIX;
     private String goal = StringUtils.EMPTY;
     private String module = StringUtils.EMPTY;

--- a/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
@@ -26,6 +26,7 @@ public abstract class AbstractMavenLogParser extends LookaheadParser {
     private static final String MAVEN_PLUGIN_SUFFIX = "-plugin";
     static final String MAVEN_COMPILER_PLUGIN = MAVEN_PLUGIN_PREFIX + "compiler" + MAVEN_PLUGIN_SUFFIX;
     static final String MAVEN_JAVADOC_PLUGIN = MAVEN_PLUGIN_PREFIX + "javadoc" + MAVEN_PLUGIN_SUFFIX;
+        static final String MAVEN_HPI_PLUGIN = MAVEN_PLUGIN_PREFIX + "hpi" + MAVEN_PLUGIN_SUFFIX;
     static final String MAVEN_ENFORCER_PLUGIN = MAVEN_PLUGIN_PREFIX + "enforcer" + MAVEN_PLUGIN_SUFFIX;
     private String goal = StringUtils.EMPTY;
     private String module = StringUtils.EMPTY;

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -29,13 +29,17 @@ public class JavacParser extends AbstractMavenLogParser {
                                               // whitespace followed by whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:|e:)\\s+)" // optional [WARNING] or [ERROR] or w: or e:
             + "([^\\[\\(]*):\\s*"             // group 1: filename
+            + "("                             // group 2: enclose matching group
+            + "("                             // enclose java and kotlin < 1.8 style
             + "[\\[\\(]"                      // [ or (
-            + "(\\d+)[.,;]*"                  // group 2: line number
-            + "\\s?(\\d+)?"                   // group 3: optional column
+            + "(\\d+)[.,;]*"                  // line number
+            + "\\s?(\\d+)?"                   // optional column
             + "[\\]\\)]\\s*"                  // ] or )
-            + ":?"                            // optional :
-            + "(?:\\[(\\w+)\\])?"             // group 4: optional category
-            + "\\s*(.*)$";                    // group 5: message
+            + ")"                             // close java and old kotlin style
+            + "|(\\d+:\\d+)"                  // match kotlin 1.8 style line number : column number
+            + ")"                             // close matching group
+            + "(?:\\[(\\w+)\\])?"             // group 3: optional category
+            + "\\s*(.*)$";                    // group 4: message
 
     private static final String SEVERITY_ERROR = "ERROR";
     private static final String SEVERITY_ERROR_SHORT = "e:";

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -29,17 +29,13 @@ public class JavacParser extends AbstractMavenLogParser {
                                               // whitespace followed by whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:|e:)\\s+)" // optional [WARNING] or [ERROR] or w: or e:
             + "([^\\[\\(]*):\\s*"             // group 1: filename
-            + "("                             // group 2: enclose matching group
-            + "("                             // enclose java and kotlin < 1.8 style
-            + "[\\[\\(]"                      // [ or (
-            + "(\\d+)[.,;]*"                  // line number
-            + "\\s?(\\d+)?"                   // optional column
-            + "[\\]\\)]\\s*"                  // ] or )
-            + ")"                             // close java and old kotlin style
-            + "|(\\d+:\\d+)"                  // match kotlin 1.8 style line number : column number
-            + ")"                             // close matching group
-            + "(?:\\[(\\w+)\\])?"             // group 3: optional category
-            + "\\s*(.*)$";                    // group 4: message
+            + "[\\[\\(]?"                      // [ or ( or nothing
+            + "(\\d+)[.,;]?"                  // group 2: line number
+            + "\\s?(\\d+)?"                   // group 3: optional column
+            + "[\\]\\)]?\\s*"                  // ] or ) or nothing
+            + ":?"                            // optional :
+            + "(?:\\[(\\w+)\\])?"             // group 4: optional category
+            + "\\s*(.*)$";                    // group 5: message
 
     private static final String SEVERITY_ERROR = "ERROR";
     private static final String SEVERITY_ERROR_SHORT = "e:";
@@ -55,7 +51,7 @@ public class JavacParser extends AbstractMavenLogParser {
     @Override
     protected boolean isLineInteresting(final String line) {
         return (line.contains("[") || line.contains("w:") || line.contains("e:"))
-                && !hasGoals(MAVEN_JAVADOC_PLUGIN);
+                && !hasGoals(MAVEN_JAVADOC_PLUGIN, MAVEN_HPI_PLUGIN);
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -25,17 +25,19 @@ public class JavacParser extends AbstractMavenLogParser {
     private static final String ERROR_PRONE_URL_PATTERN = "\\s+\\(see https?://\\S+\\s*\\)";
 
     private static final String JAVAC_WARNING_PATTERN
-            = "^(?:\\S+\\s+)?"                // optional preceding arbitrary number of characters that are not a
-                                              // whitespace followed by whitespace. This can be used for timestamps.
+            = "^(?:\\S+\\s+)?"                          // optional preceding arbitrary number of characters that are not a
+                                                        // whitespace followed by whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:|e:)\\s+)" // optional [WARNING] or [ERROR] or w: or e:
-            + "([^\\[\\(]*):\\s*"             // group 1: filename
-            + "[\\[\\(]?"                      // [ or ( or nothing
-            + "(\\d+)[.,;]?"                  // group 2: line number
-            + "\\s?(\\d+)?"                   // group 3: optional column
-            + "[\\]\\)]?\\s*"                  // ] or ) or nothing
-            + ":?"                            // optional :
-            + "(?:\\[(\\w+)\\])?"             // group 4: optional category
-            + "\\s*(.*)$";                    // group 5: message
+            + "(((\\/?[a-zA-Z]|file):)?[^\\[\\(:]*):"   // group 2: filename starting path with C:\ or /C:\ or file:/// or /
+            + "("                                       // start group 5
+            + "(\\s*[\\[\\(]?)?"                        // optional ( or [
+            + "(\\d+)"                                  // group 7 line
+            + "[.,;]?\\s?:?"                            // separator
+            + "(\\d+)?"                                 // group 8 column
+            + "[\\]\\)]?\\s*:?\\s?"                     // optional ) or ] or whitespace or :
+            + ")"                                       // end group 5
+            + "(?:\\[(\\w+)\\])?"                       // group 9: optional category
+            + "\\s*(.*)$";                              // group 10: message
 
     private static final String SEVERITY_ERROR = "ERROR";
     private static final String SEVERITY_ERROR_SHORT = "e:";
@@ -69,14 +71,14 @@ public class JavacParser extends AbstractMavenLogParser {
             builder.setSeverity(Severity.WARNING_NORMAL);
         }
 
-        String message = matcher.group(6);
-        String category = guessCategoryIfEmpty(matcher.group(5), message);
+        String message = matcher.group(10);
+        String category = guessCategoryIfEmpty(matcher.group(9), message);
 
         // get rid of leading / from windows compiler output JENKINS-66738
         return builder.setFileName(RegExUtils.replaceAll(matcher.group(2), "^/([a-zA-Z]):", "$1:"))
-                .setLineStart(matcher.group(3))
+                .setLineStart(matcher.group(7))
                 .setType(StringUtils.defaultString(getGoal(), DEFAULT_GOAL))
-                .setColumnStart(matcher.group(4))
+                .setColumnStart(matcher.group(8))
                 .setCategory(category)
                 .setMessage(message)
                 .buildOptional();

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -308,14 +308,39 @@ class JavacParserTest extends AbstractParserTest {
     void kotlin18WarningStyle() {
         Report warnings = parse("kotlin-1_8.txt");
 
-        assertThat(warnings).hasSize(2);
+        assertThat(warnings).hasSize(7);
 
         assertThat(warnings.get(0)).hasSeverity(Severity.WARNING_NORMAL)
                 .hasLineStart(214)
-                .hasColumnStart(35);
+                .hasColumnStart(35)
+                .hasFileName("/project/app/src/main/java/ui/Activity.kt");
         assertThat(warnings.get(1)).hasSeverity(Severity.WARNING_NORMAL)
                 .hasLineStart(424)
-                .hasColumnStart(29);
+                .hasColumnStart(29)
+                .hasFileName("/project/app/src/main/java/ui/Activity.kt");
+        assertThat(warnings.get(2)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(425)
+                .hasColumnStart(29)
+                .hasFileName("/project/app/src/main/java/ui/Activity.kt")
+                .hasCategory("Deprecation")
+                .hasMessage("deprecated: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */");
+        assertThat(warnings.get(3)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(424)
+                .hasColumnStart(29)
+                .hasFileName("/project/app/src/main/java/ui/Activity.kt");
+        assertThat(warnings.get(4)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(123)
+                .hasColumnStart(456);
+        assertThat(warnings.get(5)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(426)
+                .hasColumnStart(29)
+                .hasMessage("Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */");
+        assertThat(warnings.get(6)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(8)
+                .hasColumnStart(27)
+                .hasCategory("Deprecation")
+                .hasFileName("file:///project/src/main/java/com/app/ui/model/Activity.kt")
+                .hasMessage("'PackageStats' is deprecated. Deprecated in Java");
     }
 }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -309,6 +309,13 @@ class JavacParserTest extends AbstractParserTest {
         Report warnings = parse("kotlin-1_8.txt");
 
         assertThat(warnings).hasSize(2);
+
+        assertThat(warnings.get(0)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(214)
+                .hasColumnStart(35);
+        assertThat(warnings.get(1)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(424)
+                .hasColumnStart(29);
     }
 }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -299,5 +299,16 @@ class JavacParserTest extends AbstractParserTest {
                 .hasLineStart(194)
                 .hasFileName("/home/runner/work/warnings-ng-plugin/warnings-ng-plugin/plugin/target/generated-test-sources/assertj-assertions/io/jenkins/plugins/analysis/core/assertions/Assertions.java");
     }
+
+     /**
+     * Parses a warning log written by Gradle containing 2 Kotlin warnings.
+     * One in kotlin 1.8 style and the other one in the old style.
+     */
+    @Test
+    void kotlin18WarningStyle() {
+        Report warnings = parse("kotlin-1_8.txt");
+
+        assertThat(warnings).hasSize(2);
+    }
 }
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-1_8.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-1_8.txt
@@ -6,3 +6,8 @@ registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollec
 app: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.android.databinding:compiler:3.0.1'.
 w: /project/app/src/main/java/ui/Activity.kt: (214, 35): Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
 w: /project/app/src/main/java/ui/Activity.kt:424:29 Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+e: /project/app/src/main/java/ui/Activity.kt:425:29 deprecated: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: /project/app/src/main/java/ui/Activity.kt:424:29 Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: /project/app/src/main/java/ui/Activity.kt:123:456 Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: c:\project\app\src\main\java\ui\Activity.kt:426:29 Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: file:///project/src/main/java/com/app/ui/model/Activity.kt:8:27 'PackageStats' is deprecated. Deprecated in Java

--- a/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-1_8.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-1_8.txt
@@ -1,0 +1,8 @@
+> Configure project :app
+Configuration 'compile' in project ':app' is deprecated. Use 'implementation' instead.
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+app: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.android.databinding:compiler:3.0.1'.
+w: /project/app/src/main/java/ui/Activity.kt: (214, 35): Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: /project/app/src/main/java/ui/Activity.kt:424:29 Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */


### PR DESCRIPTION
with kotlin 1.8 they changed the compile warnings style.
Old style `<package-name><filename>.kt: (line,column)`
new style `<package-name><filename>.kt:line:column`
to archive this we need to make the `(`, `)˙ and `[`, `]` optional as well ad a new separator `:` 

### Testing done

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
