### PR TITLE
Add parser for CCES (CrossCore Embedded Studio)

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -1,4 +1,4 @@
-<!--- DO NOT EDIT -- Generated at 2023-07-20T18:42:19.715720048 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
+<!--- DO NOT EDIT -- Generated at 2023-08-01T11:30:25.603198 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
 # Supported Report Formats
 
 The static analysis model supports the following report formats.
@@ -515,6 +515,22 @@ If your tool is supported, but some properties are missing (icon, URL, etc.), pl
         <tr>
             <td colspan="4">
                 :bulb: You need to use the Eclipse format with the option <code>--output=eclipse</code>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                crosscore-embedded-studio
+            </td>
+            <td>
+                -
+            </td>
+            <td>
+                <a href="https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/adswt-cces.html">
+                    CrossCore Embedded Studio (CCES)
+                </a>
+            </td>
+            <td>
+                -
             </td>
         </tr>
         <tr>

--- a/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
@@ -38,10 +38,6 @@ public class CrossCoreEmbeddedStudioParser extends LookaheadParser {
         super(CCES_WARNING_PATTERN);
     }
 
-    CrossCoreEmbeddedStudioParser(final String pattern) {
-        super(pattern);
-    }
-
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
             final IssueBuilder builder) {

--- a/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
@@ -24,12 +24,7 @@ public class CrossCoreEmbeddedStudioParser extends LookaheadParser {
      *  - Errors are not parsed, only warnings
      */
     private static final String CCES_WARNING_PATTERN =
-            "^\"(.+?)\", line (\\d+).*(cc\\d+).*warning:(.*)";
-
-    private static final Integer MATCHER_FILE = 1;
-    private static final Integer MATCHER_LINE = 2;
-    private static final Integer MATCHER_CATEGORY = 3;
-    private static final Integer MATCHER_MESSAGE_BEGIN = 4;
+            "^\"(?<file>.+?)\", line (?<line>\\d+).*(?<category>cc\\d+).*warning:(?<messageBegin>.*)";
 
     /**
      * Creates a new instance of {@link CrossCoreEmbeddedStudioParser}.
@@ -42,7 +37,7 @@ public class CrossCoreEmbeddedStudioParser extends LookaheadParser {
     protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
             final IssueBuilder builder) {
 
-        StringBuilder message = new StringBuilder(matcher.group(MATCHER_MESSAGE_BEGIN).trim());
+        StringBuilder message = new StringBuilder(matcher.group("messageBegin").trim());
 
         // always grab the second line
         if (lookahead.hasNext()) {
@@ -50,10 +45,10 @@ public class CrossCoreEmbeddedStudioParser extends LookaheadParser {
             message.append(lookahead.next().trim());
         }
 
-        return builder.setFileName(matcher.group(MATCHER_FILE))
-                .setLineStart(matcher.group(MATCHER_LINE))
+        return builder.setFileName(matcher.group("file"))
+                .setLineStart(matcher.group("line"))
                 .setSeverity(Severity.WARNING_NORMAL)
-                .setCategory(matcher.group(MATCHER_CATEGORY))
+                .setCategory(matcher.group("category"))
                 .setMessage(message.toString())
                 .buildOptional();
     }

--- a/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
@@ -5,7 +5,6 @@ import java.util.regex.Matcher;
 
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.IssueBuilder;
-import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.LookaheadParser;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.LookaheadStream;

--- a/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
@@ -1,0 +1,71 @@
+package edu.hm.hafner.analysis.parser;
+
+
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.LookaheadParser;
+import edu.hm.hafner.analysis.ParsingException;
+import edu.hm.hafner.analysis.ReaderFactory;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.util.LookaheadStream;
+
+/**
+ * A parser for the CrossCoreEmbeddedStudio (CCES) log files.
+ */
+public class CrossCoreEmbeddedStudioParser extends LookaheadParser {
+    private static final long serialVersionUID = 5490211629355204910L;
+
+    /* Regex to match the CCES warnings.
+     *
+     * Details:
+     *  - See below the MATCHER_* ids to ease their retrieval.
+     *  - Potential columns are ignored
+     *  - Assume warnings description are always spread over two lines (what was observed so far)
+     *  - Errors are not parsed, only warnings
+     */
+    private static final String CCES_WARNING_PATTERN =
+        "^\"(.+?)\", line (\\d+).*(cc\\d+).*warning:(.*)";
+
+    private static final Integer MATCHER_FILE = 1;
+    private static final Integer MATCHER_LINE = 2;
+    private static final Integer MATCHER_CATEGORY = 3;
+    private static final Integer MATCHER_MESSAGE_BEGIN = 4;
+
+    public CrossCoreEmbeddedStudioParser() {
+        super(CCES_WARNING_PATTERN);
+    }
+
+    CrossCoreEmbeddedStudioParser(final String pattern) {
+        super(pattern);
+    }
+
+    @Override
+    protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
+            final IssueBuilder builder) {
+
+        StringBuilder message = new StringBuilder(matcher.group(MATCHER_MESSAGE_BEGIN).trim());
+
+        // always grab the second line
+        if (lookahead.hasNext()) {
+            message.append(" ");
+            message.append(lookahead.next().trim());
+        }
+
+        return builder.setFileName(matcher.group(MATCHER_FILE))
+                .setLineStart(matcher.group(MATCHER_LINE))
+                .setSeverity(Severity.WARNING_NORMAL)
+                .setCategory(matcher.group(MATCHER_CATEGORY))
+                .setMessage(message.toString())
+                .buildOptional();
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
@@ -1,21 +1,12 @@
 package edu.hm.hafner.analysis.parser;
 
-
-import java.io.UncheckedIOException;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.LookaheadParser;
-import edu.hm.hafner.analysis.ParsingException;
-import edu.hm.hafner.analysis.ReaderFactory;
-import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.LookaheadStream;
 
@@ -34,13 +25,16 @@ public class CrossCoreEmbeddedStudioParser extends LookaheadParser {
      *  - Errors are not parsed, only warnings
      */
     private static final String CCES_WARNING_PATTERN =
-        "^\"(.+?)\", line (\\d+).*(cc\\d+).*warning:(.*)";
+            "^\"(.+?)\", line (\\d+).*(cc\\d+).*warning:(.*)";
 
     private static final Integer MATCHER_FILE = 1;
     private static final Integer MATCHER_LINE = 2;
     private static final Integer MATCHER_CATEGORY = 3;
     private static final Integer MATCHER_MESSAGE_BEGIN = 4;
 
+    /**
+     * Creates a new instance of {@link CrossCoreEmbeddedStudioParser}.
+     */
     public CrossCoreEmbeddedStudioParser() {
         super(CCES_WARNING_PATTERN);
     }

--- a/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParser.java
@@ -13,7 +13,7 @@ import edu.hm.hafner.util.LookaheadStream;
  * A parser for the CrossCoreEmbeddedStudio (CCES) log files.
  */
 public class CrossCoreEmbeddedStudioParser extends LookaheadParser {
-    private static final long serialVersionUID = 5490211629355204910L;
+    private static final long serialVersionUID = 1L;
 
     /* Regex to match the CCES warnings.
      *

--- a/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
@@ -1,0 +1,26 @@
+package edu.hm.hafner.analysis.registry;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.parser.CrossCoreEmbeddedStudioParser;
+
+/**
+ * A descriptor for CrossCore Embedded Studio from Analog Devices
+ */
+public class CrossCoreEmbeddedStudioDescriptor extends ParserDescriptor {
+    private static final String ID = "crosscore-embedded-studio";
+    private static final String NAME = "CrossCore Embedded Studio (CCES)";
+
+    CrossCoreEmbeddedStudioDescriptor() {
+        super(ID, NAME);
+    }
+
+    @Override
+    public IssueParser createParser(final Option... options) {
+        return new CrossCoreEmbeddedStudioParser();
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/adswt-cces.html";
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
@@ -4,7 +4,7 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.parser.CrossCoreEmbeddedStudioParser;
 
 /**
- * A descriptor for CrossCore Embedded Studio from Analog Devices
+ * A descriptor for CrossCore Embedded Studio from Analog Devices.
  */
 public class CrossCoreEmbeddedStudioDescriptor extends ParserDescriptor {
     private static final String ID = "crosscore-embedded-studio";

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -62,6 +62,7 @@ public class ParserRegistry {
             new CpdDescriptor(),
             new CppCheckDescriptor(),
             new CppLintDescriptor(),
+            new CrossCoreEmbeddedStudioDescriptor(),
             new CssLintDescriptor(),
             new DartAnalyzeDescriptor(),
             new DetektDescriptor(),

--- a/src/test/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParserTest.java
@@ -23,7 +23,6 @@ class CrossCoreEmbeddedStudioParserTest extends AbstractParserTest {
         // check all warnings were caught
         softly.assertThat(report).hasSize(6);
 
-
         // test in details the first warning
         softly.assertThat(report.get(0))
                 .hasFileName("src/dummy_1.c")
@@ -34,11 +33,10 @@ class CrossCoreEmbeddedStudioParserTest extends AbstractParserTest {
 
         // test in details the last warning, that has column (but not parsed)
         softly.assertThat(report.get(5))
-            .hasFileName("src/dummy_5.c")
-            .hasLineStart(125)
-            .hasSeverity(Severity.WARNING_NORMAL)
-            .hasCategory("cc1462")
-            .hasMessage("call to dummy_btc has not been inlined");
-
+                .hasFileName("src/dummy_5.c")
+                .hasLineStart(125)
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("cc1462")
+                .hasMessage("call to dummy_btc has not been inlined");
     }
 }

--- a/src/test/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/CrossCoreEmbeddedStudioParserTest.java
@@ -1,0 +1,44 @@
+package edu.hm.hafner.analysis.parser;
+
+import edu.hm.hafner.analysis.AbstractParserTest;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+
+/**
+ * Tests the class {@link CrossCoreEmbeddedStudioParser}.
+ */
+class CrossCoreEmbeddedStudioParserTest extends AbstractParserTest {
+    CrossCoreEmbeddedStudioParserTest() {
+        super("cces.log");
+    }
+
+    @Override
+    protected CrossCoreEmbeddedStudioParser createParser() {
+        return new CrossCoreEmbeddedStudioParser();
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        // check all warnings were caught
+        softly.assertThat(report).hasSize(6);
+
+
+        // test in details the first warning
+        softly.assertThat(report.get(0))
+                .hasFileName("src/dummy_1.c")
+                .hasLineStart(333)
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasCategory("cc0188")
+                .hasMessage("enumerated type mixed with another type");
+
+        // test in details the last warning, that has column (but not parsed)
+        softly.assertThat(report.get(5))
+            .hasFileName("src/dummy_5.c")
+            .hasLineStart(125)
+            .hasSeverity(Severity.WARNING_NORMAL)
+            .hasCategory("cc1462")
+            .hasMessage("call to dummy_btc has not been inlined");
+
+    }
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/cces.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/cces.log
@@ -1,0 +1,33 @@
+Building libdummy for toolchain sharc_21565...
+  CC      src/dummy_1.c
+"src/dummy_1.c", line 333: cc0188: {D} warning: 
+          enumerated type mixed with another type
+  		dummy_get();
+  		^
+
+"src/dummy_2.c", line 36: cc0188: {D} warning: enumerated type
+          mixed with another type
+  			dummy_get();
+  			^
+
+  CC      src/dummy_3.c
+"src/dummy_3.c", line 149: cc0111: {D} warning: statement is
+          unreachable
+  	break;
+  	^
+
+  CC      src/dummy_4.c
+"src/dummy_4.c", line 85: cc0188: {D} warning: enumerated type
+          mixed with another type
+  			dummy_get();
+  			^
+
+"src/dummy_4.c", line 295: cc0111: {D} warning: statement is
+          unreachable
+  	break;
+  	^
+
+  CC      src/dummy_5.c
+"src/dummy_5.c", line 125 (col. 22): cc1462: {D} warning: call to
+          dummy_btc has not been inlined
+


### PR DESCRIPTION
Add support for parsing compiler logs generated by CrossCore Embedded Studio.

### Notes

- Implementation inspired from `Gcc4CompilerParser.java` and `EmbeddedEngineerParser.java`
- Compiler errors are not parsed, only warnings. Could be improved in a second stage

### Testing done

- Added relatively extensive tests in `CrossCoreEmbeddedStudioParserTest.java` 

### See also

- https://github.com/jenkinsci/warnings-ng-plugin/pull/1566

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

#### Extra:
- [x] Update SUPPORTED-FORMATS.md.
Not clear to me how to  _"run `main` method of `ParserRegistry`"_. Where is the binary? (Note that my java level is extremely low)