### PR TITLE
Make descriptor classes public

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/registry/AcuCobolDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AcuCobolDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.AcuCobolParser;
  *
  * @author Lorenz Munsch
  */
-class AcuCobolDescriptor extends ParserDescriptor {
+public class AcuCobolDescriptor extends ParserDescriptor {
     private static final String ID = "acu-cobol";
     private static final String NAME = "AcuCobol";
 
-    AcuCobolDescriptor() {
+    public AcuCobolDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/AjcDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AjcDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.AjcParser;
  *
  * @author Lorenz Munsch
  */
-class AjcDescriptor extends ParserDescriptor {
+public class AjcDescriptor extends ParserDescriptor {
     private static final String ID = "aspectj";
     private static final String NAME = "AspectJ";
 
-    AjcDescriptor() {
+    public AjcDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/AndroidLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AndroidLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.AndroidLintParserAdapter;
  *
  * @author Lorenz Munsch
  */
-class AndroidLintDescriptor extends ParserDescriptor {
+public class AndroidLintDescriptor extends ParserDescriptor {
     private static final String ID = "android-lint";
     private static final String NAME = "Android Lint";
 
-    AndroidLintDescriptor() {
+    public AndroidLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/AnsibleLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AnsibleLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.AnsibleLintParser;
  *
  * @author Lorenz Munsch
  */
-class AnsibleLintDescriptor extends ParserDescriptor {
+public class AnsibleLintDescriptor extends ParserDescriptor {
     private static final String ID = "ansiblelint";
     private static final String NAME = "Ansible Lint";
 
-    AnsibleLintDescriptor() {
+    public AnsibleLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/AquaScannerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AquaScannerDescriptor.java
@@ -10,11 +10,11 @@ import static j2html.TagCreator.*;
  *
  * @author Juri Duval
  */
-class AquaScannerDescriptor extends ParserDescriptor {
+public class AquaScannerDescriptor extends ParserDescriptor {
     private static final String ID = "scannercli";
     private static final String NAME = "Aqua Scanner";
 
-    AquaScannerDescriptor() {
+    public AquaScannerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ArmccCompilerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ArmccCompilerDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.ArmccCompilerParser;
  *
  * @author Lorenz Munsch
  */
-class ArmccCompilerDescriptor extends CompositeParserDescriptor {
+public class ArmccCompilerDescriptor extends CompositeParserDescriptor {
     private static final String ID = "armcc";
     private static final String NAME = "Armcc Compiler";
 
-    ArmccCompilerDescriptor() {
+    public ArmccCompilerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/BluePearlDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/BluePearlDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.BluePearlParser;
  *
  * @author Simon Matthews
  */
-class BluePearlDescriptor extends ParserDescriptor {
+public class BluePearlDescriptor extends ParserDescriptor {
     private static final String ID = "bluepearl";
     private static final String NAME = "Blue Pearl Visual Verification Suite";
 
-    BluePearlDescriptor() {
+    public BluePearlDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/BrakemanDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/BrakemanDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.BrakemanParser;
  *
  * @author Lorenz Munsch
  */
-class BrakemanDescriptor extends ParserDescriptor {
+public class BrakemanDescriptor extends ParserDescriptor {
     private static final String ID = "brakeman";
     private static final String NAME = "Brakeman";
 
-    BrakemanDescriptor() {
+    public BrakemanDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/BuckminsterDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/BuckminsterDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.BuckminsterParser;
  *
  * @author Lorenz Munsch
  */
-class BuckminsterDescriptor extends ParserDescriptor {
+public class BuckminsterDescriptor extends ParserDescriptor {
     private static final String ID = "buckminster";
     private static final String NAME = "Buckminster";
 
-    BuckminsterDescriptor() {
+    public BuckminsterDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CadenceIncisiveDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CadenceIncisiveDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.CadenceIncisiveParser;
  *
  * @author Lorenz Munsch
  */
-class CadenceIncisiveDescriptor extends ParserDescriptor {
+public class CadenceIncisiveDescriptor extends ParserDescriptor {
     private static final String ID = "cadence";
     private static final String NAME = "Cadence Incisive";
 
-    CadenceIncisiveDescriptor() {
+    public CadenceIncisiveDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CargoClippyDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CargoClippyDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.CargoClippyParser;
  *
  * @author Ullrich Hafner
  */
-class CargoClippyDescriptor extends ParserDescriptor {
+public class CargoClippyDescriptor extends ParserDescriptor {
     private static final String ID = "clippy";
     private static final String NAME = "Cargo Clippy";
 
-    CargoClippyDescriptor() {
+    public CargoClippyDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CargoDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CargoDescriptor.java
@@ -9,11 +9,11 @@ import edu.hm.hafner.analysis.parser.CargoCheckParser;
  *
  * @author Lorenz Munsch
  */
-class CargoDescriptor extends ParserDescriptor {
+public class CargoDescriptor extends ParserDescriptor {
     private static final String ID = "cargo";
     private static final String NAME = "Cargo Check";
 
-    CargoDescriptor() {
+    public CargoDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CcmDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CcmDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.ccm.CcmParser;
  *
  * @author Lorenz Munsch
  */
-class CcmDescriptor extends ParserDescriptor {
+public class CcmDescriptor extends ParserDescriptor {
     private static final String ID = "ccm";
     private static final String NAME = "CCM";
 
-    CcmDescriptor() {
+    public CcmDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CheckStyleDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CheckStyleDescriptor.java
@@ -11,13 +11,13 @@ import edu.hm.hafner.analysis.util.Deferred;
  *
  * @author Lorenz Munsch
  */
-class CheckStyleDescriptor extends ParserDescriptor {
+public class CheckStyleDescriptor extends ParserDescriptor {
     private static final String ID = "checkstyle";
     private static final String NAME = "CheckStyle";
 
     private final Deferred<CheckStyleRules> messages = new Deferred<>(CheckStyleRules::new);
 
-    CheckStyleDescriptor() {
+    public CheckStyleDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ClairDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ClairDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.ClairParser;
  *
  * @author Lorenz Munsch
  */
-class ClairDescriptor extends ParserDescriptor {
+public class ClairDescriptor extends ParserDescriptor {
     private static final String ID = "clair";
     private static final String NAME = "Clair Scanner";
 
-    ClairDescriptor() {
+    public ClairDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ClangAnalyzerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ClangAnalyzerDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.ClangAnalyzerPlistParser;
  *
  * @author Lorenz Munsch
  */
-class ClangAnalyzerDescriptor extends ParserDescriptor {
+public class ClangAnalyzerDescriptor extends ParserDescriptor {
     private static final String ID = "clang-analyzer";
     private static final String NAME = "Clang Analyzer";
 
-    ClangAnalyzerDescriptor() {
+    public ClangAnalyzerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ClangDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ClangDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.ClangParser;
  *
  * @author Lorenz Munsch
  */
-class ClangDescriptor extends ParserDescriptor {
+public class ClangDescriptor extends ParserDescriptor {
     private static final String ID = "clang";
     private static final String NAME = "Clang";
 
-    ClangDescriptor() {
+    public ClangDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ClangTidyDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ClangTidyDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.ClangTidyParser;
  *
  * @author Lorenz Munsch
  */
-class ClangTidyDescriptor extends ParserDescriptor {
+public class ClangTidyDescriptor extends ParserDescriptor {
     private static final String ID = "clang-tidy";
     private static final String NAME = "Clang-Tidy";
 
-    ClangTidyDescriptor() {
+    public ClangTidyDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CmakeDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CmakeDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.CMakeParser;
  *
  * @author Lorenz Munsch
  */
-class CmakeDescriptor extends ParserDescriptor {
+public class CmakeDescriptor extends ParserDescriptor {
     private static final String ID = "cmake";
     private static final String NAME = "CMake";
 
-    CmakeDescriptor() {
+    public CmakeDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CodeAnalysisDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CodeAnalysisDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.CodeAnalysisParser;
  *
  * @author Lorenz Munsch
  */
-class CodeAnalysisDescriptor extends ParserDescriptor {
+public class CodeAnalysisDescriptor extends ParserDescriptor {
     private static final String ID = "code-analysis";
     private static final String NAME = "Code Analysis";
 
-    CodeAnalysisDescriptor() {
+    public CodeAnalysisDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CodeCheckerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CodeCheckerDescriptor.java
@@ -7,11 +7,11 @@ import edu.hm.hafner.analysis.parser.CodeCheckerParser;
  * A descriptor for the Codechecker parser.
  *
  */
-class CodeCheckerDescriptor extends ParserDescriptor {
+public class CodeCheckerDescriptor extends ParserDescriptor {
     private static final String ID = "code-checker";
     private static final String NAME = "CodeChecker";
 
-    CodeCheckerDescriptor() {
+    public CodeCheckerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CodeGeneratorDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CodeGeneratorDescriptor.java
@@ -14,7 +14,7 @@ public class CodeGeneratorDescriptor extends ParserDescriptor {
     private static final String ID = "code-generator";
     private static final String NAME = "Code Generator Tool";
 
-    CodeGeneratorDescriptor() {
+    public CodeGeneratorDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CodeNarcDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CodeNarcDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.CodeNarcAdapter;
  *
  * @author Lorenz Munsch
  */
-class CodeNarcDescriptor extends ParserDescriptor {
+public class CodeNarcDescriptor extends ParserDescriptor {
     private static final String ID = "codenarc";
     private static final String NAME = "CodeNarc";
 
-    CodeNarcDescriptor() {
+    public CodeNarcDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CoolfluxChessccDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CoolfluxChessccDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.CoolfluxChessccParser;
  *
  * @author Lorenz Munsch
  */
-class CoolfluxChessccDescriptor extends ParserDescriptor {
+public class CoolfluxChessccDescriptor extends ParserDescriptor {
     private static final String ID = "coolflux";
     private static final String NAME = "Coolflux DSP Compiler";
 
-    CoolfluxChessccDescriptor() {
+    public CoolfluxChessccDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CpdDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CpdDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.dry.cpd.CpdParser;
  *
  * @author Lorenz Munsch
  */
-class CpdDescriptor extends DryDescriptor {
+public class CpdDescriptor extends DryDescriptor {
     private static final String ID = "cpd";
     private static final String NAME = "CPD";
 
-    CpdDescriptor() {
+    public CpdDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CppCheckDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CppCheckDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.CppCheckAdapter;
  *
  * @author Lorenz Munsch
  */
-class CppCheckDescriptor extends ParserDescriptor {
+public class CppCheckDescriptor extends ParserDescriptor {
     private static final String ID = "cppcheck";
     private static final String NAME = "CPPCheck";
 
-    CppCheckDescriptor() {
+    public CppCheckDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CppLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CppLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.CppLintParser;
  *
  * @author Lorenz Munsch
  */
-class CppLintDescriptor extends ParserDescriptor {
+public class CppLintDescriptor extends ParserDescriptor {
     private static final String ID = "cpplint";
     private static final String NAME = "Cpplint";
 
-    CppLintDescriptor() {
+    public CppLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
@@ -10,7 +10,7 @@ public class CrossCoreEmbeddedStudioDescriptor extends ParserDescriptor {
     private static final String ID = "crosscore-embedded-studio";
     private static final String NAME = "CrossCore Embedded Studio (CCES)";
 
-    CrossCoreEmbeddedStudioDescriptor() {
+    public CrossCoreEmbeddedStudioDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/CssLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CssLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.LintParser;
  *
  * @author Lorenz Munsch
  */
-class CssLintDescriptor extends ParserDescriptor {
+public class CssLintDescriptor extends ParserDescriptor {
     private static final String ID = "csslint";
     private static final String NAME = "CSS-Lint";
 
-    CssLintDescriptor() {
+    public CssLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DScannerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DScannerDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.DScannerParser;
  *
  * @author Lorenz Munsch
  */
-class DScannerDescriptor extends ParserDescriptor {
+public class DScannerDescriptor extends ParserDescriptor {
     private static final String ID = "dscanner";
     private static final String NAME = "DScanner";
 
-    DScannerDescriptor() {
+    public DScannerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DartAnalyzeDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DartAnalyzeDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.DartAnalyzeParserAdapter;
  *
  * @author Ullrich Hafner
  */
-class DartAnalyzeDescriptor extends ParserDescriptor {
+public class DartAnalyzeDescriptor extends ParserDescriptor {
     private static final String ID = "dart";
     private static final String NAME = "Dart Analyze";
 
-    DartAnalyzeDescriptor() {
+    public DartAnalyzeDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DetektDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DetektDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class DetektDescriptor extends ParserDescriptor {
+public class DetektDescriptor extends ParserDescriptor {
     private static final String ID = "detekt";
     private static final String NAME = "Detekt";
 
-    DetektDescriptor() {
+    public DetektDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DiabCDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DiabCDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.DiabCParser;
  *
  * @author Lorenz Munsch
  */
-class DiabCDescriptor extends ParserDescriptor {
+public class DiabCDescriptor extends ParserDescriptor {
     private static final String ID = "diabc";
     private static final String NAME = "Wind River Diab Compiler (C/C++)";
 
-    DiabCDescriptor() {
+    public DiabCDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DocFxDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DocFxDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.DocFxAdapter;
  *
  * @author Lorenz Munsch
  */
-class DocFxDescriptor extends ParserDescriptor {
+public class DocFxDescriptor extends ParserDescriptor {
     private static final String ID = "docfx";
     private static final String NAME = "DocFX";
 
-    DocFxDescriptor() {
+    public DocFxDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DockerLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DockerLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.DockerLintParser;
  *
  * @author Lorenz Munsch
  */
-class DockerLintDescriptor extends ParserDescriptor {
+public class DockerLintDescriptor extends ParserDescriptor {
     private static final String ID = "dockerlint";
     private static final String NAME = "Dockerfile Lint";
 
-    DockerLintDescriptor() {
+    public DockerLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DoxygenDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DoxygenDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.DoxygenParser;
  *
  * @author Lorenz Munsch
  */
-class DoxygenDescriptor extends ParserDescriptor {
+public class DoxygenDescriptor extends ParserDescriptor {
     private static final String ID = "doxygen";
     private static final String NAME = "Doxygen";
 
-    DoxygenDescriptor() {
+    public DoxygenDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DrMemoryDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DrMemoryDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.DrMemoryParser;
  *
  * @author Lorenz Munsch
  */
-class DrMemoryDescriptor extends ParserDescriptor {
+public class DrMemoryDescriptor extends ParserDescriptor {
     private static final String ID = "dr-memory";
     private static final String NAME = "Dr. Memory";
 
-    DrMemoryDescriptor() {
+    public DrMemoryDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/DupfinderDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DupfinderDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.dry.dupfinder.DupFinderParser;
  *
  * @author Lorenz Munsch
  */
-class DupfinderDescriptor extends DryDescriptor {
+public class DupfinderDescriptor extends DryDescriptor {
     private static final String ID = "dupfinder";
     private static final String NAME = "Resharper DupFinder";
 
-    DupfinderDescriptor() {
+    public DupfinderDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/EclipseDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/EclipseDescriptor.java
@@ -12,11 +12,11 @@ import edu.hm.hafner.analysis.parser.EclipseXMLParser;
  *
  * @author Lorenz Munsch
  */
-class EclipseDescriptor extends CompositeParserDescriptor {
+public class EclipseDescriptor extends CompositeParserDescriptor {
     private static final String ID = "eclipse";
     private static final String NAME = "Eclipse ECJ";
 
-    EclipseDescriptor() {
+    public EclipseDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/EmbeddedEngineerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/EmbeddedEngineerDescriptor.java
@@ -12,7 +12,7 @@ public class EmbeddedEngineerDescriptor extends ParserDescriptor {
     private static final String ID = "embedded-engineer";
     private static final String NAME = "Embedded Engineer Tool";
 
-    EmbeddedEngineerDescriptor() {
+    public EmbeddedEngineerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ErlcDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ErlcDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.ErlcParser;
  *
  * @author Lorenz Munsch
  */
-class ErlcDescriptor extends ParserDescriptor {
+public class ErlcDescriptor extends ParserDescriptor {
     private static final String ID = "erlc";
     private static final String NAME = "Erlang Compiler (erlc)";
 
-    ErlcDescriptor() {
+    public ErlcDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ErrorProneDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ErrorProneDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.GradleErrorProneParser;
  *
  * @author Lorenz Munsch
  */
-class ErrorProneDescriptor extends CompositeParserDescriptor {
+public class ErrorProneDescriptor extends CompositeParserDescriptor {
     private static final String ID = "error-prone";
     private static final String NAME = "Error Prone";
 
-    ErrorProneDescriptor() {
+    public ErrorProneDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/EsLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/EsLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class EsLintDescriptor extends ParserDescriptor {
+public class EsLintDescriptor extends ParserDescriptor {
     private static final String ID = "eslint";
     private static final String NAME = "ESLint";
 
-    EsLintDescriptor() {
+    public EsLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/FindBugsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FindBugsDescriptor.java
@@ -21,7 +21,7 @@ public class FindBugsDescriptor extends ParserDescriptor {
 
     private final Deferred<FindBugsMessages> messages = new Deferred<>(FindBugsMessages::new);
 
-    FindBugsDescriptor() {
+    public FindBugsDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/Flake8Descriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/Flake8Descriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.Flake8Adapter;
  *
  * @author Lorenz Munsch
  */
-class Flake8Descriptor extends ParserDescriptor {
+public class Flake8Descriptor extends ParserDescriptor {
     private static final String ID = "flake8";
     private static final String NAME = "Flake8";
 
-    Flake8Descriptor() {
+    public Flake8Descriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/FlawfinderDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FlawfinderDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.FlawfinderParser;
  *
  * @author Lorenz Munsch
  */
-class FlawfinderDescriptor extends ParserDescriptor {
+public class FlawfinderDescriptor extends ParserDescriptor {
     private static final String ID = "flawfinder";
     private static final String NAME = "FlawFinder";
 
-    FlawfinderDescriptor() {
+    public FlawfinderDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/FlexSdkDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FlexSdkDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.FlexSdkParser;
  *
  * @author Lorenz Munsch
  */
-class FlexSdkDescriptor extends ParserDescriptor {
+public class FlexSdkDescriptor extends ParserDescriptor {
     private static final String ID = "flex";
     private static final String NAME = "Flex SDK Compiler";
 
-    FlexSdkDescriptor() {
+    public FlexSdkDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/FlowDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FlowDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.FlowParser;
  *
  * @author Lorenz Munsch
  */
-class FlowDescriptor extends ParserDescriptor {
+public class FlowDescriptor extends ParserDescriptor {
     private static final String ID = "flow";
     private static final String NAME = "Flow";
 
-    FlowDescriptor() {
+    public FlowDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/FoodCriticDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FoodCriticDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.FoodcriticParser;
  *
  * @author Lorenz Munsch
  */
-class FoodCriticDescriptor extends ParserDescriptor {
+public class FoodCriticDescriptor extends ParserDescriptor {
     private static final String ID = "foodcritic";
     private static final String NAME = "Foodcritic";
 
-    FoodCriticDescriptor() {
+    public FoodCriticDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/FxcopDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FxcopDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.fxcop.FxCopParser;
  *
  * @author Lorenz Munsch
  */
-class FxcopDescriptor extends ParserDescriptor {
+public class FxcopDescriptor extends ParserDescriptor {
     private static final String ID = "fxcop";
     private static final String NAME = "FxCop";
 
-    FxcopDescriptor() {
+    public FxcopDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/Gcc4Descriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/Gcc4Descriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.Gcc4LinkerParser;
  *
  * @author Lorenz Munsch
  */
-class Gcc4Descriptor extends CompositeParserDescriptor {
+public class Gcc4Descriptor extends CompositeParserDescriptor {
     private static final String ID = "gcc";
     private static final String NAME = "GNU C Compiler (gcc)";
 
-    Gcc4Descriptor() {
+    public Gcc4Descriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GccDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GccDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.GccParser;
  *
  * @author Lorenz Munsch
  */
-class GccDescriptor extends ParserDescriptor {
+public class GccDescriptor extends ParserDescriptor {
     private static final String ID = "gcc3";
     private static final String NAME = "GNU C Compiler 3 (gcc)";
 
-    GccDescriptor() {
+    public GccDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GendarmeDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GendarmeDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.gendarme.GendarmeParser;
  *
  * @author Lorenz Munsch
  */
-class GendarmeDescriptor extends ParserDescriptor {
+public class GendarmeDescriptor extends ParserDescriptor {
     private static final String ID = "gendarme";
     private static final String NAME = "Gendarme";
 
-    GendarmeDescriptor() {
+    public GendarmeDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GhsMultiDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GhsMultiDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.GhsMultiParser;
  *
  * @author Lorenz Munsch
  */
-class GhsMultiDescriptor extends ParserDescriptor {
+public class GhsMultiDescriptor extends ParserDescriptor {
     private static final String ID = "ghs-multi";
     private static final String NAME = "GHS Multi Compiler";
 
-    GhsMultiDescriptor() {
+    public GhsMultiDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GnatDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GnatDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.GnatParser;
  *
  * @author Lorenz Munsch
  */
-class GnatDescriptor extends ParserDescriptor {
+public class GnatDescriptor extends ParserDescriptor {
     private static final String ID = "gnat";
     private static final String NAME = "Ada Compiler (gnat)";
 
-    GnatDescriptor() {
+    public GnatDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GnuFortranDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GnuFortranDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.GnuFortranParser;
  *
  * @author Lorenz Munsch
  */
-class GnuFortranDescriptor extends ParserDescriptor {
+public class GnuFortranDescriptor extends ParserDescriptor {
     private static final String ID = "fortran";
     private static final String NAME = "GNU Fortran Compiler";
 
-    GnuFortranDescriptor() {
+    public GnuFortranDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GoLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GoLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.GoLintParser;
  *
  * @author Lorenz Munsch
  */
-class GoLintDescriptor extends ParserDescriptor {
+public class GoLintDescriptor extends ParserDescriptor {
     private static final String ID = "golint";
     private static final String NAME = "Go Lint";
 
-    GoLintDescriptor() {
+    public GoLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GoVetDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GoVetDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.GoVetParser;
  *
  * @author Lorenz Munsch
  */
-class GoVetDescriptor extends ParserDescriptor {
+public class GoVetDescriptor extends ParserDescriptor {
     private static final String ID = "go-vet";
     private static final String NAME = "Go Vet";
 
-    GoVetDescriptor() {
+    public GoVetDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GrypeDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GrypeDescriptor.java
@@ -10,7 +10,7 @@ public class GrypeDescriptor extends ParserDescriptor {
     private static final String ID = "grype";
     private static final String NAME = "Grype";
 
-    GrypeDescriptor() {
+    public GrypeDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/HadoLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/HadoLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.HadoLintParser;
  *
  * @author Lorenz Munsch
  */
-class HadoLintDescriptor extends ParserDescriptor {
+public class HadoLintDescriptor extends ParserDescriptor {
     private static final String ID = "hadolint";
     private static final String NAME = "HadoLint";
 
-    HadoLintDescriptor() {
+    public HadoLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/IarCstatDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/IarCstatDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.IarCstatParser;
  *
  * @author Lorenz Munsch
  */
-class IarCstatDescriptor extends ParserDescriptor {
+public class IarCstatDescriptor extends ParserDescriptor {
     private static final String ID = "iar-cstat";
     private static final String NAME = "IAR C-STAT";
 
-    IarCstatDescriptor() {
+    public IarCstatDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/IarDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/IarDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.IarParser;
  *
  * @author Lorenz Munsch
  */
-class IarDescriptor extends ParserDescriptor {
+public class IarDescriptor extends ParserDescriptor {
     private static final String ID = "iar";
     private static final String NAME = "IAR Compiler (C/C++)";
 
-    IarDescriptor() {
+    public IarDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/IbLinterDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/IbLinterDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class IbLinterDescriptor extends ParserDescriptor {
+public class IbLinterDescriptor extends ParserDescriptor {
     private static final String ID = "iblinter";
     private static final String NAME = "IbLinter";
 
-    IbLinterDescriptor() {
+    public IbLinterDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/IdeaInspectionDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/IdeaInspectionDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.IdeaInspectionParser;
  *
  * @author Lorenz Munsch
  */
-class IdeaInspectionDescriptor extends ParserDescriptor {
+public class IdeaInspectionDescriptor extends ParserDescriptor {
     private static final String ID = "idea";
     private static final String NAME = "IntelliJ IDEA Inspections";
 
-    IdeaInspectionDescriptor() {
+    public IdeaInspectionDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/InferDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/InferDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.pmd.PmdParser;
  *
  * @author Lorenz Munsch
  */
-class InferDescriptor extends ParserDescriptor {
+public class InferDescriptor extends ParserDescriptor {
     private static final String ID = "infer";
     private static final String NAME = "Infer";
 
-    InferDescriptor() {
+    public InferDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/IntelDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/IntelDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.IntelParser;
  *
  * @author Lorenz Munsch
  */
-class IntelDescriptor extends ParserDescriptor {
+public class IntelDescriptor extends ParserDescriptor {
     private static final String ID = "intel";
     private static final String NAME = "Intel Compiler (C, Fortran)";
 
-    IntelDescriptor() {
+    public IntelDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/InvalidsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/InvalidsDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.InvalidsParser;
  *
  * @author Lorenz Munsch
  */
-class InvalidsDescriptor extends ParserDescriptor {
+public class InvalidsDescriptor extends ParserDescriptor {
     private static final String ID = "invalids";
     private static final String NAME = "Oracle Invalids";
 
-    InvalidsDescriptor() {
+    public InvalidsDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/JUnitDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/JUnitDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.JUnitAdapter;
  *
  * @author Lorenz Munsch
  */
-class JUnitDescriptor extends ParserDescriptor {
+public class JUnitDescriptor extends ParserDescriptor {
     private static final String ID = "junit";
     private static final String NAME = "JUnit";
 
-    JUnitDescriptor() {
+    public JUnitDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/JavaDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/JavaDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.JavacParser;
  *
  * @author Lorenz Munsch
  */
-class JavaDescriptor extends CompositeParserDescriptor {
+public class JavaDescriptor extends CompositeParserDescriptor {
     private static final String ID = "java";
     private static final String NAME = "Java Compiler";
 
-    JavaDescriptor() {
+    public JavaDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/JavaDocDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/JavaDocDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.JavaDocParser;
  *
  * @author Lorenz Munsch
  */
-class JavaDocDescriptor extends ParserDescriptor {
+public class JavaDocDescriptor extends ParserDescriptor {
     private static final String ID = "javadoc-warnings";
     private static final String NAME = "JavaDoc";
 
-    JavaDocDescriptor() {
+    public JavaDocDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/JcreportDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/JcreportDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.jcreport.JcReportParser;
  *
  * @author Lorenz Munsch
  */
-class JcreportDescriptor extends ParserDescriptor {
+public class JcreportDescriptor extends ParserDescriptor {
     private static final String ID = "jc-report";
     private static final String NAME = "JCReport";
 
-    JcreportDescriptor() {
+    public JcreportDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/JsHintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/JsHintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.JsHintAdapter;
  *
  * @author Lorenz Munsch
  */
-class JsHintDescriptor extends ParserDescriptor {
+public class JsHintDescriptor extends ParserDescriptor {
     private static final String ID = "js-hint";
     private static final String NAME = "JsHint";
 
-    JsHintDescriptor() {
+    public JsHintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/JsLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/JsLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.LintParser;
  *
  * @author Lorenz Munsch
  */
-class JsLintDescriptor extends ParserDescriptor {
+public class JsLintDescriptor extends ParserDescriptor {
     private static final String ID = "jslint";
     private static final String NAME = "JSLint";
 
-    JsLintDescriptor() {
+    public JsLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/KlocWorkDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/KlocWorkDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.KlocWorkAdapter;
  *
  * @author Lorenz Munsch
  */
-class KlocWorkDescriptor extends ParserDescriptor {
+public class KlocWorkDescriptor extends ParserDescriptor {
     private static final String ID = "klocwork";
     private static final String NAME = "Klocwork";
 
-    KlocWorkDescriptor() {
+    public KlocWorkDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/KotlinDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/KotlinDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.JavacParser;
  *
  * @author Lorenz Munsch
  */
-class KotlinDescriptor extends ParserDescriptor {
+public class KotlinDescriptor extends ParserDescriptor {
     private static final String ID = "kotlin";
     private static final String NAME = "Kotlin";
 
-    KotlinDescriptor() {
+    public KotlinDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/KtLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/KtLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class KtLintDescriptor extends ParserDescriptor {
+public class KtLintDescriptor extends ParserDescriptor {
     private static final String ID = "ktlint";
     private static final String NAME = "KtLint";
 
-    KtLintDescriptor() {
+    public KtLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/MavenConsoleDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/MavenConsoleDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.MavenConsoleParser;
  *
  * @author Lorenz Munsch
  */
-class MavenConsoleDescriptor extends ParserDescriptor {
+public class MavenConsoleDescriptor extends ParserDescriptor {
     private static final String ID = "maven-warnings";
     private static final String NAME = "Maven";
 
-    MavenConsoleDescriptor() {
+    public MavenConsoleDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/MentorGraphicsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/MentorGraphicsDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.MentorParser;
  *
  * @author Lorenz Munsch
  */
-class MentorGraphicsDescriptor extends ParserDescriptor {
+public class MentorGraphicsDescriptor extends ParserDescriptor {
     private static final String ID = "modelsim";
     private static final String NAME = "Mentor Graphics Modelsim/Questa Simulators";
 
-    MentorGraphicsDescriptor() {
+    public MentorGraphicsDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/MetrowerksCodeWarriorDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/MetrowerksCodeWarriorDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.MetrowerksCwLinkerParser;
  *
  * @author Lorenz Munsch
  */
-class MetrowerksCodeWarriorDescriptor extends CompositeParserDescriptor {
+public class MetrowerksCodeWarriorDescriptor extends CompositeParserDescriptor {
     private static final String ID = "metrowerks";
     private static final String NAME = "Metrowerks CodeWarrior Compiler";
 
-    MetrowerksCodeWarriorDescriptor() {
+    public MetrowerksCodeWarriorDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/MsBuildDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/MsBuildDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.MsBuildParser;
  *
  * @author Lorenz Munsch
  */
-class MsBuildDescriptor extends ParserDescriptor {
+public class MsBuildDescriptor extends ParserDescriptor {
     private static final String ID = "msbuild";
     private static final String NAME = "MSBuild";
 
-    MsBuildDescriptor() {
+    public MsBuildDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/MyPyDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/MyPyDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.MyPyAdapter;
  *
  * @author Lorenz Munsch
  */
-class MyPyDescriptor extends ParserDescriptor {
+public class MyPyDescriptor extends ParserDescriptor {
     private static final String ID = "mypy";
     private static final String NAME = "MyPy";
 
-    MyPyDescriptor() {
+    public MyPyDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/NagFortranDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/NagFortranDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.NagFortranParser;
  *
  * @author Lorenz Munsch
  */
-class NagFortranDescriptor extends ParserDescriptor {
+public class NagFortranDescriptor extends ParserDescriptor {
     private static final String ID = "nag-fortran";
     private static final String NAME = "NAG Fortran Compiler";
 
-    NagFortranDescriptor() {
+    public NagFortranDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/NativeFormatDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/NativeFormatDescriptor.java
@@ -16,11 +16,11 @@ import static j2html.TagCreator.*;
  *
  * @author Lorenz Munsch
  */
-class NativeFormatDescriptor extends CompositeParserDescriptor {
+public class NativeFormatDescriptor extends CompositeParserDescriptor {
     private static final String ID = "native";
     private static final String NAME = "Native Analysis Model Format";
 
-    NativeFormatDescriptor() {
+    public NativeFormatDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/OELintAdvDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/OELintAdvDescriptor.java
@@ -6,11 +6,11 @@ import edu.hm.hafner.analysis.parser.OELintAdvParser;
 /**
  * Descriptor for oelint-adv.
  */
-class OELintAdvDescriptor extends ParserDescriptor {
+public class OELintAdvDescriptor extends ParserDescriptor {
     private static final String ID = "oelint-adv";
     private static final String NAME = ID;
 
-    OELintAdvDescriptor() {
+    public OELintAdvDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/OtDockerLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/OtDockerLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.OTDockerLintParser;
  *
  * @author Lorenz Munsch
  */
-class OtDockerLintDescriptor extends ParserDescriptor {
+public class OtDockerLintDescriptor extends ParserDescriptor {
     private static final String ID = "ot-docker-linter";
     private static final String NAME = "OT Docker Linter";
 
-    OtDockerLintDescriptor() {
+    public OtDockerLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/OwaspDependencyCheckDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/OwaspDependencyCheckDescriptor.java
@@ -10,7 +10,7 @@ public class OwaspDependencyCheckDescriptor extends ParserDescriptor {
     private static final String ID = "owasp-dependency-check";
     private static final String NAME = "OWASP Dependency Check";
 
-    OwaspDependencyCheckDescriptor() {
+    public OwaspDependencyCheckDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PcLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PcLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.MsBuildParser;
  *
  * @author Lorenz Munsch
  */
-class PcLintDescriptor extends ParserDescriptor {
+public class PcLintDescriptor extends ParserDescriptor {
     private static final String ID = "pclint";
     private static final String NAME = "PC-Lint Tool";
 
-    PcLintDescriptor() {
+    public PcLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/Pep8Descriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/Pep8Descriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.Pep8Parser;
  *
  * @author Lorenz Munsch
  */
-class Pep8Descriptor extends ParserDescriptor {
+public class Pep8Descriptor extends ParserDescriptor {
     private static final String ID = "pep8";
     private static final String NAME = "PEP8";
 
-    Pep8Descriptor() {
+    public Pep8Descriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PerforceDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PerforceDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.P4Parser;
  *
  * @author Lorenz Munsch
  */
-class PerforceDescriptor extends ParserDescriptor {
+public class PerforceDescriptor extends ParserDescriptor {
     private static final String ID = "perforce";
     private static final String NAME = "Perforce Compiler";
 
-    PerforceDescriptor() {
+    public PerforceDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PerlCriticDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PerlCriticDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.PerlCriticParser;
  *
  * @author Lorenz Munsch
  */
-class PerlCriticDescriptor extends ParserDescriptor {
+public class PerlCriticDescriptor extends ParserDescriptor {
     private static final String ID = "perl-critic";
     private static final String NAME = "Perl::Critic";
 
-    PerlCriticDescriptor() {
+    public PerlCriticDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PhpCodeSnifferDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PhpCodeSnifferDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class PhpCodeSnifferDescriptor extends ParserDescriptor {
+public class PhpCodeSnifferDescriptor extends ParserDescriptor {
     private static final String ID = "php-code-sniffer";
     private static final String NAME = "PHP_CodeSniffer";
 
-    PhpCodeSnifferDescriptor() {
+    public PhpCodeSnifferDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PhpDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PhpDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.PhpParser;
  *
  * @author Lorenz Munsch
  */
-class PhpDescriptor extends ParserDescriptor {
+public class PhpDescriptor extends ParserDescriptor {
     private static final String ID = "php";
     private static final String NAME = "PHP Runtime";
 
-    PhpDescriptor() {
+    public PhpDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PhpStanDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PhpStanDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class PhpStanDescriptor extends ParserDescriptor {
+public class PhpStanDescriptor extends ParserDescriptor {
     private static final String ID = "phpstan";
     private static final String NAME = "PHPStan";
 
-    PhpStanDescriptor() {
+    public PhpStanDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PitDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PitDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.PitAdapter;
  *
  * @author Lorenz Munsch
  */
-class PitDescriptor extends ParserDescriptor {
+public class PitDescriptor extends ParserDescriptor {
     private static final String ID = "pit";
     private static final String NAME = "PIT";
 
-    PitDescriptor() {
+    public PitDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PmdDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PmdDescriptor.java
@@ -11,13 +11,13 @@ import edu.hm.hafner.analysis.util.Deferred;
  *
  * @author Lorenz Munsch
  */
-class PmdDescriptor extends ParserDescriptor {
+public class PmdDescriptor extends ParserDescriptor {
     private static final String ID = "pmd";
     private static final String NAME = "PMD";
 
     private final Deferred<PmdMessages> messages = new Deferred<>(PmdMessages::new);
 
-    PmdDescriptor() {
+    public PmdDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PnpmAuditDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PnpmAuditDescriptor.java
@@ -15,7 +15,7 @@ public class PnpmAuditDescriptor extends ParserDescriptor {
     private static final String ID = "pnpm-audit";
     private static final String NAME = "pnpm Audit";
 
-    PnpmAuditDescriptor() {
+    public PnpmAuditDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PolyspaceDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PolyspaceDescriptor.java
@@ -13,7 +13,7 @@ public class PolyspaceDescriptor extends ParserDescriptor {
     private static final String ID = "polyspace-parser";
     private static final String NAME = "Polyspace Tool";
 
-    PolyspaceDescriptor() {
+    public PolyspaceDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PreFastDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PreFastDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.PreFastParser;
  *
  * @author Lorenz Munsch
  */
-class PreFastDescriptor extends ParserDescriptor {
+public class PreFastDescriptor extends ParserDescriptor {
     private static final String ID = "prefast";
     private static final String NAME = "PREfast";
 
-    PreFastDescriptor() {
+    public PreFastDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ProtoLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ProtoLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.ProtoLintParser;
  *
  * @author Lorenz Munsch
  */
-class ProtoLintDescriptor extends ParserDescriptor {
+public class ProtoLintDescriptor extends ParserDescriptor {
     private static final String ID = "protolint";
     private static final String NAME = "ProtoLint";
 
-    ProtoLintDescriptor() {
+    public ProtoLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PuppetLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PuppetLintDescriptor.java
@@ -10,11 +10,11 @@ import static j2html.TagCreator.*;
  *
  * @author Lorenz Munsch
  */
-class PuppetLintDescriptor extends ParserDescriptor {
+public class PuppetLintDescriptor extends ParserDescriptor {
     private static final String ID = "puppetlint";
     private static final String NAME = "Puppet Lint";
 
-    PuppetLintDescriptor() {
+    public PuppetLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PvsStudioDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PvsStudioDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.pvsstudio.PVSStudioParser;
  *
  * @author Lorenz Munsch
  */
-class PvsStudioDescriptor extends ParserDescriptor {
+public class PvsStudioDescriptor extends ParserDescriptor {
     private static final String ID = "pvs-studio";
     private static final String NAME = "PVS-Studio";
 
-    PvsStudioDescriptor() {
+    public PvsStudioDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PyDocStyleDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PyDocStyleDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.PyDocStyleAdapter;
  *
  * @author Lorenz Munsch
  */
-class PyDocStyleDescriptor extends ParserDescriptor {
+public class PyDocStyleDescriptor extends ParserDescriptor {
     private static final String ID = "pydocstyle";
     private static final String NAME = "PyDocStyle";
 
-    PyDocStyleDescriptor() {
+    public PyDocStyleDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PyLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PyLintDescriptor.java
@@ -11,13 +11,13 @@ import edu.hm.hafner.analysis.util.Deferred;
  *
  * @author Lorenz Munsch
  */
-class PyLintDescriptor extends ParserDescriptor {
+public class PyLintDescriptor extends ParserDescriptor {
     private static final String ID = "pylint";
     private static final String NAME = "Pylint";
 
     private final Deferred<PyLintDescriptions> messages = new Deferred<>(PyLintDescriptions::new);
 
-    PyLintDescriptor() {
+    public PyLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/QacSourceCodeAnalyserDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/QacSourceCodeAnalyserDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.QacSourceCodeAnalyserParser;
  *
  * @author Lorenz Munsch
  */
-class QacSourceCodeAnalyserDescriptor extends ParserDescriptor {
+public class QacSourceCodeAnalyserDescriptor extends ParserDescriptor {
     private static final String ID = "qac";
     private static final String NAME = "QA-C Sourcecode Analyser";
 
-    QacSourceCodeAnalyserDescriptor() {
+    public QacSourceCodeAnalyserDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/QtTranslationDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/QtTranslationDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.QtTranslationParser;
  *
  * @author Lorenz Munsch
  */
-class QtTranslationDescriptor extends ParserDescriptor {
+public class QtTranslationDescriptor extends ParserDescriptor {
     private static final String ID = "qt-translation";
     private static final String NAME = "Qt translations";
 
-    QtTranslationDescriptor() {
+    public QtTranslationDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ResharperDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ResharperDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.ResharperInspectCodeAdapter;
  *
  * @author Lorenz Munsch
  */
-class ResharperDescriptor extends ParserDescriptor {
+public class ResharperDescriptor extends ParserDescriptor {
     private static final String ID = "resharper";
     private static final String NAME = "Resharper Inspections";
 
-    ResharperDescriptor() {
+    public ResharperDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/RevApiDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/RevApiDescriptor.java
@@ -12,7 +12,7 @@ public class RevApiDescriptor extends ParserDescriptor {
     private static final String ID = "revapi";
     private static final String NAME = "Revapi";
 
-    RevApiDescriptor() {
+    public RevApiDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/RfLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/RfLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.RfLintParser;
  *
  * @author Lorenz Munsch
  */
-class RfLintDescriptor extends ParserDescriptor {
+public class RfLintDescriptor extends ParserDescriptor {
     private static final String ID = "rflint";
     private static final String NAME = "Robot Framework Lint";
 
-    RfLintDescriptor() {
+    public RfLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/RoboCopyDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/RoboCopyDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.RobocopyParser;
  *
  * @author Lorenz Munsch
  */
-class RoboCopyDescriptor extends ParserDescriptor {
+public class RoboCopyDescriptor extends ParserDescriptor {
     private static final String ID = "robocopy";
     private static final String NAME = "Robocopy";
 
-    RoboCopyDescriptor() {
+    public RoboCopyDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/RuboCopDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/RuboCopDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.RuboCopParser;
  *
  * @author Lorenz Munsch
  */
-class RuboCopDescriptor extends ParserDescriptor {
+public class RuboCopDescriptor extends ParserDescriptor {
     private static final String ID = "rubocop";
     private static final String NAME = "Rubocop";
 
-    RuboCopDescriptor() {
+    public RuboCopDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SarifDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SarifDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.SarifAdapter;
  *
  * @author Ullrich Hafner
  */
-class SarifDescriptor extends ParserDescriptor {
+public class SarifDescriptor extends ParserDescriptor {
     private static final String ID = "sarif";
     private static final String NAME = "SARIF";
 
-    SarifDescriptor() {
+    public SarifDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ScalaDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ScalaDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.ScalacParser;
  *
  * @author Lorenz Munsch
  */
-class ScalaDescriptor extends CompositeParserDescriptor {
+public class ScalaDescriptor extends CompositeParserDescriptor {
     private static final String ID = "scala";
     private static final String NAME = "Scala Compiler";
 
-    ScalaDescriptor() {
+    public ScalaDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SemgrepDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SemgrepDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.SemgrepAdapter;
  *
  * @author Ullrich Hafner
  */
-class SemgrepDescriptor extends ParserDescriptor {
+public class SemgrepDescriptor extends ParserDescriptor {
     private static final String ID = "semgrep";
     private static final String NAME = "Semgrep";
 
-    SemgrepDescriptor() {
+    public SemgrepDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SimianDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SimianDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.dry.simian.SimianParser;
  *
  * @author Lorenz Munsch
  */
-class SimianDescriptor extends DryDescriptor {
+public class SimianDescriptor extends DryDescriptor {
     private static final String ID = "simian";
     private static final String NAME = "Simian";
 
-    SimianDescriptor() {
+    public SimianDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SimulinkCheckDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SimulinkCheckDescriptor.java
@@ -14,7 +14,7 @@ public class SimulinkCheckDescriptor extends ParserDescriptor {
     private static final String ID = "simulink-check-parser";
     private static final String NAME = "Simulink Check Tool";
 
-    SimulinkCheckDescriptor() {
+    public SimulinkCheckDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SonarQubeDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SonarQubeDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.SonarQubeIssuesParser;
  *
  * @author Lorenz Munsch
  */
-class SonarQubeDescriptor extends CompositeParserDescriptor {
+public class SonarQubeDescriptor extends CompositeParserDescriptor {
     private static final String ID = "sonar";
     private static final String NAME = "SonarQube Issues";
 
-    SonarQubeDescriptor() {
+    public SonarQubeDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SphinxBuildDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SphinxBuildDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.SphinxBuildParser;
  *
  * @author Lorenz Munsch
  */
-class SphinxBuildDescriptor extends CompositeParserDescriptor {
+public class SphinxBuildDescriptor extends CompositeParserDescriptor {
     private static final String ID = "sphinx";
     private static final String NAME = "Sphinx Build";
 
-    SphinxBuildDescriptor() {
+    public SphinxBuildDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SpotBugsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SpotBugsDescriptor.java
@@ -5,11 +5,11 @@ package edu.hm.hafner.analysis.registry;
  *
  * @author Lorenz Munsch
  */
-class SpotBugsDescriptor extends FindBugsDescriptor {
+public class SpotBugsDescriptor extends FindBugsDescriptor {
     private static final String ID = "spotbugs";
     private static final String NAME = "SpotBugs";
 
-    SpotBugsDescriptor() {
+    public SpotBugsDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/StyleCopDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/StyleCopDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.StyleCopParser;
  *
  * @author Lorenz Munsch
  */
-class StyleCopDescriptor extends ParserDescriptor {
+public class StyleCopDescriptor extends ParserDescriptor {
     private static final String ID = "stylecop";
     private static final String NAME = "StyleCop";
 
-    StyleCopDescriptor() {
+    public StyleCopDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/StyleLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/StyleLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Alexander Brandes
  */
-class StyleLintDescriptor extends ParserDescriptor {
+public class StyleLintDescriptor extends ParserDescriptor {
     private static final String ID = "stylelint";
     private static final String NAME = "Stylelint";
 
-    StyleLintDescriptor() {
+    public StyleLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SunCDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SunCDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.SunCParser;
  *
  * @author Lorenz Munsch
  */
-class SunCDescriptor extends ParserDescriptor {
+public class SunCDescriptor extends ParserDescriptor {
     private static final String ID = "sunc";
     private static final String NAME = "SUN C++ Compiler";
 
-    SunCDescriptor() {
+    public SunCDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SwiftLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SwiftLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class SwiftLintDescriptor extends ParserDescriptor {
+public class SwiftLintDescriptor extends ParserDescriptor {
     private static final String ID = "swiftlint";
     private static final String NAME = "SwiftLint";
 
-    SwiftLintDescriptor() {
+    public SwiftLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/TaglistDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/TaglistDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.TaglistParser;
  *
  * @author Lorenz Munsch
  */
-class TaglistDescriptor extends ParserDescriptor {
+public class TaglistDescriptor extends ParserDescriptor {
     private static final String ID = "taglist";
     private static final String NAME = "Maven Taglist Plugin";
 
-    TaglistDescriptor() {
+    public TaglistDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/TaskingVxCompilerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/TaskingVxCompilerDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.TaskingVxCompilerParser;
  *
  * @author Lorenz Munsch
  */
-class TaskingVxCompilerDescriptor extends ParserDescriptor {
+public class TaskingVxCompilerDescriptor extends ParserDescriptor {
     private static final String ID = "tasking-vx";
     private static final String NAME = "TASKING VX Compiler";
 
-    TaskingVxCompilerDescriptor() {
+    public TaskingVxCompilerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/TiCcsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/TiCcsDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.TiCcsParser;
  *
  * @author Lorenz Munsch
  */
-class TiCcsDescriptor extends ParserDescriptor {
+public class TiCcsDescriptor extends ParserDescriptor {
     private static final String ID = "code-composer";
     private static final String NAME = "Texas Instruments Code Composer Studio";
 
-    TiCcsDescriptor() {
+    public TiCcsDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/TnsdlDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/TnsdlDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.TnsdlParser;
  *
  * @author Lorenz Munsch
  */
-class TnsdlDescriptor extends ParserDescriptor {
+public class TnsdlDescriptor extends ParserDescriptor {
     private static final String ID = "tnsdl";
     private static final String NAME = "TNSDL Translator";
 
-    TnsdlDescriptor() {
+    public TnsdlDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/TrivyDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/TrivyDescriptor.java
@@ -10,11 +10,11 @@ import static j2html.TagCreator.*;
  *
  * @author Lorenz Munsch
  */
-class TrivyDescriptor extends ParserDescriptor {
+public class TrivyDescriptor extends ParserDescriptor {
     private static final String ID = "trivy";
     private static final String NAME = "Aquasec Trivy";
 
-    TrivyDescriptor() {
+    public TrivyDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/TsLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/TsLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.checkstyle.CheckStyleParser;
  *
  * @author Lorenz Munsch
  */
-class TsLintDescriptor extends ParserDescriptor {
+public class TsLintDescriptor extends ParserDescriptor {
     private static final String ID = "tslint";
     private static final String NAME = "TSLint  ";
 
-    TsLintDescriptor() {
+    public TsLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
@@ -12,7 +12,7 @@ public class ValgrindDescriptor extends ParserDescriptor {
     private static final String ID = "valgrind";
     private static final String NAME = "Valgrind";
 
-    ValgrindDescriptor() {
+    public ValgrindDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/VeraCodePipelineScannerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/VeraCodePipelineScannerDescriptor.java
@@ -10,11 +10,11 @@ import static j2html.TagCreator.*;
  *
  * @author Juri Duval
  */
-class VeraCodePipelineScannerDescriptor extends ParserDescriptor {
+public class VeraCodePipelineScannerDescriptor extends ParserDescriptor {
     private static final String ID = "veracode-pipeline-scanner";
     private static final String NAME = "Veracode Pipeline Scanner";
 
-    VeraCodePipelineScannerDescriptor() {
+    public VeraCodePipelineScannerDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/XlcDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/XlcDescriptor.java
@@ -11,11 +11,11 @@ import edu.hm.hafner.analysis.parser.XlcLinkerParser;
  *
  * @author Lorenz Munsch
  */
-class XlcDescriptor extends CompositeParserDescriptor {
+public class XlcDescriptor extends CompositeParserDescriptor {
     private static final String ID = "xlc";
     private static final String NAME = "IBM XLC Compiler";
 
-    XlcDescriptor() {
+    public XlcDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/XmlLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/XmlLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.XmlLintAdapter;
  *
  * @author Lorenz Munsch
  */
-class XmlLintDescriptor extends ParserDescriptor {
+public class XmlLintDescriptor extends ParserDescriptor {
     private static final String ID = "xmllint";
     private static final String NAME = "XML-Lint";
 
-    XmlLintDescriptor() {
+    public XmlLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/YamlLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/YamlLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.YamlLintAdapter;
  *
  * @author Lorenz Munsch
  */
-class YamlLintDescriptor extends ParserDescriptor {
+public class YamlLintDescriptor extends ParserDescriptor {
     private static final String ID = "yamllint";
     private static final String NAME = "YamlLint";
 
-    YamlLintDescriptor() {
+    public YamlLintDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/YuiCompressorDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/YuiCompressorDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.YuiCompressorParser;
  *
  * @author Lorenz Munsch
  */
-class YuiCompressorDescriptor extends ParserDescriptor {
+public class YuiCompressorDescriptor extends ParserDescriptor {
     private static final String ID = "yui";
     private static final String NAME = "YUI Compressor";
 
-    YuiCompressorDescriptor() {
+    public YuiCompressorDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ZptLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ZptLintDescriptor.java
@@ -8,11 +8,11 @@ import edu.hm.hafner.analysis.parser.violations.ZptLintAdapter;
  *
  * @author Lorenz Munsch
  */
-class ZptLintDescriptor extends ParserDescriptor {
+public class ZptLintDescriptor extends ParserDescriptor {
     private static final String ID = "zptlint";
     private static final String NAME = "ZPT-Lint";
 
-    ZptLintDescriptor() {
+    public ZptLintDescriptor() {
         super(ID, NAME);
     }
 


### PR DESCRIPTION

When re-using this library outside of Jenkins, I would like to access the list of all the `ParserDescriptor`.

This is currently difficult since only following classes are public:

* `edu.hm.hafner.analysis.registry.CodeGeneratorDescriptor`
* `edu.hm.hafner.analysis.registry.CrossCoreEmbeddedStudioDescriptor`
* `edu.hm.hafner.analysis.registry.EmbeddedEngineerDescriptor`
* `edu.hm.hafner.analysis.registry.FindBugsDescriptor`
* `edu.hm.hafner.analysis.registry.GrypeDescriptor`
* `edu.hm.hafner.analysis.registry.OwaspDependencyCheckDescriptor`
* `edu.hm.hafner.analysis.registry.PnpmAuditDescriptor`
* `edu.hm.hafner.analysis.registry.PolyspaceDescriptor`
* `edu.hm.hafner.analysis.registry.RevApiDescriptor`
* `edu.hm.hafner.analysis.registry.SimulinkCheckDescriptor`
* `edu.hm.hafner.analysis.registry.ValgrindDescriptor`

All the other one have only a package visibility.

In addition it would be great to have a public constructor.

Current work-around:

```java
	private static ParserDescriptor init(Class<?> cls) {
		try {
			Constructor<?> constructor = cls.getDeclaredConstructor();
			constructor.setAccessible(true);
			return (ParserDescriptor) constructor.newInstance();
		} catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
			throw new RuntimeException("Can not instantiate " + cls.getSimpleName(), e);
		}
	}
```

This pull request is making the non-abstract child classes of `ParserDescriptor` to public and is making the 0-arg constructor public as well.

---

I have used a jbang script to create this pull request:

<details><summary>ModifyCode.java</summary>
<p>
```java
///usr/bin/env jbang "$0" "$@" ; exit $?

//DEPS io.smallrye:jandex:3.1.2
//JAVA 17

import java.io.BufferedReader;
import java.io.File;
import java.io.IOException;
import java.io.InputStream;
import java.io.InputStreamReader;
import java.lang.reflect.Modifier;
import java.nio.charset.StandardCharsets;
import java.nio.file.Files;
import java.nio.file.Path;
import java.nio.file.Paths;
import java.util.Collection;
import java.util.List;
import java.util.Objects;
import java.util.stream.Collectors;

import org.jboss.jandex.ClassInfo;
import org.jboss.jandex.Index;
import org.jboss.jandex.MethodInfo;

public class ModifyCode {

    public static void main(String... args) throws Exception {
        Index index = Index.of(new File(System.getProperty("user.home") + "/.m2/repository/edu/hm/hafner/analysis-model/11.13.0/analysis-model-11.13.0.jar"));

        Collection<ClassInfo> subclasses = index.getAllKnownSubclasses("edu.hm.hafner.analysis.registry.ParserDescriptor");
        List<ClassInfo> list = subclasses.stream()
                .filter(classInfo -> !Modifier.isAbstract(classInfo.flags()))
                .toList();

        // System.out.println(list);

        for (ClassInfo classInfo : list) {
            String name = classInfo.simpleName();
            Path file = Paths.get(System.getProperty("user.home") + "/Git/jenkinsci_analysis-model/src/main/java/edu/hm/hafner/analysis/registry/" + name + ".java");
            String oldContent = Files.readString(file);
            String content = oldContent;
            if (!Modifier.isPublic(classInfo.flags())) {
                content = content.replaceFirst("class", "public class");
            }
            //            if (classInfo.constructors().size() != 1) {
            //                System.out.println("Expecting only one constructor in " + file);
            //            }
            MethodInfo methodInfo = classInfo.constructors().get(0);
            if (!Modifier.isPublic(methodInfo.flags())) {
                content = content.replaceFirst("    " + name + "\\(\\)", "    public " + name + "()");
            }
            if (!Objects.equals(oldContent, content)) {
                Files.writeString(file, content);
            }
        }    }
}

```
</p>
</details> 
