### PR TITLE
Parse grype report without description

### DIFF
--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -1,4 +1,4 @@
-<!--- DO NOT EDIT -- Generated at 2023-09-20T10:55:02.107301 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
+<!--- DO NOT EDIT -- Generated at 2023-10-18T13:51:54.758873600 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
 # Supported Report Formats
 
 The static analysis model supports the following report formats.

--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -1,0 +1,93 @@
+@startuml
+skinparam defaultTextAlignment center
+skinparam rectangle {
+  BackgroundColor<<optional>> beige
+  BackgroundColor<<test>> lightGreen
+  BackgroundColor<<runtime>> lightBlue
+  BackgroundColor<<provided>> lightGray
+}
+rectangle "analysis-model\n\n11.11.0-SNAPSHOT" as edu_hm_hafner_analysis_model_jar
+rectangle "jsoup\n\n1.16.1" as org_jsoup_jsoup_jar
+rectangle "commons-io\n\n2.11.0" as commons_io_commons_io_jar
+rectangle "commons-digester3\n\n3.2" as org_apache_commons_commons_digester3_jar
+rectangle "cglib\n\n2.2.2" as cglib_cglib_jar
+rectangle "commons-logging\n\n1.1.1" as commons_logging_commons_logging_jar
+rectangle "commons-beanutils\n\n1.9.4" as commons_beanutils_commons_beanutils_jar
+rectangle "commons-collections\n\n3.2.2" as commons_collections_commons_collections_jar
+rectangle "commons-text\n\n1.10.0" as org_apache_commons_commons_text_jar
+rectangle "violations-lib\n\n1.156.7" as se_bjurr_violations_violations_lib_jar
+rectangle "j2html\n\n1.4.0" as com_j2html_j2html_jar
+rectangle "xercesImpl\n\n2.12.2" as xerces_xercesImpl_jar
+rectangle "xml-apis\n\n1.4.01" as xml_apis_xml_apis_jar
+rectangle "asm\n\n9.6" as org_ow2_asm_asm_jar
+rectangle "asm-analysis\n\n9.6" as org_ow2_asm_asm_analysis_jar
+rectangle "asm-tree\n\n9.6" as org_ow2_asm_asm_tree_jar
+rectangle "spotbugs\n\n4.8.0" as com_github_spotbugs_spotbugs_jar
+rectangle "asm-commons\n\n9.6" as org_ow2_asm_asm_commons_jar
+rectangle "asm-util\n\n9.6" as org_ow2_asm_asm_util_jar
+rectangle "jcip-annotations\n\n1.0-1" as com_github_stephenc_jcip_jcip_annotations_jar
+rectangle "dom4j\n\n2.1.4" as org_dom4j_dom4j_jar
+rectangle "gson\n\n2.10.1" as com_google_code_gson_gson_jar
+rectangle "bcel\n\n6.7.0" as org_apache_bcel_bcel_jar
+rectangle "commons-lang3\n\n3.13.0" as org_apache_commons_commons_lang3_jar
+rectangle "pmd-core\n\n6.55.0" as net_sourceforge_pmd_pmd_core_jar
+rectangle "antlr4-runtime\n\n4.7.2" as org_antlr_antlr4_runtime_jar
+rectangle "jcommander\n\n1.82" as com_beust_jcommander_jar
+rectangle "pmd-java\n\n6.55.0" as net_sourceforge_pmd_pmd_java_jar
+rectangle "json\n\n20230618" as org_json_json_jar
+rectangle "json-smart\n\n2.5.0" as net_minidev_json_smart_jar
+rectangle "accessors-smart\n\n2.5.0" as net_minidev_accessors_smart_jar
+rectangle "slf4j-api\n\n2.0.9" as org_slf4j_slf4j_api_jar
+rectangle "spotbugs-annotations\n\n4.8.0" as com_github_spotbugs_spotbugs_annotations_jar
+rectangle "jsr305\n\n3.0.2" as com_google_code_findbugs_jsr305_jar
+rectangle "error_prone_annotations\n\n2.22.0" as com_google_errorprone_error_prone_annotations_jar
+rectangle "streamex\n\n0.8.2" as one_util_streamex_jar
+rectangle "codingstyle\n\n3.24.0" as edu_hm_hafner_codingstyle_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_jsoup_jsoup_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> commons_io_commons_io_jar
+org_apache_commons_commons_digester3_jar -[#000000]-> cglib_cglib_jar
+org_apache_commons_commons_digester3_jar -[#000000]-> commons_logging_commons_logging_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_apache_commons_commons_digester3_jar
+commons_beanutils_commons_beanutils_jar .[#FF0000].> commons_logging_commons_logging_jar: 1.2
+commons_beanutils_commons_beanutils_jar -[#000000]-> commons_collections_commons_collections_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> commons_beanutils_commons_beanutils_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_apache_commons_commons_text_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> se_bjurr_violations_violations_lib_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> com_j2html_j2html_jar
+xerces_xercesImpl_jar -[#000000]-> xml_apis_xml_apis_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> xerces_xercesImpl_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_ow2_asm_asm_jar
+org_ow2_asm_asm_analysis_jar .[#D3D3D3].> org_ow2_asm_asm_tree_jar
+com_github_spotbugs_spotbugs_jar -[#000000]-> org_ow2_asm_asm_analysis_jar
+org_ow2_asm_asm_commons_jar .[#D3D3D3].> org_ow2_asm_asm_tree_jar
+com_github_spotbugs_spotbugs_jar -[#000000]-> org_ow2_asm_asm_commons_jar
+com_github_spotbugs_spotbugs_jar -[#000000]-> org_ow2_asm_asm_tree_jar
+org_ow2_asm_asm_util_jar .[#D3D3D3].> org_ow2_asm_asm_tree_jar
+org_ow2_asm_asm_util_jar .[#D3D3D3].> org_ow2_asm_asm_analysis_jar
+com_github_spotbugs_spotbugs_jar -[#000000]-> org_ow2_asm_asm_util_jar
+com_github_spotbugs_spotbugs_jar -[#000000]-> com_github_stephenc_jcip_jcip_annotations_jar
+com_github_spotbugs_spotbugs_jar -[#000000]-> org_dom4j_dom4j_jar
+com_github_spotbugs_spotbugs_jar -[#000000]-> com_google_code_gson_gson_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> com_github_spotbugs_spotbugs_jar
+org_apache_bcel_bcel_jar .[#FF0000].> org_apache_commons_commons_lang3_jar: 3.12.0
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_apache_bcel_bcel_jar
+net_sourceforge_pmd_pmd_core_jar -[#000000]-> org_antlr_antlr4_runtime_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> net_sourceforge_pmd_pmd_core_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> com_beust_jcommander_jar
+net_sourceforge_pmd_pmd_java_jar .[#D3D3D3].> net_sourceforge_pmd_pmd_core_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> net_sourceforge_pmd_pmd_java_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_json_json_jar
+net_minidev_json_smart_jar -[#000000]-> net_minidev_accessors_smart_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> net_minidev_json_smart_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_slf4j_slf4j_api_jar
+com_github_spotbugs_spotbugs_annotations_jar -[#000000]-> com_google_code_findbugs_jsr305_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> com_github_spotbugs_spotbugs_annotations_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> com_google_errorprone_error_prone_annotations_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> one_util_streamex_jar
+edu_hm_hafner_codingstyle_jar .[#FF0000].> com_github_spotbugs_spotbugs_annotations_jar: 4.7.3
+edu_hm_hafner_codingstyle_jar .[#D3D3D3].> com_google_errorprone_error_prone_annotations_jar
+edu_hm_hafner_codingstyle_jar .[#D3D3D3].> org_apache_commons_commons_lang3_jar
+edu_hm_hafner_codingstyle_jar .[#D3D3D3].> commons_io_commons_io_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> edu_hm_hafner_codingstyle_jar
+edu_hm_hafner_analysis_model_jar -[#000000]-> org_apache_commons_commons_lang3_jar
+@enduml

--- a/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
@@ -49,7 +49,7 @@ public class GrypeParser extends JsonIssueParser {
                 .setCategory(vuln.getString(SEVERITY_TAG))
                 .setSeverity(Severity.guessFromString(vuln.getString(SEVERITY_TAG)))
                 .setType(vuln.getString(ID_TAG))
-                .setMessage(vuln.getString(DESCRIPTION_TAG))
+                .setMessage(vuln.optString(DESCRIPTION_TAG, "Unknown"))
                 .setOriginName("Grype")
                 .setPathName(fileName)
                 .setDescription(p().with(a()

--- a/src/test/java/edu/hm/hafner/analysis/parser/GrypeParserWoDescriptionTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GrypeParserWoDescriptionTest.java
@@ -1,0 +1,46 @@
+package edu.hm.hafner.analysis.parser;
+
+import edu.hm.hafner.analysis.AbstractParserTest;
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.p;
+
+class GrypeParserWoDescriptionTest extends AbstractParserTest {
+    protected GrypeParserWoDescriptionTest() {
+        super("grype-report-wo-description.json");
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        softly.assertThat(report).hasSize(20).hasDuplicatesSize(13);
+        softly.assertThat(report.get(0))
+                .hasFileName("/usr/local/bin/environment-to-ini")
+                .hasSeverity(Severity.ERROR)
+                .hasCategory("Critical")
+                .hasType("GHSA-pg38-r834-g45j")
+                .hasMessage("Improper Privilege Management in Gitea")
+                .hasDescription(p().with(a()
+                        .withHref("https://github.com/advisories/GHSA-pg38-r834-g45j")
+                        .withText("https://github.com/advisories/GHSA-pg38-r834-g45j")).render());
+
+        softly.assertThat(report.get(13))
+                .hasFileName("/lib/apk/db/installed")
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasCategory("High")
+                .hasType("CVE-2023-38039")
+                .hasMessage("Unknown")
+
+                .hasDescription(p().with(a()
+                        .withHref("http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039")
+                        .withText("http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039")).render());
+    }
+
+    @Override
+    protected IssueParser createParser() {
+        return new GrypeParser();
+    }
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/grype-report-wo-description.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/grype-report-wo-description.json
@@ -1,0 +1,3674 @@
+{
+  "matches": [
+    {
+      "vulnerability": {
+        "id": "GHSA-pg38-r834-g45j",
+        "dataSource": "https://github.com/advisories/GHSA-pg38-r834-g45j",
+        "namespace": "github:language:go",
+        "severity": "Critical",
+        "urls": [
+          "https://github.com/advisories/GHSA-pg38-r834-g45j"
+        ],
+        "description": "Improper Privilege Management in Gitea",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "metrics": {
+              "baseScore": 9.8,
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            "vendorMetadata": {
+              "base_severity": "Critical",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.6.0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2021-45330",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-45330",
+          "namespace": "nvd:cpe",
+          "severity": "Critical",
+          "urls": [
+            "https://github.com/go-gitea/gitea/issues/4336"
+          ],
+          "description": "An issue exsits in Gitea through 1.15.7, which could let a malicious user gain privileges due to client side cookies not being deleted and the session remains valid on the server side for reuse.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 10,
+                "impactScore": 6.4
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "metrics": {
+                "baseScore": 9.8,
+                "exploitabilityScore": 3.9,
+                "impactScore": 5.9
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.6.0 (unknown)",
+            "vulnerabilityID": "GHSA-pg38-r834-g45j"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-hfmf-q69j-6m5p",
+        "dataSource": "https://github.com/advisories/GHSA-hfmf-q69j-6m5p",
+        "namespace": "github:language:go",
+        "severity": "Critical",
+        "urls": [
+          "https://github.com/advisories/GHSA-hfmf-q69j-6m5p"
+        ],
+        "description": "Reuse of one time passwords allowed in Gitea",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "metrics": {
+              "baseScore": 9.8,
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            "vendorMetadata": {
+              "base_severity": "Critical",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.5.0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2021-45331",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-45331",
+          "namespace": "nvd:cpe",
+          "severity": "Critical",
+          "urls": [
+            "https://blog.gitea.io/2018/08/gitea-1.5.0-is-released/",
+            "https://github.com/go-gitea/gitea/pull/3878"
+          ],
+          "description": "An Authentication Bypass vulnerability exists in Gitea before 1.5.0, which could let a malicious user gain privileges. If captured, the TOTP code for the 2FA can be submitted correctly more than once.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 10,
+                "impactScore": 6.4
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "metrics": {
+                "baseScore": 9.8,
+                "exploitabilityScore": 3.9,
+                "impactScore": 5.9
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.5.0 (unknown)",
+            "vulnerabilityID": "GHSA-hfmf-q69j-6m5p"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-hf6f-jq25-8gq9",
+        "dataSource": "https://github.com/advisories/GHSA-hf6f-jq25-8gq9",
+        "namespace": "github:language:go",
+        "severity": "Critical",
+        "urls": [
+          "https://github.com/advisories/GHSA-hf6f-jq25-8gq9"
+        ],
+        "description": "Gitea Remote Code Execution (RCE)",
+        "cvss": [
+          {
+            "version": "3.0",
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "metrics": {
+              "baseScore": 9.8,
+              "exploitabilityScore": 3.9,
+              "impactScore": 5.9
+            },
+            "vendorMetadata": {
+              "base_severity": "Critical",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.5.2"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2018-18926",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2018-18926",
+          "namespace": "nvd:cpe",
+          "severity": "Critical",
+          "urls": [
+            "https://github.com/go-gitea/gitea/issues/5140"
+          ],
+          "description": "Gitea before 1.5.4 allows remote code execution because it does not properly validate session IDs. This is related to session ID handling in the go-macaron/session code for Macaron.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 10,
+                "impactScore": 6.4
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.0",
+              "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+              "metrics": {
+                "baseScore": 9.8,
+                "exploitabilityScore": 3.9,
+                "impactScore": 5.9
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.5.2 (unknown)",
+            "vulnerabilityID": "GHSA-hf6f-jq25-8gq9"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-p5f9-c9j9-g8qx",
+        "dataSource": "https://github.com/advisories/GHSA-p5f9-c9j9-g8qx",
+        "namespace": "github:language:go",
+        "severity": "High",
+        "urls": [
+          "https://github.com/advisories/GHSA-p5f9-c9j9-g8qx"
+        ],
+        "description": "Shell command injection in gitea",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "metrics": {
+              "baseScore": 7.5,
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            "vendorMetadata": {
+              "base_severity": "High",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.16.7"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2022-30781",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-30781",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "http://packetstormsecurity.com/files/168400/Gitea-1.16.6-Remote-Code-Execution.html",
+            "http://packetstormsecurity.com/files/169928/Gitea-Git-Fetch-Remote-Code-Execution.html",
+            "https://blog.gitea.io/2022/05/gitea-1.16.7-is-released/",
+            "https://github.com/go-gitea/gitea/pull/19487",
+            "https://github.com/go-gitea/gitea/pull/19490"
+          ],
+          "description": "Gitea before 1.16.7 does not escape git fetch remote.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+              "metrics": {
+                "baseScore": 5,
+                "exploitabilityScore": 10,
+                "impactScore": 2.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 3.9,
+                "impactScore": 3.6
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.16.7 (unknown)",
+            "vulnerabilityID": "GHSA-p5f9-c9j9-g8qx"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-jr9c-h74f-2v28",
+        "dataSource": "https://github.com/advisories/GHSA-jr9c-h74f-2v28",
+        "namespace": "github:language:go",
+        "severity": "High",
+        "urls": [
+          "https://github.com/advisories/GHSA-jr9c-h74f-2v28"
+        ],
+        "description": "Gitea Missing Authorization vulnerability",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N",
+            "metrics": {
+              "baseScore": 7.1,
+              "exploitabilityScore": 2.8,
+              "impactScore": 4.2
+            },
+            "vendorMetadata": {
+              "base_severity": "High",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.16.4"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2022-0905",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-0905",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "https://github.com/go-gitea/gitea/commit/1314f38b59748397b3429fb9bc9f9d6bac85d2f2",
+            "https://huntr.dev/bounties/8d221f92-b2b1-4878-bc31-66ff272e5ceb"
+          ],
+          "description": "Missing Authorization in GitHub repository go-gitea/gitea prior to 1.16.4.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+              "metrics": {
+                "baseScore": 5.5,
+                "exploitabilityScore": 8,
+                "impactScore": 4.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "security@huntr.dev",
+              "type": "Secondary",
+              "version": "3.0",
+              "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N",
+              "metrics": {
+                "baseScore": 6.5,
+                "exploitabilityScore": 2.2,
+                "impactScore": 4.2
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N",
+              "metrics": {
+                "baseScore": 7.1,
+                "exploitabilityScore": 2.8,
+                "impactScore": 4.2
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<=1.16.3 (unknown)",
+            "vulnerabilityID": "GHSA-jr9c-h74f-2v28"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-g7p7-x6w7-w6qg",
+        "dataSource": "https://github.com/advisories/GHSA-g7p7-x6w7-w6qg",
+        "namespace": "github:language:go",
+        "severity": "High",
+        "urls": [
+          "https://github.com/advisories/GHSA-g7p7-x6w7-w6qg"
+        ],
+        "description": "Arbitrary file deletion in gitea",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "metrics": {
+              "baseScore": 7.5,
+              "exploitabilityScore": 3.9,
+              "impactScore": 3.6
+            },
+            "vendorMetadata": {
+              "base_severity": "High",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.16.4"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2022-27313",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-27313",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "https://github.com/go-gitea/gitea/pull/19072"
+          ],
+          "description": "An arbitrary file deletion vulnerability in Gitea v1.16.3 allows attackers to cause a Denial of Service (DoS) via deleting the configuration file.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "metrics": {
+                "baseScore": 5,
+                "exploitabilityScore": 10,
+                "impactScore": 2.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 3.9,
+                "impactScore": 3.6
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.16.4 (unknown)",
+            "vulnerabilityID": "GHSA-g7p7-x6w7-w6qg"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-fg3x-rwq9-74cw",
+        "dataSource": "https://github.com/advisories/GHSA-fg3x-rwq9-74cw",
+        "namespace": "github:language:go",
+        "severity": "High",
+        "urls": [
+          "https://github.com/advisories/GHSA-fg3x-rwq9-74cw"
+        ],
+        "description": "Gogs and Gitea SSRF Vulnerability",
+        "cvss": [
+          {
+            "version": "3.0",
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
+            "metrics": {
+              "baseScore": 8.6,
+              "exploitabilityScore": 3.9,
+              "impactScore": 4
+            },
+            "vendorMetadata": {
+              "base_severity": "High",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.16.0-rc1"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2018-15192",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2018-15192",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "https://github.com/go-gitea/gitea/issues/4624",
+            "https://github.com/gogs/gogs/issues/5366"
+          ],
+          "description": "An SSRF vulnerability in webhooks in Gitea through 1.5.0-rc2 and Gogs through 0.11.53 allows remote attackers to access intranet services.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+              "metrics": {
+                "baseScore": 5,
+                "exploitabilityScore": 10,
+                "impactScore": 2.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.0",
+              "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
+              "metrics": {
+                "baseScore": 8.6,
+                "exploitabilityScore": 3.9,
+                "impactScore": 4
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.16.0-rc1 (unknown)",
+            "vulnerabilityID": "GHSA-fg3x-rwq9-74cw"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-ph3w-2843-72mx",
+        "dataSource": "https://github.com/advisories/GHSA-ph3w-2843-72mx",
+        "namespace": "github:language:go",
+        "severity": "Medium",
+        "urls": [
+          "https://github.com/advisories/GHSA-ph3w-2843-72mx"
+        ],
+        "description": "Stored Cross-site Scripting in gitea",
+        "cvss": [
+          {
+            "version": "3.0",
+            "vector": "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:N",
+            "metrics": {
+              "baseScore": 4.4,
+              "exploitabilityScore": 1.3,
+              "impactScore": 2.7
+            },
+            "vendorMetadata": {
+              "base_severity": "Medium",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.16.9"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2022-1928",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-1928",
+          "namespace": "nvd:cpe",
+          "severity": "Medium",
+          "urls": [
+            "https://github.com/go-gitea/gitea/commit/65e0688a5c9dacad50e71024b7529fdf0e3c2e9c",
+            "https://huntr.dev/bounties/6336ec42-5c4d-4f61-ae38-2bb539f433d2",
+            "https://security.gentoo.org/glsa/202210-14"
+          ],
+          "description": "Cross-site Scripting (XSS) - Stored in GitHub repository go-gitea/gitea prior to 1.16.9.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:M/Au:S/C:N/I:P/A:N",
+              "metrics": {
+                "baseScore": 3.5,
+                "exploitabilityScore": 6.8,
+                "impactScore": 2.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "security@huntr.dev",
+              "type": "Secondary",
+              "version": "3.0",
+              "vector": "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:N",
+              "metrics": {
+                "baseScore": 4.4,
+                "exploitabilityScore": 1.3,
+                "impactScore": 2.7
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+              "metrics": {
+                "baseScore": 5.4,
+                "exploitabilityScore": 2.3,
+                "impactScore": 2.7
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.16.9 (unknown)",
+            "vulnerabilityID": "GHSA-ph3w-2843-72mx"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-h3q4-vmw4-cpr5",
+        "dataSource": "https://github.com/advisories/GHSA-h3q4-vmw4-cpr5",
+        "namespace": "github:language:go",
+        "severity": "Medium",
+        "urls": [
+          "https://github.com/advisories/GHSA-h3q4-vmw4-cpr5"
+        ],
+        "description": "Path Traversal in Gitea",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "metrics": {
+              "baseScore": 5.3,
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {
+              "base_severity": "Medium",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.13.6"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2021-29134",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-29134",
+          "namespace": "nvd:cpe",
+          "severity": "Medium",
+          "urls": [
+            "https://github.com/go-gitea/gitea/pull/15125/files",
+            "https://github.com/go-gitea/gitea/releases/tag/v1.13.6"
+          ],
+          "description": "The avatar middleware in Gitea before 1.13.6 allows Directory Traversal via a crafted URL.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+              "metrics": {
+                "baseScore": 5,
+                "exploitabilityScore": 10,
+                "impactScore": 2.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+              "metrics": {
+                "baseScore": 5.3,
+                "exploitabilityScore": 3.9,
+                "impactScore": 1.4
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.13.6 (unknown)",
+            "vulnerabilityID": "GHSA-h3q4-vmw4-cpr5"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-g95p-88p4-76cm",
+        "dataSource": "https://github.com/advisories/GHSA-g95p-88p4-76cm",
+        "namespace": "github:language:go",
+        "severity": "Medium",
+        "urls": [
+          "https://github.com/advisories/GHSA-g95p-88p4-76cm"
+        ],
+        "description": "Cross-site Scripting in Gitea",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+            "metrics": {
+              "baseScore": 5.4,
+              "exploitabilityScore": 2.3,
+              "impactScore": 2.7
+            },
+            "vendorMetadata": {
+              "base_severity": "Medium",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.13.4"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2021-28378",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-28378",
+          "namespace": "nvd:cpe",
+          "severity": "Medium",
+          "urls": [
+            "https://blog.gitea.io/2021/03/gitea-1.13.4-is-released/",
+            "https://github.com/PandatiX/CVE-2021-28378",
+            "https://github.com/go-gitea/gitea/pull/14898"
+          ],
+          "description": "Gitea 1.12.x and 1.13.x before 1.13.4 allows XSS via certain issue data in some situations.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:M/Au:S/C:N/I:P/A:N",
+              "metrics": {
+                "baseScore": 3.5,
+                "exploitabilityScore": 6.8,
+                "impactScore": 2.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
+              "metrics": {
+                "baseScore": 5.4,
+                "exploitabilityScore": 2.3,
+                "impactScore": 2.7
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "cve@mitre.org",
+              "type": "Secondary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
+              "metrics": {
+                "baseScore": 3.7,
+                "exploitabilityScore": 1.2,
+                "impactScore": 2.5
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.13.4 (unknown)",
+            "vulnerabilityID": "GHSA-g95p-88p4-76cm"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-8j3v-68w3-3848",
+        "dataSource": "https://github.com/advisories/GHSA-8j3v-68w3-3848",
+        "namespace": "github:language:go",
+        "severity": "Medium",
+        "urls": [
+          "https://github.com/advisories/GHSA-8j3v-68w3-3848"
+        ],
+        "description": "Gitea erroneous repo clones",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+            "metrics": {
+              "baseScore": 6.5,
+              "exploitabilityScore": 3.9,
+              "impactScore": 2.5
+            },
+            "vendorMetadata": {
+              "base_severity": "Medium",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.17.2"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2022-38795",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-38795",
+          "namespace": "nvd:cpe",
+          "severity": "Medium",
+          "urls": [
+            "https://blog.gitea.com/release-of-1.17.2/",
+            "https://github.com/go-gitea/gitea/pull/20869",
+            "https://github.com/go-gitea/gitea/pull/20892"
+          ],
+          "description": "In Gitea through 1.17.1, repo cloning can occur in the migration function.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+              "metrics": {
+                "baseScore": 6.5,
+                "exploitabilityScore": 3.9,
+                "impactScore": 2.5
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.17.2 (unknown)",
+            "vulnerabilityID": "GHSA-8j3v-68w3-3848"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-5rh7-6gfj-mc87",
+        "dataSource": "https://github.com/advisories/GHSA-5rh7-6gfj-mc87",
+        "namespace": "github:language:go",
+        "severity": "Medium",
+        "urls": [
+          "https://github.com/advisories/GHSA-5rh7-6gfj-mc87"
+        ],
+        "description": "Gitea XSS Vulnerability",
+        "cvss": [
+          {
+            "version": "3.0",
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "metrics": {
+              "baseScore": 6.1,
+              "exploitabilityScore": 2.8,
+              "impactScore": 2.7
+            },
+            "vendorMetadata": {
+              "base_severity": "Medium",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.7.1"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2019-1010261",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010261",
+          "namespace": "nvd:cpe",
+          "severity": "Medium",
+          "urls": [
+            "https://github.com/go-gitea/gitea/pull/5905"
+          ],
+          "description": "Gitea 1.7.0 and earlier is affected by: Cross Site Scripting (XSS). The impact is: Attacker is able to have victim execute arbitrary JS in browser. The component is: go-get URL generation - PR to fix: https://github.com/go-gitea/gitea/pull/5905. The attack vector is: victim must open a specifically crafted URL. The fixed version is: 1.7.1 and later.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "2.0",
+              "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+              "metrics": {
+                "baseScore": 4.3,
+                "exploitabilityScore": 8.6,
+                "impactScore": 2.9
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.0",
+              "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+              "metrics": {
+                "baseScore": 6.1,
+                "exploitabilityScore": 2.8,
+                "impactScore": 2.7
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<=1.7.0 (unknown)",
+            "vulnerabilityID": "GHSA-5rh7-6gfj-mc87"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-cf6v-9j57-v6r6",
+        "dataSource": "https://github.com/advisories/GHSA-cf6v-9j57-v6r6",
+        "namespace": "github:language:go",
+        "severity": "Low",
+        "urls": [
+          "https://github.com/advisories/GHSA-cf6v-9j57-v6r6"
+        ],
+        "description": "code.gitea.io/gitea Open Redirect vulnerability",
+        "cvss": [
+          {
+            "version": "3.0",
+            "vector": "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:N/A:N",
+            "metrics": {
+              "baseScore": 3,
+              "exploitabilityScore": 1.3,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {
+              "base_severity": "Low",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "1.19.4"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2023-3515",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2023-3515",
+          "namespace": "nvd:cpe",
+          "severity": "Medium",
+          "urls": [
+            "https://github.com/go-gitea/gitea/commit/9aaaf980f0ba15611f30568bd67bce3ec12954e2",
+            "https://huntr.dev/bounties/e335cd18-bc4d-4585-adb7-426c817ed053"
+          ],
+          "description": "Open Redirect in GitHub repository go-gitea/gitea prior to 1.19.4.",
+          "cvss": [
+            {
+              "source": "security@huntr.dev",
+              "type": "Secondary",
+              "version": "3.0",
+              "vector": "CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:N/A:N",
+              "metrics": {
+                "baseScore": 3,
+                "exploitabilityScore": 1.3,
+                "impactScore": 1.4
+              },
+              "vendorMetadata": {}
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:N",
+              "metrics": {
+                "baseScore": 4.4,
+                "exploitabilityScore": 1.3,
+                "impactScore": 2.7
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "code.gitea.io/gitea",
+              "version": "(devel)"
+            }
+          },
+          "found": {
+            "versionConstraint": "<1.19.4 (unknown)",
+            "vulnerabilityID": "GHSA-cf6v-9j57-v6r6"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "2c5820876cb4b3d5",
+        "name": "code.gitea.io/gitea",
+        "version": "(devel)",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/usr/local/bin/environment-to-ini",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [],
+        "purl": "pkg:golang/code.gitea.io/gitea@(devel)",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "mainModule": "command-line-arguments"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2023-38039",
+        "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039",
+        "namespace": "alpine:distro:alpine:3.18",
+        "severity": "High",
+        "urls": [
+          "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039"
+        ],
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "8.3.0-r0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2023-38039",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2023-38039",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "http://seclists.org/fulldisclosure/2023/Oct/17",
+            "https://hackerone.com/reports/2072338",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/5DCZMYODALBLVOXVJEN2LF2MLANEYL4F/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M6KGKB2JNZVT276JYSKI6FV2VFJUGDOJ/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TEAWTYHC3RT6ZRS5OZRHLAIENVN6CCIS/",
+            "https://security.gentoo.org/glsa/202310-12",
+            "https://security.netapp.com/advisory/ntap-20231013-0005/"
+          ],
+          "description": "When curl retrieves an HTTP response, it stores the incoming headers so that\nthey can be accessed later via the libcurl headers API.\n\nHowever, curl did not have a limit in how many or how large headers it would\naccept in a response, allowing a malicious server to stream an endless series\nof headers and eventually cause curl to run out of heap memory.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 3.9,
+                "impactScore": 3.6
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-indirect-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.3.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38039"
+          }
+        },
+        {
+          "type": "exact-direct-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.3.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38039"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "a00e72135863bede",
+        "name": "curl",
+        "version": "8.2.1-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "curl"
+        ],
+        "cpes": [
+          "cpe:2.3:a:curl:curl:8.2.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:haxx:curl:8.2.1-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/curl@8.2.1-r0?arch=x86_64&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "curl"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2023-38546",
+        "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38546",
+        "namespace": "alpine:distro:alpine:3.18",
+        "severity": "Unknown",
+        "urls": [
+          "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38546"
+        ],
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "8.4.0-r0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "exact-indirect-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.4.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38546"
+          }
+        },
+        {
+          "type": "exact-direct-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.4.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38546"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "a00e72135863bede",
+        "name": "curl",
+        "version": "8.2.1-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "curl"
+        ],
+        "cpes": [
+          "cpe:2.3:a:curl:curl:8.2.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:haxx:curl:8.2.1-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/curl@8.2.1-r0?arch=x86_64&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "curl"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2023-38545",
+        "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545",
+        "namespace": "alpine:distro:alpine:3.18",
+        "severity": "Unknown",
+        "urls": [
+          "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545"
+        ],
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "8.4.0-r0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.4.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38545"
+          }
+        },
+        {
+          "type": "exact-indirect-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.4.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38545"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "a00e72135863bede",
+        "name": "curl",
+        "version": "8.2.1-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "curl"
+        ],
+        "cpes": [
+          "cpe:2.3:a:curl:curl:8.2.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:haxx:curl:8.2.1-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/curl@8.2.1-r0?arch=x86_64&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "curl"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "1003da6326165ec6",
+        "name": "gnupg",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gnupg@2.4.3-r0?arch=x86_64&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "8b33dd827da2a16e",
+        "name": "gnupg-dirmngr",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gnupg-dirmngr:gnupg-dirmngr:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg-dirmngr:gnupg_dirmngr:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_dirmngr:gnupg-dirmngr:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_dirmngr:gnupg_dirmngr:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg-dirmngr:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg_dirmngr:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gnupg-dirmngr@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "4e0f9a954517d678",
+        "name": "gnupg-gpgconf",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gnupg-gpgconf:gnupg-gpgconf:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg-gpgconf:gnupg_gpgconf:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_gpgconf:gnupg-gpgconf:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_gpgconf:gnupg_gpgconf:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg-gpgconf:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg_gpgconf:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gnupg-gpgconf@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "d5cb2c1c94466ebb",
+        "name": "gnupg-keyboxd",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gnupg-keyboxd:gnupg-keyboxd:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg-keyboxd:gnupg_keyboxd:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_keyboxd:gnupg-keyboxd:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_keyboxd:gnupg_keyboxd:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg-keyboxd:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg_keyboxd:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gnupg-keyboxd@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "eab7d2bd9fcaf287",
+        "name": "gnupg-utils",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gnupg-utils:gnupg-utils:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg-utils:gnupg_utils:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_utils:gnupg-utils:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_utils:gnupg_utils:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg-utils:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg_utils:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gnupg-utils@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "03499a5fb83032b3",
+        "name": "gnupg-wks-client",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gnupg-wks-client:gnupg-wks-client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg-wks-client:gnupg_wks_client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_wks_client:gnupg-wks-client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_wks_client:gnupg_wks_client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg-wks:gnupg-wks-client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg-wks:gnupg_wks_client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_wks:gnupg-wks-client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg_wks:gnupg_wks_client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg-wks-client:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gnupg:gnupg_wks_client:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gnupg-wks-client@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-qppj-fm5r-hxr3",
+        "dataSource": "https://github.com/advisories/GHSA-qppj-fm5r-hxr3",
+        "namespace": "github:language:go",
+        "severity": "Medium",
+        "urls": [
+          "https://github.com/advisories/GHSA-qppj-fm5r-hxr3"
+        ],
+        "description": "swift-nio-http2 vulnerable to HTTP/2 Stream Cancellation Attack",
+        "cvss": [
+          {
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 5.3,
+              "exploitabilityScore": 3.9,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {
+              "base_severity": "Medium",
+              "status": "N/A"
+            }
+          }
+        ],
+        "fix": {
+          "versions": [
+            "0.17.0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2023-44487",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2023-44487",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "http://www.openwall.com/lists/oss-security/2023/10/13/4",
+            "http://www.openwall.com/lists/oss-security/2023/10/13/9",
+            "https://access.redhat.com/security/cve/cve-2023-44487",
+            "https://arstechnica.com/security/2023/10/how-ddosers-used-the-http-2-protocol-to-deliver-attacks-of-unprecedented-size/",
+            "https://aws.amazon.com/security/security-bulletins/AWS-2023-011/",
+            "https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/",
+            "https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack/",
+            "https://blog.litespeedtech.com/2023/10/11/rapid-reset-http-2-vulnerablilty/",
+            "https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack",
+            "https://blog.vespa.ai/cve-2023-44487/",
+            "https://bugzilla.proxmox.com/show_bug.cgi?id=4988",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2242803",
+            "https://bugzilla.suse.com/show_bug.cgi?id=1216123",
+            "https://cgit.freebsd.org/ports/commit/?id=c64c329c2c1752f46b73e3e6ce9f4329be6629f9",
+            "https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps/",
+            "https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack",
+            "https://community.traefik.io/t/is-traefik-vulnerable-to-cve-2023-44487/20125",
+            "https://edg.io/lp/blog/resets-leaks-ddos-and-the-tale-of-a-hidden-cve",
+            "https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764",
+            "https://gist.github.com/adulau/7c2bfb8e9cdbe4b35a5e131c66a0c088",
+            "https://github.com/Azure/AKS/issues/3947",
+            "https://github.com/Kong/kong/discussions/11741",
+            "https://github.com/advisories/GHSA-qppj-fm5r-hxr3",
+            "https://github.com/advisories/GHSA-vx74-f528-fxqg",
+            "https://github.com/advisories/GHSA-xpw8-rcwv-8f8p",
+            "https://github.com/akka/akka-http/issues/4323",
+            "https://github.com/alibaba/tengine/issues/1872",
+            "https://github.com/apache/apisix/issues/10320",
+            "https://github.com/apache/httpd-site/pull/10",
+            "https://github.com/apache/httpd/blob/afcdbeebbff4b0c50ea26cdd16e178c0d1f24152/modules/http2/h2_mplx.c#L1101-L1113",
+            "https://github.com/apache/tomcat/tree/main/java/org/apache/coyote/http2",
+            "https://github.com/apache/trafficserver/pull/10564",
+            "https://github.com/arkrwn/PoC/tree/main/CVE-2023-44487",
+            "https://github.com/bcdannyboy/CVE-2023-44487",
+            "https://github.com/caddyserver/caddy/issues/5877",
+            "https://github.com/caddyserver/caddy/releases/tag/v2.7.5",
+            "https://github.com/dotnet/announcements/issues/277",
+            "https://github.com/dotnet/core/blob/e4613450ea0da7fd2fc6b61dfb2c1c1dec1ce9ec/release-notes/6.0/6.0.23/6.0.23.md?plain=1#L73",
+            "https://github.com/eclipse/jetty.project/issues/10679",
+            "https://github.com/envoyproxy/envoy/pull/30055",
+            "https://github.com/etcd-io/etcd/issues/16740",
+            "https://github.com/facebook/proxygen/pull/466",
+            "https://github.com/golang/go/issues/63417",
+            "https://github.com/grpc/grpc-go/pull/6703",
+            "https://github.com/h2o/h2o/pull/3291",
+            "https://github.com/h2o/h2o/security/advisories/GHSA-2m7v-gc89-fjqf",
+            "https://github.com/haproxy/haproxy/issues/2312",
+            "https://github.com/icing/mod_h2/blob/0a864782af0a942aa2ad4ed960a6b32cd35bcf0a/mod_http2/README.md?plain=1#L239-L244",
+            "https://github.com/junkurihara/rust-rpxy/issues/97",
+            "https://github.com/kazu-yamamoto/http2/commit/f61d41a502bd0f60eb24e1ce14edc7b6df6722a1",
+            "https://github.com/kazu-yamamoto/http2/issues/93",
+            "https://github.com/kubernetes/kubernetes/pull/121120",
+            "https://github.com/line/armeria/pull/5232",
+            "https://github.com/linkerd/website/pull/1695/commits/4b9c6836471bc8270ab48aae6fd2181bc73fd632",
+            "https://github.com/micrictor/http2-rst-stream",
+            "https://github.com/microsoft/CBL-Mariner/pull/6381",
+            "https://github.com/netty/netty/commit/58f75f665aa81a8cbcf6ffa74820042a285c5e61",
+            "https://github.com/nghttp2/nghttp2/pull/1961",
+            "https://github.com/nghttp2/nghttp2/releases/tag/v1.57.0",
+            "https://github.com/ninenines/cowboy/issues/1615",
+            "https://github.com/nodejs/node/pull/50121",
+            "https://github.com/openresty/openresty/issues/930",
+            "https://github.com/opensearch-project/data-prepper/issues/3474",
+            "https://github.com/oqtane/oqtane.framework/discussions/3367",
+            "https://github.com/projectcontour/contour/pull/5826",
+            "https://github.com/tempesta-tech/tempesta/issues/1986",
+            "https://github.com/varnishcache/varnish-cache/issues/3996",
+            "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo",
+            "https://istio.io/latest/news/security/istio-security-2023-004/",
+            "https://linkerd.io/2023/10/12/linkerd-cve-2023-44487/",
+            "https://lists.apache.org/thread/5py8h42mxfsn8l1wy6o41xwhsjlsd87q",
+            "https://lists.debian.org/debian-lts-announce/2023/10/msg00020.html",
+            "https://lists.debian.org/debian-lts-announce/2023/10/msg00023.html",
+            "https://lists.debian.org/debian-lts-announce/2023/10/msg00024.html",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY/",
+            "https://lists.w3.org/Archives/Public/ietf-http-wg/2023OctDec/0025.html",
+            "https://mailman.nginx.org/pipermail/nginx-devel/2023-October/S36Q5HBXR7CAIMPLLPRSSSYR4PCMWILK.html",
+            "https://martinthomson.github.io/h2-stream-limits/draft-thomson-httpbis-h2-stream-limits.html",
+            "https://msrc.microsoft.com/blog/2023/10/microsoft-response-to-distributed-denial-of-service-ddos-attacks-against-http/2/",
+            "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-44487",
+            "https://my.f5.com/manage/s/article/K000137106",
+            "https://netty.io/news/2023/10/10/4-1-100-Final.html",
+            "https://news.ycombinator.com/item?id=37830987",
+            "https://news.ycombinator.com/item?id=37830998",
+            "https://news.ycombinator.com/item?id=37831062",
+            "https://news.ycombinator.com/item?id=37837043",
+            "https://openssf.org/blog/2023/10/10/http-2-rapid-reset-vulnerability-highlights-need-for-rapid-response/",
+            "https://seanmonstar.com/post/730794151136935936/hyper-http2-rapid-reset-unaffected",
+            "https://security.netapp.com/advisory/ntap-20231016-0001/",
+            "https://security.paloaltonetworks.com/CVE-2023-44487",
+            "https://tomcat.apache.org/security-10.html#Fixed_in_Apache_Tomcat_10.1.14",
+            "https://ubuntu.com/security/CVE-2023-44487",
+            "https://www.bleepingcomputer.com/news/security/new-http-2-rapid-reset-zero-day-attack-breaks-ddos-records/",
+            "https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487",
+            "https://www.darkreading.com/cloud/internet-wide-zero-day-bug-fuels-largest-ever-ddos-event",
+            "https://www.debian.org/security/2023/dsa-5521",
+            "https://www.debian.org/security/2023/dsa-5522",
+            "https://www.haproxy.com/blog/haproxy-is-not-affected-by-the-http-2-rapid-reset-attack-cve-2023-44487",
+            "https://www.netlify.com/blog/netlify-successfully-mitigates-cve-2023-44487/",
+            "https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products/",
+            "https://www.openwall.com/lists/oss-security/2023/10/10/6",
+            "https://www.phoronix.com/news/HTTP2-Rapid-Reset-Attack",
+            "https://www.theregister.com/2023/10/10/http2_rapid_reset_zeroday/"
+          ],
+          "description": "The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 3.9,
+                "impactScore": 3.6
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "golang.org/x/net",
+              "version": "v0.13.0"
+            }
+          },
+          "found": {
+            "versionConstraint": "<0.17.0 (unknown)",
+            "vulnerabilityID": "GHSA-qppj-fm5r-hxr3"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "6351cf9c063f902a",
+        "name": "golang.org/x/net",
+        "version": "v0.13.0",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/app/gitea/gitea",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [
+          "cpe:2.3:a:golang:x/net:v0.13.0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:golang/golang.org/x/net@v0.13.0",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "h1Digest": "h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=",
+          "mainModule": "code.gitea.io/gitea"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "GHSA-4374-p667-p6c8",
+        "dataSource": "https://github.com/advisories/GHSA-4374-p667-p6c8",
+        "namespace": "github:language:go",
+        "severity": "Medium",
+        "urls": [
+          "https://github.com/advisories/GHSA-4374-p667-p6c8"
+        ],
+        "description": "HTTP/2 rapid reset can cause excessive work in net/http",
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "0.17.0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2023-39325",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2023-39325",
+          "namespace": "nvd:cpe",
+          "urls": [
+            "https://go.dev/cl/534215",
+            "https://go.dev/cl/534235",
+            "https://go.dev/issue/63417",
+            "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo/m/UDd7VKQuAAAJ",
+            "https://pkg.go.dev/vuln/GO-2023-2102"
+          ],
+          "description": "A malicious HTTP/2 client which rapidly creates requests and immediately resets them can cause excessive server resource consumption. While the total number of requests is bounded by the http2.Server.MaxConcurrentStreams setting, resetting an in-progress request allows the attacker to create a new request while the existing one is still executing. With the fix applied, HTTP/2 servers now bound the number of simultaneously executing handler goroutines to the stream concurrency limit (MaxConcurrentStreams). New requests arriving when at the limit (which can only happen after the client has reset an existing, in-flight request) will be queued until a handler exits. If the request queue grows too large, the server will terminate the connection. This issue is also fixed in golang.org/x/net/http2 for users manually configuring HTTP/2. The default stream concurrency limit is 250 streams (requests) per HTTP/2 connection. This value may be adjusted using the golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams setting and the ConfigureServer function.",
+          "cvss": []
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-direct-match",
+          "matcher": "go-module-matcher",
+          "searchedBy": {
+            "language": "go",
+            "namespace": "github:language:go",
+            "package": {
+              "name": "golang.org/x/net",
+              "version": "v0.13.0"
+            }
+          },
+          "found": {
+            "versionConstraint": "<0.17.0 (unknown)",
+            "vulnerabilityID": "GHSA-4374-p667-p6c8"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "6351cf9c063f902a",
+        "name": "golang.org/x/net",
+        "version": "v0.13.0",
+        "type": "go-module",
+        "locations": [
+          {
+            "path": "/app/gitea/gitea",
+            "layerID": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b"
+          }
+        ],
+        "language": "go",
+        "licenses": [],
+        "cpes": [
+          "cpe:2.3:a:golang:x/net:v0.13.0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:golang/golang.org/x/net@v0.13.0",
+        "upstreams": [],
+        "metadataType": "GolangBinMetadata",
+        "metadata": {
+          "goCompiledVersion": "go1.20.8",
+          "architecture": "amd64",
+          "h1Digest": "h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=",
+          "mainModule": "code.gitea.io/gitea"
+        }
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "f7eca0d6869017ec",
+        "name": "gpg",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gpg:gpg:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gpg@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "f959b5fd957e34c9",
+        "name": "gpg-agent",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gpg-agent:gpg-agent:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg-agent:gpg_agent:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg_agent:gpg-agent:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg_agent:gpg_agent:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg:gpg-agent:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg:gpg_agent:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gpg-agent@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "ecfa102014423164",
+        "name": "gpg-wks-server",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gpg-wks-server:gpg-wks-server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg-wks-server:gpg_wks_server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg_wks_server:gpg-wks-server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg_wks_server:gpg_wks_server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg-wks:gpg-wks-server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg-wks:gpg_wks_server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg_wks:gpg-wks-server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg_wks:gpg_wks_server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg:gpg-wks-server:2.4.3-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:gpg:gpg_wks_server:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gpg-wks-server@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "fe80354ac98143a1",
+        "name": "gpgsm",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gpgsm:gpgsm:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gpgsm@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2022-3219",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2022-3219",
+        "namespace": "nvd:cpe",
+        "severity": "Low",
+        "urls": [
+          "https://access.redhat.com/security/cve/CVE-2022-3219",
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2127010",
+          "https://dev.gnupg.org/D556",
+          "https://dev.gnupg.org/T5993",
+          "https://marc.info/?l=oss-security&m=165696590211434&w=4",
+          "https://security.netapp.com/advisory/ntap-20230324-0001/"
+        ],
+        "description": "GnuPG can be made to spin on a relatively small input by (for example) crafting a public key with thousands of signatures attached, compressed down to just a few KB.",
+        "cvss": [
+          {
+            "source": "nvd@nist.gov",
+            "type": "Primary",
+            "version": "3.1",
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+            "metrics": {
+              "baseScore": 3.3,
+              "exploitabilityScore": 1.8,
+              "impactScore": 1.4
+            },
+            "vendorMetadata": {}
+          }
+        ],
+        "fix": {
+          "versions": [],
+          "state": "unknown"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "cpe-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "namespace": "nvd:cpe",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:2.4.3-r0:*:*:*:*:*:*:*"
+            ],
+            "Package": {
+              "name": "gnupg",
+              "version": "2.4.3-r0"
+            }
+          },
+          "found": {
+            "vulnerabilityID": "CVE-2022-3219",
+            "versionConstraint": "none (unknown)",
+            "cpes": [
+              "cpe:2.3:a:gnupg:gnupg:-:*:*:*:*:*:*:*"
+            ]
+          }
+        }
+      ],
+      "artifact": {
+        "id": "dba43e5888e86310",
+        "name": "gpgv",
+        "version": "2.4.3-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "GPL-3.0-or-later"
+        ],
+        "cpes": [
+          "cpe:2.3:a:gpgv:gpgv:2.4.3-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/gpgv@2.4.3-r0?arch=x86_64&upstream=gnupg&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "gnupg"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2023-38039",
+        "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039",
+        "namespace": "alpine:distro:alpine:3.18",
+        "severity": "High",
+        "urls": [
+          "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039"
+        ],
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "8.3.0-r0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2023-38039",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2023-38039",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "http://seclists.org/fulldisclosure/2023/Oct/17",
+            "https://hackerone.com/reports/2072338",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/5DCZMYODALBLVOXVJEN2LF2MLANEYL4F/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M6KGKB2JNZVT276JYSKI6FV2VFJUGDOJ/",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TEAWTYHC3RT6ZRS5OZRHLAIENVN6CCIS/",
+            "https://security.gentoo.org/glsa/202310-12",
+            "https://security.netapp.com/advisory/ntap-20231013-0005/"
+          ],
+          "description": "When curl retrieves an HTTP response, it stores the incoming headers so that\nthey can be accessed later via the libcurl headers API.\n\nHowever, curl did not have a limit in how many or how large headers it would\naccept in a response, allowing a malicious server to stream an endless series\nof headers and eventually cause curl to run out of heap memory.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 3.9,
+                "impactScore": 3.6
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-indirect-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.3.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38039"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "8bd2fef8b6104d86",
+        "name": "libcurl",
+        "version": "8.2.1-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "curl"
+        ],
+        "cpes": [
+          "cpe:2.3:a:libcurl:libcurl:8.2.1-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/libcurl@8.2.1-r0?arch=x86_64&upstream=curl&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "curl"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2023-38546",
+        "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38546",
+        "namespace": "alpine:distro:alpine:3.18",
+        "severity": "Unknown",
+        "urls": [
+          "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38546"
+        ],
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "8.4.0-r0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "exact-indirect-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.4.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38546"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "8bd2fef8b6104d86",
+        "name": "libcurl",
+        "version": "8.2.1-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "curl"
+        ],
+        "cpes": [
+          "cpe:2.3:a:libcurl:libcurl:8.2.1-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/libcurl@8.2.1-r0?arch=x86_64&upstream=curl&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "curl"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2023-38545",
+        "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545",
+        "namespace": "alpine:distro:alpine:3.18",
+        "severity": "Unknown",
+        "urls": [
+          "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545"
+        ],
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "8.4.0-r0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+        {
+          "type": "exact-indirect-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "curl",
+              "version": "8.2.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 8.4.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-38545"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "8bd2fef8b6104d86",
+        "name": "libcurl",
+        "version": "8.2.1-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "curl"
+        ],
+        "cpes": [
+          "cpe:2.3:a:libcurl:libcurl:8.2.1-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/libcurl@8.2.1-r0?arch=x86_64&upstream=curl&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "curl"
+          }
+        ]
+      }
+    },
+    {
+      "vulnerability": {
+        "id": "CVE-2023-44487",
+        "dataSource": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487",
+        "namespace": "alpine:distro:alpine:3.18",
+        "severity": "High",
+        "urls": [
+          "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487"
+        ],
+        "cvss": [],
+        "fix": {
+          "versions": [
+            "1.57.0-r0"
+          ],
+          "state": "fixed"
+        },
+        "advisories": []
+      },
+      "relatedVulnerabilities": [
+        {
+          "id": "CVE-2023-44487",
+          "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2023-44487",
+          "namespace": "nvd:cpe",
+          "severity": "High",
+          "urls": [
+            "http://www.openwall.com/lists/oss-security/2023/10/13/4",
+            "http://www.openwall.com/lists/oss-security/2023/10/13/9",
+            "https://access.redhat.com/security/cve/cve-2023-44487",
+            "https://arstechnica.com/security/2023/10/how-ddosers-used-the-http-2-protocol-to-deliver-attacks-of-unprecedented-size/",
+            "https://aws.amazon.com/security/security-bulletins/AWS-2023-011/",
+            "https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/",
+            "https://blog.cloudflare.com/zero-day-rapid-reset-http2-record-breaking-ddos-attack/",
+            "https://blog.litespeedtech.com/2023/10/11/rapid-reset-http-2-vulnerablilty/",
+            "https://blog.qualys.com/vulnerabilities-threat-research/2023/10/10/cve-2023-44487-http-2-rapid-reset-attack",
+            "https://blog.vespa.ai/cve-2023-44487/",
+            "https://bugzilla.proxmox.com/show_bug.cgi?id=4988",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2242803",
+            "https://bugzilla.suse.com/show_bug.cgi?id=1216123",
+            "https://cgit.freebsd.org/ports/commit/?id=c64c329c2c1752f46b73e3e6ce9f4329be6629f9",
+            "https://cloud.google.com/blog/products/identity-security/google-cloud-mitigated-largest-ddos-attack-peaking-above-398-million-rps/",
+            "https://cloud.google.com/blog/products/identity-security/how-it-works-the-novel-http2-rapid-reset-ddos-attack",
+            "https://community.traefik.io/t/is-traefik-vulnerable-to-cve-2023-44487/20125",
+            "https://edg.io/lp/blog/resets-leaks-ddos-and-the-tale-of-a-hidden-cve",
+            "https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764",
+            "https://gist.github.com/adulau/7c2bfb8e9cdbe4b35a5e131c66a0c088",
+            "https://github.com/Azure/AKS/issues/3947",
+            "https://github.com/Kong/kong/discussions/11741",
+            "https://github.com/advisories/GHSA-qppj-fm5r-hxr3",
+            "https://github.com/advisories/GHSA-vx74-f528-fxqg",
+            "https://github.com/advisories/GHSA-xpw8-rcwv-8f8p",
+            "https://github.com/akka/akka-http/issues/4323",
+            "https://github.com/alibaba/tengine/issues/1872",
+            "https://github.com/apache/apisix/issues/10320",
+            "https://github.com/apache/httpd-site/pull/10",
+            "https://github.com/apache/httpd/blob/afcdbeebbff4b0c50ea26cdd16e178c0d1f24152/modules/http2/h2_mplx.c#L1101-L1113",
+            "https://github.com/apache/tomcat/tree/main/java/org/apache/coyote/http2",
+            "https://github.com/apache/trafficserver/pull/10564",
+            "https://github.com/arkrwn/PoC/tree/main/CVE-2023-44487",
+            "https://github.com/bcdannyboy/CVE-2023-44487",
+            "https://github.com/caddyserver/caddy/issues/5877",
+            "https://github.com/caddyserver/caddy/releases/tag/v2.7.5",
+            "https://github.com/dotnet/announcements/issues/277",
+            "https://github.com/dotnet/core/blob/e4613450ea0da7fd2fc6b61dfb2c1c1dec1ce9ec/release-notes/6.0/6.0.23/6.0.23.md?plain=1#L73",
+            "https://github.com/eclipse/jetty.project/issues/10679",
+            "https://github.com/envoyproxy/envoy/pull/30055",
+            "https://github.com/etcd-io/etcd/issues/16740",
+            "https://github.com/facebook/proxygen/pull/466",
+            "https://github.com/golang/go/issues/63417",
+            "https://github.com/grpc/grpc-go/pull/6703",
+            "https://github.com/h2o/h2o/pull/3291",
+            "https://github.com/h2o/h2o/security/advisories/GHSA-2m7v-gc89-fjqf",
+            "https://github.com/haproxy/haproxy/issues/2312",
+            "https://github.com/icing/mod_h2/blob/0a864782af0a942aa2ad4ed960a6b32cd35bcf0a/mod_http2/README.md?plain=1#L239-L244",
+            "https://github.com/junkurihara/rust-rpxy/issues/97",
+            "https://github.com/kazu-yamamoto/http2/commit/f61d41a502bd0f60eb24e1ce14edc7b6df6722a1",
+            "https://github.com/kazu-yamamoto/http2/issues/93",
+            "https://github.com/kubernetes/kubernetes/pull/121120",
+            "https://github.com/line/armeria/pull/5232",
+            "https://github.com/linkerd/website/pull/1695/commits/4b9c6836471bc8270ab48aae6fd2181bc73fd632",
+            "https://github.com/micrictor/http2-rst-stream",
+            "https://github.com/microsoft/CBL-Mariner/pull/6381",
+            "https://github.com/netty/netty/commit/58f75f665aa81a8cbcf6ffa74820042a285c5e61",
+            "https://github.com/nghttp2/nghttp2/pull/1961",
+            "https://github.com/nghttp2/nghttp2/releases/tag/v1.57.0",
+            "https://github.com/ninenines/cowboy/issues/1615",
+            "https://github.com/nodejs/node/pull/50121",
+            "https://github.com/openresty/openresty/issues/930",
+            "https://github.com/opensearch-project/data-prepper/issues/3474",
+            "https://github.com/oqtane/oqtane.framework/discussions/3367",
+            "https://github.com/projectcontour/contour/pull/5826",
+            "https://github.com/tempesta-tech/tempesta/issues/1986",
+            "https://github.com/varnishcache/varnish-cache/issues/3996",
+            "https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo",
+            "https://istio.io/latest/news/security/istio-security-2023-004/",
+            "https://linkerd.io/2023/10/12/linkerd-cve-2023-44487/",
+            "https://lists.apache.org/thread/5py8h42mxfsn8l1wy6o41xwhsjlsd87q",
+            "https://lists.debian.org/debian-lts-announce/2023/10/msg00020.html",
+            "https://lists.debian.org/debian-lts-announce/2023/10/msg00023.html",
+            "https://lists.debian.org/debian-lts-announce/2023/10/msg00024.html",
+            "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JMEXY22BFG5Q64HQCM5CK2Q7KDKVV4TY/",
+            "https://lists.w3.org/Archives/Public/ietf-http-wg/2023OctDec/0025.html",
+            "https://mailman.nginx.org/pipermail/nginx-devel/2023-October/S36Q5HBXR7CAIMPLLPRSSSYR4PCMWILK.html",
+            "https://martinthomson.github.io/h2-stream-limits/draft-thomson-httpbis-h2-stream-limits.html",
+            "https://msrc.microsoft.com/blog/2023/10/microsoft-response-to-distributed-denial-of-service-ddos-attacks-against-http/2/",
+            "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-44487",
+            "https://my.f5.com/manage/s/article/K000137106",
+            "https://netty.io/news/2023/10/10/4-1-100-Final.html",
+            "https://news.ycombinator.com/item?id=37830987",
+            "https://news.ycombinator.com/item?id=37830998",
+            "https://news.ycombinator.com/item?id=37831062",
+            "https://news.ycombinator.com/item?id=37837043",
+            "https://openssf.org/blog/2023/10/10/http-2-rapid-reset-vulnerability-highlights-need-for-rapid-response/",
+            "https://seanmonstar.com/post/730794151136935936/hyper-http2-rapid-reset-unaffected",
+            "https://security.netapp.com/advisory/ntap-20231016-0001/",
+            "https://security.paloaltonetworks.com/CVE-2023-44487",
+            "https://tomcat.apache.org/security-10.html#Fixed_in_Apache_Tomcat_10.1.14",
+            "https://ubuntu.com/security/CVE-2023-44487",
+            "https://www.bleepingcomputer.com/news/security/new-http-2-rapid-reset-zero-day-attack-breaks-ddos-records/",
+            "https://www.cisa.gov/news-events/alerts/2023/10/10/http2-rapid-reset-vulnerability-cve-2023-44487",
+            "https://www.darkreading.com/cloud/internet-wide-zero-day-bug-fuels-largest-ever-ddos-event",
+            "https://www.debian.org/security/2023/dsa-5521",
+            "https://www.debian.org/security/2023/dsa-5522",
+            "https://www.haproxy.com/blog/haproxy-is-not-affected-by-the-http-2-rapid-reset-attack-cve-2023-44487",
+            "https://www.netlify.com/blog/netlify-successfully-mitigates-cve-2023-44487/",
+            "https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products/",
+            "https://www.openwall.com/lists/oss-security/2023/10/10/6",
+            "https://www.phoronix.com/news/HTTP2-Rapid-Reset-Attack",
+            "https://www.theregister.com/2023/10/10/http2_rapid_reset_zeroday/"
+          ],
+          "description": "The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+          "cvss": [
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "version": "3.1",
+              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "metrics": {
+                "baseScore": 7.5,
+                "exploitabilityScore": 3.9,
+                "impactScore": 3.6
+              },
+              "vendorMetadata": {}
+            }
+          ]
+        }
+      ],
+      "matchDetails": [
+        {
+          "type": "exact-indirect-match",
+          "matcher": "apk-matcher",
+          "searchedBy": {
+            "distro": {
+              "type": "alpine",
+              "version": "3.18.3"
+            },
+            "namespace": "alpine:distro:alpine:3.18",
+            "package": {
+              "name": "nghttp2",
+              "version": "1.55.1-r0"
+            }
+          },
+          "found": {
+            "versionConstraint": "< 1.57.0-r0 (apk)",
+            "vulnerabilityID": "CVE-2023-44487"
+          }
+        }
+      ],
+      "artifact": {
+        "id": "eec35c5a6c1d3b1f",
+        "name": "nghttp2-libs",
+        "version": "1.55.1-r0",
+        "type": "apk",
+        "locations": [
+          {
+            "path": "/lib/apk/db/installed",
+            "layerID": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865"
+          }
+        ],
+        "language": "",
+        "licenses": [
+          "MIT"
+        ],
+        "cpes": [
+          "cpe:2.3:a:nghttp2-libs:nghttp2-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2-libs:nghttp2_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2_libs:nghttp2-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2_libs:nghttp2_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp-libs:nghttp2-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp-libs:nghttp2_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2-libs:nghttp-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2-libs:nghttp_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2_libs:nghttp-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2_libs:nghttp_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp_libs:nghttp2-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp_libs:nghttp2_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp-libs:nghttp-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp-libs:nghttp_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp_libs:nghttp-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp_libs:nghttp_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2:nghttp2-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2:nghttp2_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2:nghttp-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp2:nghttp_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp:nghttp2-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp:nghttp2_libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp:nghttp-libs:1.55.1-r0:*:*:*:*:*:*:*",
+          "cpe:2.3:a:nghttp:nghttp_libs:1.55.1-r0:*:*:*:*:*:*:*"
+        ],
+        "purl": "pkg:apk/alpine/nghttp2-libs@1.55.1-r0?arch=x86_64&upstream=nghttp2&distro=alpine-3.18.3",
+        "upstreams": [
+          {
+            "name": "nghttp2"
+          }
+        ]
+      }
+    }
+  ],
+  "source": {
+    "type": "image",
+    "target": {
+      "userInput": "6877f5aabc34",
+      "imageID": "sha256:6877f5aabc34414d9fadf365a8eeb74fd7918a0275c3c1821977fc356fac45e0",
+      "manifestDigest": "sha256:928df2c283e29649ede73a58d79612c0d75bda7ec0f9d8f1706d7e24149a07f4",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tags": [
+        "gitea/gitea:1.20.4"
+      ],
+      "imageSize": 273161964,
+      "layers": [
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:4693057ce2364720d39e57e85a5b8e0bd9ac3573716237736d6470ec5b7b7230",
+          "size": 7330497
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:6f9be519332c898696b064fd9da6048e94fcd30241ac52f541d5f6768b97c865",
+          "size": 38432342
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:639713da568d34f61e3f871b426436ba676ed786709bca5f2a09cf1dce13355d",
+          "size": 4949
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:cdf8ae9899d7e11357f87d15e83c58328081efee949379ae4623749969076cc7",
+          "size": 9111
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:513dbcb73eb7cb9cf92b62cbd0ef5e6f69bc572b67d5358a427928c78fa75b00",
+          "size": 101055760
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:da915d9f46bd2b12788a1ea8c0f2cfd0c06d6d8f604fb8a0ab623a127f998cc6",
+          "size": 12632515
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:fd307834bfc490634f639669b8086d09ebd2d9415836a0e5192647073cb885ae",
+          "size": 946
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:a4c8b13e3235488dcc2bd60fd1286af9bea7551b6b74541144e8647ba86bc21b",
+          "size": 113690000
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:b014b9a23b086079af3b90c41bbacc1fbf3a6cef363125cf6a731e556dc89971",
+          "size": 4898
+        },
+        {
+          "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+          "digest": "sha256:d7d3e1482ddf7ab4033fcde2909aec9a3b5f13b811acd0211e92c1aeb6275c15",
+          "size": 946
+        }
+      ],
+      "manifest": "eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwiY29uZmlnIjp7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuY29udGFpbmVyLmltYWdlLnYxK2pzb24iLCJzaXplIjo0NjA2LCJkaWdlc3QiOiJzaGEyNTY6Njg3N2Y1YWFiYzM0NDE0ZDlmYWRmMzY1YThlZWI3NGZkNzkxOGEwMjc1YzNjMTgyMTk3N2ZjMzU2ZmFjNDVlMCJ9LCJsYXllcnMiOlt7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjo3NjI1NzI4LCJkaWdlc3QiOiJzaGEyNTY6NDY5MzA1N2NlMjM2NDcyMGQzOWU1N2U4NWE1YjhlMGJkOWFjMzU3MzcxNjIzNzczNmQ2NDcwZWM1YjdiNzIzMCJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjM5MTU2MjI0LCJkaWdlc3QiOiJzaGEyNTY6NmY5YmU1MTkzMzJjODk4Njk2YjA2NGZkOWRhNjA0OGU5NGZjZDMwMjQxYWM1MmY1NDFkNWY2NzY4Yjk3Yzg2NSJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjEwNzUyLCJkaWdlc3QiOiJzaGEyNTY6NjM5NzEzZGE1NjhkMzRmNjFlM2Y4NzFiNDI2NDM2YmE2NzZlZDc4NjcwOWJjYTVmMmEwOWNmMWRjZTEzMzU1ZCJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjI1NjAwLCJkaWdlc3QiOiJzaGEyNTY6Y2RmOGFlOTg5OWQ3ZTExMzU3Zjg3ZDE1ZTgzYzU4MzI4MDgxZWZlZTk0OTM3OWFlNDYyMzc0OTk2OTA3NmNjNyJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjEwMTA1ODU2MCwiZGlnZXN0Ijoic2hhMjU2OjUxM2RiY2I3M2ViN2NiOWNmOTJiNjJjYmQwZWY1ZTZmNjliYzU3MmI2N2Q1MzU4YTQyNzkyOGM3OGZhNzViMDAifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjoxMjYzNTY0OCwiZGlnZXN0Ijoic2hhMjU2OmRhOTE1ZDlmNDZiZDJiMTI3ODhhMWVhOGMwZjJjZmQwYzA2ZDZkOGY2MDRmYjhhMGFiNjIzYTEyN2Y5OThjYzYifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjozNTg0LCJkaWdlc3QiOiJzaGEyNTY6ZmQzMDc4MzRiZmM0OTA2MzRmNjM5NjY5YjgwODZkMDllYmQyZDk0MTU4MzZhMGU1MTkyNjQ3MDczY2I4ODVhZSJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjExMzY5Nzc5MiwiZGlnZXN0Ijoic2hhMjU2OmE0YzhiMTNlMzIzNTQ4OGRjYzJiZDYwZmQxMjg2YWY5YmVhNzU1MWI2Yjc0NTQxMTQ0ZTg2NDdiYTg2YmMyMWIifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjoxNDg0OCwiZGlnZXN0Ijoic2hhMjU2OmIwMTRiOWEyM2IwODYwNzlhZjNiOTBjNDFiYmFjYzFmYmYzYTZjZWYzNjMxMjVjZjZhNzMxZTU1NmRjODk5NzEifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjozNTg0LCJkaWdlc3QiOiJzaGEyNTY6ZDdkM2UxNDgyZGRmN2FiNDAzM2ZjZGUyOTA5YWVjOWEzYjVmMTNiODExYWNkMDIxMWU5MmMxYWViNjI3NWMxNSJ9XX0=",
+      "config": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJFeHBvc2VkUG9ydHMiOnsiMjIvdGNwIjp7fSwiMzAwMC90Y3AiOnt9fSwiRW52IjpbIlBBVEg9L3Vzci9sb2NhbC9zYmluOi91c3IvbG9jYWwvYmluOi91c3Ivc2JpbjovdXNyL2Jpbjovc2JpbjovYmluIiwiVVNFUj1naXQiLCJHSVRFQV9DVVNUT009L2RhdGEvZ2l0ZWEiXSwiRW50cnlwb2ludCI6WyIvdXNyL2Jpbi9lbnRyeXBvaW50Il0sIkNtZCI6WyIvYmluL3M2LXN2c2NhbiIsIi9ldGMvczYiXSwiVm9sdW1lcyI6eyIvZGF0YSI6e319LCJMYWJlbHMiOnsibWFpbnRhaW5lciI6Im1haW50YWluZXJzQGdpdGVhLmlvIiwib3JnLm9wZW5jb250YWluZXJzLmltYWdlLmNyZWF0ZWQiOiIyMDIzLTA5LTA4VDA4OjQ2OjAyWiIsIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS5yZXZpc2lvbiI6ImU1MDJiZTQ2ZjNhYzVmMTA3NWFiZDk2YmQ5YjMyNmE0YzFmN2U5NmYiLCJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2Uuc291cmNlIjoiaHR0cHM6Ly9naXRodWIuY29tL2dvLWdpdGVhL2dpdGVhLmdpdCIsIm9yZy5vcGVuY29udGFpbmVycy5pbWFnZS51cmwiOiJodHRwczovL2dpdGh1Yi5jb20vZ28tZ2l0ZWEvZ2l0ZWEifSwiQXJnc0VzY2FwZWQiOnRydWUsIk9uQnVpbGQiOm51bGx9LCJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0ODo0Mi4yOTgyOTg2MTNaIiwiaGlzdG9yeSI6W3siY3JlYXRlZCI6IjIwMjMtMDgtMDdUMTk6MjA6MjAuNzE4OTQ5ODRaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApIEFERCBmaWxlOjMyZmY1ZTdhNzhiODkwOTk2ZWU0NjgxY2MwYTI2MTg1ZDNlOWFjZGI0ZWIxZTJhYWNjYjI0MTFmOTIyZmVkNmIgaW4gLyAifSx7ImNyZWF0ZWQiOiIyMDIzLTA4LTA3VDE5OjIwOjIwLjg5NDE0MDYyM1oiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIENNRCBbXCIvYmluL3NoXCJdIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDguMjA3ODM4ODcyWiIsImNyZWF0ZWRfYnkiOiJMQUJFTCBtYWludGFpbmVyPW1haW50YWluZXJzQGdpdGVhLmlvIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0NjowOC4yMDc4Mzg4NzJaIiwiY3JlYXRlZF9ieSI6IkVYUE9TRSBtYXBbMjIvdGNwOnt9IDMwMDAvdGNwOnt9XSIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDguMjA3ODM4ODcyWiIsImNyZWF0ZWRfYnkiOiJSVU4gL2Jpbi9zaCAtYyBhcGsgLS1uby1jYWNoZSBhZGQgICAgIGJhc2ggICAgIGNhLWNlcnRpZmljYXRlcyAgICAgY3VybCAgICAgZ2V0dGV4dCAgICAgZ2l0ICAgICBsaW51eC1wYW0gICAgIG9wZW5zc2ggICAgIHM2ICAgICBzcWxpdGUgICAgIHN1LWV4ZWMgICAgIGdudXBnICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDkuNTE5MDk4MDNaIiwiY3JlYXRlZF9ieSI6IlJVTiAvYmluL3NoIC1jIGFkZGdyb3VwICAgICAtUyAtZyAxMDAwICAgICBnaXQgXHUwMDI2XHUwMDI2ICAgYWRkdXNlciAgICAgLVMgLUggLUQgICAgIC1oIC9kYXRhL2dpdCAgICAgLXMgL2Jpbi9iYXNoICAgICAtdSAxMDAwICAgICAtRyBnaXQgICAgIGdpdCBcdTAwMjZcdTAwMjYgICBlY2hvIFwiZ2l0OipcIiB8IGNocGFzc3dkIC1lICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDkuNTE5MDk4MDNaIiwiY3JlYXRlZF9ieSI6IkVOViBVU0VSPWdpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDkuNTE5MDk4MDNaIiwiY3JlYXRlZF9ieSI6IkVOViBHSVRFQV9DVVNUT009L2RhdGEvZ2l0ZWEiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWQiOiIyMDIzLTA5LTA4VDA4OjQ2OjA5LjUxOTA5ODAzWiIsImNyZWF0ZWRfYnkiOiJWT0xVTUUgWy9kYXRhXSIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDkuNTE5MDk4MDNaIiwiY3JlYXRlZF9ieSI6IkVOVFJZUE9JTlQgW1wiL3Vzci9iaW4vZW50cnlwb2ludFwiXSIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDkuNTE5MDk4MDNaIiwiY3JlYXRlZF9ieSI6IkNNRCBbXCIvYmluL3M2LXN2c2NhblwiIFwiL2V0Yy9zNlwiXSIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjMtMDktMDhUMDg6NDY6MDkuOTQyNTUyNTU3WiIsImNyZWF0ZWRfYnkiOiJDT1BZIGRvY2tlci9yb290IC8gIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0ODo0MC45NjcwNDc5NDhaIiwiY3JlYXRlZF9ieSI6IkNPUFkgL2dvL3NyYy9jb2RlLmdpdGVhLmlvL2dpdGVhL2dpdGVhIC9hcHAvZ2l0ZWEvZ2l0ZWEgIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0ODo0MS4wMTQ3OTE1MzFaIiwiY3JlYXRlZF9ieSI6IkNPUFkgL2dvL3NyYy9jb2RlLmdpdGVhLmlvL2dpdGVhL2Vudmlyb25tZW50LXRvLWluaSAvdXNyL2xvY2FsL2Jpbi9lbnZpcm9ubWVudC10by1pbmkgIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0ODo0MS4wMjczMTU0MTNaIiwiY3JlYXRlZF9ieSI6IkNPUFkgL2dvL3NyYy9jb2RlLmdpdGVhLmlvL2dpdGVhL2NvbnRyaWIvYXV0b2NvbXBsZXRpb24vYmFzaF9hdXRvY29tcGxldGUgL2V0Yy9wcm9maWxlLmQvZ2l0ZWFfYmFzaF9hdXRvY29tcGxldGUuc2ggIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0ODo0MS42MTQ3OTIxNVoiLCJjcmVhdGVkX2J5IjoiUlVOIC9iaW4vc2ggLWMgY2htb2QgNzU1IC91c3IvYmluL2VudHJ5cG9pbnQgL2FwcC9naXRlYS9naXRlYSAvdXNyL2xvY2FsL2Jpbi9naXRlYSAvdXNyL2xvY2FsL2Jpbi9lbnZpcm9ubWVudC10by1pbmkgIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0ODo0Mi4wNDc4Njg5MjRaIiwiY3JlYXRlZF9ieSI6IlJVTiAvYmluL3NoIC1jIGNobW9kIDc1NSAvZXRjL3M2L2dpdGVhLyogL2V0Yy9zNi9vcGVuc3NoLyogL2V0Yy9zNi8uczYtc3ZzY2FuLyogIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMy0wOS0wOFQwODo0ODo0Mi4yOTgyOTg2MTNaIiwiY3JlYXRlZF9ieSI6IlJVTiAvYmluL3NoIC1jIGNobW9kIDY0NCAvZXRjL3Byb2ZpbGUuZC9naXRlYV9iYXNoX2F1dG9jb21wbGV0ZS5zaCAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifV0sIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1Njo0NjkzMDU3Y2UyMzY0NzIwZDM5ZTU3ZTg1YTViOGUwYmQ5YWMzNTczNzE2MjM3NzM2ZDY0NzBlYzViN2I3MjMwIiwic2hhMjU2OjZmOWJlNTE5MzMyYzg5ODY5NmIwNjRmZDlkYTYwNDhlOTRmY2QzMDI0MWFjNTJmNTQxZDVmNjc2OGI5N2M4NjUiLCJzaGEyNTY6NjM5NzEzZGE1NjhkMzRmNjFlM2Y4NzFiNDI2NDM2YmE2NzZlZDc4NjcwOWJjYTVmMmEwOWNmMWRjZTEzMzU1ZCIsInNoYTI1NjpjZGY4YWU5ODk5ZDdlMTEzNTdmODdkMTVlODNjNTgzMjgwODFlZmVlOTQ5Mzc5YWU0NjIzNzQ5OTY5MDc2Y2M3Iiwic2hhMjU2OjUxM2RiY2I3M2ViN2NiOWNmOTJiNjJjYmQwZWY1ZTZmNjliYzU3MmI2N2Q1MzU4YTQyNzkyOGM3OGZhNzViMDAiLCJzaGEyNTY6ZGE5MTVkOWY0NmJkMmIxMjc4OGExZWE4YzBmMmNmZDBjMDZkNmQ4ZjYwNGZiOGEwYWI2MjNhMTI3Zjk5OGNjNiIsInNoYTI1NjpmZDMwNzgzNGJmYzQ5MDYzNGY2Mzk2NjliODA4NmQwOWViZDJkOTQxNTgzNmEwZTUxOTI2NDcwNzNjYjg4NWFlIiwic2hhMjU2OmE0YzhiMTNlMzIzNTQ4OGRjYzJiZDYwZmQxMjg2YWY5YmVhNzU1MWI2Yjc0NTQxMTQ0ZTg2NDdiYTg2YmMyMWIiLCJzaGEyNTY6YjAxNGI5YTIzYjA4NjA3OWFmM2I5MGM0MWJiYWNjMWZiZjNhNmNlZjM2MzEyNWNmNmE3MzFlNTU2ZGM4OTk3MSIsInNoYTI1NjpkN2QzZTE0ODJkZGY3YWI0MDMzZmNkZTI5MDlhZWM5YTNiNWYxM2I4MTFhY2QwMjExZTkyYzFhZWI2Mjc1YzE1Il19fQ==",
+      "repoDigests": [
+        "gitea/gitea@sha256:95ad1dc17f78eef1f12807a8f28e94e416587b266aa5153f7da3eafddc037b27"
+      ],
+      "architecture": "amd64",
+      "os": "linux"
+    }
+  },
+  "distro": {
+    "name": "alpine",
+    "version": "3.18.3",
+    "idLike": []
+  },
+  "descriptor": {
+    "name": "grype",
+    "version": "0.71.0",
+    "configuration": {
+      "output": [
+        "json"
+      ],
+      "file": "",
+      "distro": "",
+      "add-cpes-if-none": false,
+      "output-template-file": "",
+      "check-for-app-update": true,
+      "only-fixed": false,
+      "only-notfixed": false,
+      "platform": "",
+      "search": {
+        "scope": "Squashed",
+        "unindexed-archives": false,
+        "indexed-archives": true
+      },
+      "ignore": null,
+      "exclude": [],
+      "db": {
+        "cache-dir": "/home/johan/.cache/grype/db",
+        "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+        "ca-cert": "",
+        "auto-update": true,
+        "validate-by-hash-on-start": false,
+        "validate-age": true,
+        "max-allowed-built-age": 432000000000000
+      },
+      "externalSources": {
+        "enable": false,
+        "maven": {
+          "searchUpstreamBySha1": true,
+          "baseUrl": "https://search.maven.org/solrsearch/select"
+        }
+      },
+      "match": {
+        "java": {
+          "using-cpes": false
+        },
+        "dotnet": {
+          "using-cpes": false
+        },
+        "golang": {
+          "using-cpes": false
+        },
+        "javascript": {
+          "using-cpes": false
+        },
+        "python": {
+          "using-cpes": false
+        },
+        "ruby": {
+          "using-cpes": false
+        },
+        "rust": {
+          "using-cpes": false
+        },
+        "stock": {
+          "using-cpes": true
+        }
+      },
+      "fail-on-severity": "",
+      "registry": {
+        "insecure-skip-tls-verify": false,
+        "insecure-use-http": false,
+        "auth": null,
+        "ca-cert": ""
+      },
+      "show-suppressed": false,
+      "by-cve": false,
+      "name": "",
+      "default-image-pull-source": "",
+      "vex-documents": [],
+      "vex-add": []
+    },
+    "db": {
+      "built": "2023-10-18T01:27:01Z",
+      "schemaVersion": 5,
+      "location": "/home/johan/.cache/grype/db/5",
+      "checksum": "sha256:3d645110a85196185e04ca12f42bb7ca46c6946833db616c7db1c751f261ab04",
+      "error": null
+    },
+    "timestamp": "2023-10-18T13:08:28.564089666+02:00"
+  }
+}


### PR DESCRIPTION
The element `"description"` is not always available for a `"vulnerability"` in the JSON generated by Grype. This leads to the error `JSONObject["description"] not found.`

Example to reproduce (using Grype version 0.71.0 with the vulnerability db built 2023-10-18 01:27:01 +0000 UTC):

```bash
docker pull gitea/gitea:1.20.4
grype -o json <image_id> > grype-report-wo-description.json
```

To resolve this, I implemented a change to the `GrypeParser`, where the default value `"Unknown"` is set if `"description"` is missing.

### Testing done

I added a new test `GrypeParserWoDescriptionTest.java` to verify that a `"vulnerability"` without `"description"` can be parsed.

I ran `mvn verify`, and all tests are green.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
