### PR TITLE
Changed id of grype parser: from grypescanner to grype

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -1,4 +1,4 @@
-<!--- DO NOT EDIT -- Generated at 2023-07-26T22:22:13.878391 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
+<!--- DO NOT EDIT -- Generated at 2023-07-30T22:54:43.181363 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
 # Supported Report Formats
 
 The static analysis model supports the following report formats.
@@ -940,14 +940,14 @@ If your tool is supported, but some properties are missing (icon, URL, etc.), pl
         </tr>
         <tr>
             <td>
-                grypescanner
+                grype
             </td>
             <td>
-                <img src="https://user-images.githubusercontent.com/5199289/136855393-d0a9eef9-ccf1-4e2b-9d7c-7aad16a567e5.png" alt="Grype scanner" height="64" width="64">
+                <img src="https://user-images.githubusercontent.com/5199289/136855393-d0a9eef9-ccf1-4e2b-9d7c-7aad16a567e5.png" alt="Grype" height="64" width="64">
             </td>
             <td>
                 <a href="https://github.com/anchore/grype">
-                    Grype scanner
+                    Grype
                 </a>
             </td>
             <td>

--- a/src/main/java/edu/hm/hafner/analysis/registry/GrypeDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GrypeDescriptor.java
@@ -7,8 +7,8 @@ import edu.hm.hafner.analysis.parser.GrypeParser;
  * Descriptor for Grype report parser.
  */
 public class GrypeDescriptor extends ParserDescriptor {
-    private static final String ID = "grypescanner";
-    private static final String NAME = "Grype scanner";
+    private static final String ID = "grype";
+    private static final String NAME = "Grype";
 
     GrypeDescriptor() {
         super(ID, NAME);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Changed id, as suggested in comment here: [warnings-ng-plugin/pull/1563](https://github.com/jenkinsci/warnings-ng-plugin/pull/1563)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
