### PR TITLE
Make descriptor classes package protected

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/registry/CodeGeneratorDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CodeGeneratorDescriptor.java
@@ -9,7 +9,7 @@ import edu.hm.hafner.analysis.parser.CodeGeneratorParser;
  * @author Eva Habeeb
  */
 
-public class CodeGeneratorDescriptor extends ParserDescriptor {
+class CodeGeneratorDescriptor extends ParserDescriptor {
 
     private static final String ID = "code-generator";
     private static final String NAME = "Code Generator Tool";

--- a/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CrossCoreEmbeddedStudioDescriptor.java
@@ -6,7 +6,7 @@ import edu.hm.hafner.analysis.parser.CrossCoreEmbeddedStudioParser;
 /**
  * A descriptor for CrossCore Embedded Studio from Analog Devices.
  */
-public class CrossCoreEmbeddedStudioDescriptor extends ParserDescriptor {
+class CrossCoreEmbeddedStudioDescriptor extends ParserDescriptor {
     private static final String ID = "crosscore-embedded-studio";
     private static final String NAME = "CrossCore Embedded Studio (CCES)";
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/EmbeddedEngineerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/EmbeddedEngineerDescriptor.java
@@ -8,7 +8,7 @@ import edu.hm.hafner.analysis.parser.EmbeddedEngineerParser;
  *
  * @author Eva Habeeb
  */
-public class EmbeddedEngineerDescriptor extends ParserDescriptor {
+class EmbeddedEngineerDescriptor extends ParserDescriptor {
     private static final String ID = "embedded-engineer";
     private static final String NAME = "Embedded Engineer Tool";
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/FindBugsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FindBugsDescriptor.java
@@ -12,7 +12,7 @@ import edu.hm.hafner.analysis.util.Deferred;
  *
  * @author Lorenz Munsch
  */
-public class FindBugsDescriptor extends ParserDescriptor {
+class FindBugsDescriptor extends ParserDescriptor {
     private static final String ID = "findbugs";
     private static final String NAME = "FindBugs";
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/GrypeDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/GrypeDescriptor.java
@@ -6,7 +6,7 @@ import edu.hm.hafner.analysis.parser.GrypeParser;
 /**
  * Descriptor for Grype report parser.
  */
-public class GrypeDescriptor extends ParserDescriptor {
+class GrypeDescriptor extends ParserDescriptor {
     private static final String ID = "grype";
     private static final String NAME = "Grype";
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/OwaspDependencyCheckDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/OwaspDependencyCheckDescriptor.java
@@ -6,7 +6,7 @@ import edu.hm.hafner.analysis.parser.OwaspDependencyCheckParser;
 /**
  * Descriptor for OWASP dependency check report parser.
  */
-public class OwaspDependencyCheckDescriptor extends ParserDescriptor {
+class OwaspDependencyCheckDescriptor extends ParserDescriptor {
     private static final String ID = "owasp-dependency-check";
     private static final String NAME = "OWASP Dependency Check";
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PnpmAuditDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PnpmAuditDescriptor.java
@@ -10,7 +10,7 @@ import static j2html.TagCreator.*;
  *
  * @author Fabian Kaupp - kauppfbi@gmail.com
  */
-public class PnpmAuditDescriptor extends ParserDescriptor {
+class PnpmAuditDescriptor extends ParserDescriptor {
 
     private static final String ID = "pnpm-audit";
     private static final String NAME = "pnpm Audit";

--- a/src/main/java/edu/hm/hafner/analysis/registry/PolyspaceDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PolyspaceDescriptor.java
@@ -9,7 +9,7 @@ import edu.hm.hafner.analysis.parser.PolyspaceParser;
  * @author Eva Habeeb
  */
 
-public class PolyspaceDescriptor extends ParserDescriptor {
+class PolyspaceDescriptor extends ParserDescriptor {
     private static final String ID = "polyspace-parser";
     private static final String NAME = "Polyspace Tool";
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/RevApiDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/RevApiDescriptor.java
@@ -8,7 +8,7 @@ import edu.hm.hafner.analysis.parser.RevApiParser;
  *
  * @author Dominik Jantschar
  */
-public class RevApiDescriptor extends ParserDescriptor {
+class RevApiDescriptor extends ParserDescriptor {
     private static final String ID = "revapi";
     private static final String NAME = "Revapi";
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/SimulinkCheckDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SimulinkCheckDescriptor.java
@@ -9,7 +9,7 @@ import edu.hm.hafner.analysis.parser.SimulinkCheckParser;
  * @author Eva Habeeb
  */
 
-public class SimulinkCheckDescriptor extends ParserDescriptor {
+class SimulinkCheckDescriptor extends ParserDescriptor {
 
     private static final String ID = "simulink-check-parser";
     private static final String NAME = "Simulink Check Tool";

--- a/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ValgrindDescriptor.java
@@ -8,7 +8,7 @@ import static j2html.TagCreator.*;
 /**
  * A descriptor for Valgrind.
  */
-public class ValgrindDescriptor extends ParserDescriptor {
+class ValgrindDescriptor extends ParserDescriptor {
     private static final String ID = "valgrind";
     private static final String NAME = "Valgrind";
 


### PR DESCRIPTION
As discussed in https://github.com/jenkinsci/analysis-model/pull/972#issuecomment-1790981252 the descriptor classes are not intended to be public.

This MR makes it consistent between all the descriptor classes.