### PR TITLE
[JENKINS-72011] Do not read from empty stream

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AbstractMavenLogParser.java
@@ -48,6 +48,9 @@ public abstract class AbstractMavenLogParser extends LookaheadParser {
         if (goalMatcher.find()) {
             goal = String.format("%s:%s", goalMatcher.group("id"), goalMatcher.group("goal"));
         }
+        else if (line.contains("[INFO] BUILD ")) {
+            goal = StringUtils.EMPTY; // reset goal after build
+        }
 
         Matcher moduleMatcher = MAVEN_MODULE_START.matcher(line);
         if (moduleMatcher.find()) {

--- a/src/main/java/edu/hm/hafner/analysis/parser/MavenConsoleParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MavenConsoleParser.java
@@ -76,7 +76,7 @@ public class MavenConsoleParser extends AbstractMavenLogParser {
             int length = StringUtils.length(timestamp);
 
             String continuation = "^(?:.*\\s|)\\[(INFO|WARNING|ERROR)";
-            while (!lookahead.hasNext(continuation)) {
+            while (lookahead.hasNext() && !lookahead.hasNext(continuation)) {
                 message.append('\n');
                 message.append(StringUtils.substring(lookahead.next(), length));
             }

--- a/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
@@ -27,9 +27,11 @@ class MavenConsoleParserTest extends AbstractParserTest {
 
     @Test
     void issue72011MavenEnforcerExceptionWhenEmpty() {
-        Report warnings = parse("issue72011.txt");
+        var report = parse("issue72011.txt");
+        assertThat(report).hasSize(1);
+        assertThat(report.get(0)).hasModuleName("-");
 
-        assertThat(warnings).isEmpty();
+        assertThat(parse("enforcer-empty.txt")).hasSize(1);
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MavenConsoleParserTest.java
@@ -26,6 +26,13 @@ class MavenConsoleParserTest extends AbstractParserTest {
     }
 
     @Test
+    void issue72011MavenEnforcerExceptionWhenEmpty() {
+        Report warnings = parse("issue72011.txt");
+
+        assertThat(warnings).isEmpty();
+    }
+
+    @Test
     void issue70658RemovePrefixAndSuffixFromMavenPlugins() {
         Report warnings = parse("maven.3.9.1.log");
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/enforcer-empty.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/enforcer-empty.txt
@@ -1,0 +1,2 @@
+[2023-09-13T11:34:06.033Z] [INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven) @ tframe-tgate-root ---
+[2023-09-13T11:34:06.033Z] [WARNING] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue72011.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue72011.txt
@@ -1,0 +1,15 @@
+[2023-09-13T11:34:06.033Z] [INFO]
+[2023-09-13T11:34:06.033Z] [INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven) @ tframe-tgate-root ---
+[2023-09-13T11:34:06.033Z] [INFO] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom
+[2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom (2.8 kB at 123 kB/s)
+[2023-09-13T11:34:06.033Z] [INFO] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.pom
+[2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.pom (4.1 kB at 295 kB/s)
+[2023-09-13T11:34:06.033Z] [INFO] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/commons-codec/commons-codec/1.12/commons-codec-1.12.pom
+[2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/commons-codec/commons-codec/1.12/commons-codec-1.12.pom (14 kB at 1.2 MB/s)
+[2023-09-13T11:34:06.033Z] [INFO] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.jar
+[2023-09-13T11:34:06.033Z] [INFO] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/commons-codec/commons-codec/1.12/commons-codec-1.12.jar
+[2023-09-13T11:34:06.033Z] [INFO] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.jar
+[2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.jar (12 kB at 585 kB/s)
+[2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.jar (107 kB at 5.1 MB/s)
+[2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/commons-codec/commons-codec/1.12/commons-codec-1.12.jar (340 kB at 12 MB/s)
+[2023-09-13T11:34:06.033Z] [INFO] ------------------------------------------------------------------------

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue72011.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue72011.txt
@@ -1,4 +1,3 @@
-[2023-09-13T11:34:06.033Z] [INFO]
 [2023-09-13T11:34:06.033Z] [INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven) @ tframe-tgate-root ---
 [2023-09-13T11:34:06.033Z] [INFO] Downloading from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom
 [2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-api/3.0.0-M3/enforcer-api-3.0.0-M3.pom (2.8 kB at 123 kB/s)
@@ -13,3 +12,16 @@
 [2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/org/apache/maven/enforcer/enforcer-rules/3.0.0-M3/enforcer-rules-3.0.0-M3.jar (107 kB at 5.1 MB/s)
 [2023-09-13T11:34:06.033Z] [INFO] Downloaded from magenta-mirror: https://bin.t-mobile.at/artifactory/maven/commons-codec/commons-codec/1.12/commons-codec-1.12.jar (340 kB at 12 MB/s)
 [2023-09-13T11:34:06.033Z] [INFO] ------------------------------------------------------------------------
+[2023-09-13T11:34:06.033Z] [INFO] Reactor Summary:
+[2023-09-13T11:34:06.033Z] [INFO]
+[2023-09-13T11:34:06.033Z] [INFO] webapi ............................................. SUCCESS [ 17.201 s]
+[2023-09-13T11:34:06.033Z] [INFO] oauth2 ............................................. SUCCESS [23:15 min]
+[2023-09-13T11:34:06.033Z] [INFO] tframe-tgate-root 23.09.19-SNAPSHOT ................ SUCCESS [  0.149 s]
+[2023-09-13T11:34:06.033Z] [INFO] ------------------------------------------------------------------------
+[2023-09-13T11:34:06.033Z] [INFO] BUILD SUCCESS
+[2023-09-13T11:34:06.033Z] [INFO] ------------------------------------------------------------------------
+[2023-09-13T11:34:06.033Z] [INFO] Total time: 23:34 min
+[2023-09-13T11:34:06.033Z] [INFO] Finished at: 2023-09-13T11:34:06Z
+[2023-09-13T11:34:06.033Z] [INFO] ------------------------------------------------------------------------
+[2023-09-13T11:34:06.033Z] [WARNING] The requested profile "with-jacoco" could not be activated because it does not exist.
+[Pipeline] }


### PR DESCRIPTION
Add a guard before reading additional info messages to the buffer.

See [JENKINS-72011](https://issues.jenkins.io/browse/JENKINS-72011) for details.