### PR TITLE
GrypeParser: added artifact name and type to report

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
@@ -48,8 +48,8 @@ public class GrypeParser extends JsonIssueParser {
         JSONObject artifact = match.getJSONObject(ARTIFACT_TAG);
         String fileName = artifact.getJSONArray(LOCATIONS_TAG).getJSONObject(0).getString(PATH_TAG);
         String packageName = artifact.optString(NAME_TAG, "Unknown");
-        String version = artifact.optString(VERSION_TAG);
-        if (version != null) {
+        String version = artifact.optString(VERSION_TAG, "");
+        if (!version.isEmpty()) {
             packageName = packageName + " " + version;
         }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
@@ -27,6 +27,9 @@ public class GrypeParser extends JsonIssueParser {
     private static final String SEVERITY_TAG = "severity";
     private static final String ID_TAG = "id";
     private static final String DESCRIPTION_TAG = "description";
+    private static final String NAME_TAG = "name";
+    private static final String VERSION_TAG = "version";
+    private static final String TYPE_TAG = "type";
 
     @Override
     protected void parseJsonObject(final Report report, final JSONObject jsonReport, final IssueBuilder issueBuilder) {
@@ -42,11 +45,17 @@ public class GrypeParser extends JsonIssueParser {
 
     private Issue getIssue(final IssueBuilder issueBuilder, final JSONObject match) {
         JSONObject vuln = match.getJSONObject(VULNERABILIY_TAG);
-        String fileName = match.getJSONObject(ARTIFACT_TAG).getJSONArray(LOCATIONS_TAG).getJSONObject(0)
-                .getString(PATH_TAG);
+        JSONObject artifact = match.getJSONObject(ARTIFACT_TAG);
+        String fileName = artifact.getJSONArray(LOCATIONS_TAG).getJSONObject(0).getString(PATH_TAG);
+        String packageName = artifact.optString(NAME_TAG, "Unknown");
+        String version = artifact.optString(VERSION_TAG);
+        if(version != null){
+            packageName = packageName + " " + version;
+        }
 
         return issueBuilder.setFileName(fileName)
-                .setCategory(vuln.getString(SEVERITY_TAG))
+                .setPackageName(packageName)
+                .setCategory(artifact.optString(TYPE_TAG, "Unknown"))
                 .setSeverity(Severity.guessFromString(vuln.getString(SEVERITY_TAG)))
                 .setType(vuln.getString(ID_TAG))
                 .setMessage(vuln.optString(DESCRIPTION_TAG, "Unknown"))

--- a/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/GrypeParser.java
@@ -49,7 +49,7 @@ public class GrypeParser extends JsonIssueParser {
         String fileName = artifact.getJSONArray(LOCATIONS_TAG).getJSONObject(0).getString(PATH_TAG);
         String packageName = artifact.optString(NAME_TAG, "Unknown");
         String version = artifact.optString(VERSION_TAG);
-        if(version != null){
+        if (version != null) {
             packageName = packageName + " " + version;
         }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/GrypeParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GrypeParserTest.java
@@ -19,8 +19,9 @@ class GrypeParserTest extends AbstractParserTest {
         softly.assertThat(report).hasSize(3).hasDuplicatesSize(0);
         softly.assertThat(report.get(0))
                 .hasFileName("tomcat-jdbc/8.0.28/tomcat-jdbc-8.0.28.jar")
+                .hasPackageName("tomcat-jdbc 8.0.28")
                 .hasSeverity(Severity.WARNING_NORMAL)
-                .hasCategory("Medium")
+                .hasCategory("java-archive")
                 .hasType("CVE-2015-5345")
                 .hasMessage(
                         "The Mapper component in Apache Tomcat 6.x before 6.0.45, 7.x before 7.0.68, 8.x before 8.0.30, and 9.x before 9.0.0.M2 processes redirects before considering security constraints and Filters, which allows remote attackers to determine the existence of a directory via a URL that lacks a trailing / (slash) character.")
@@ -30,8 +31,9 @@ class GrypeParserTest extends AbstractParserTest {
 
         softly.assertThat(report.get(2))
                 .hasFileName("tomcat-jdbc/8.0.28/tomcat-jdbc-8.0.28.jar")
+                .hasPackageName("tomcat-jdbc 8.0.28")
                 .hasSeverity(Severity.WARNING_HIGH)
-                .hasCategory("High")
+                .hasCategory("java-archive")
                 .hasType("CVE-2016-8745")
                 .hasMessage(
                         "A bug in the error handling of the send file code for the NIO HTTP connector in Apache Tomcat 9.0.0.M1 to 9.0.0.M13, 8.5.0 to 8.5.8, 8.0.0.RC1 to 8.0.39, 7.0.0 to 7.0.73 and 6.0.16 to 6.0.48 resulted in the current Processor object being added to the Processor cache multiple times. This in turn meant that the same Processor could be used for concurrent requests. Sharing a Processor can result in information leakage between requests including, not not limited to, session ID and the response body. The bug was first noticed in 8.5.x onwards where it appears the refactoring of the Connector code for 8.5.x onwards made it more likely that the bug was observed. Initially it was thought that the 8.5.x refactoring introduced the bug but further investigation has shown that the bug is present in all currently supported Tomcat versions.")
@@ -46,11 +48,12 @@ class GrypeParserTest extends AbstractParserTest {
         var report = parse("grype-report-wo-description.json");
 
         try (var softly = new SoftAssertions()) {
-            softly.assertThat(report).hasSize(20).hasDuplicatesSize(13);
+            softly.assertThat(report).hasSize(33).hasDuplicatesSize(0);
             softly.assertThat(report.get(0))
                     .hasFileName("/usr/local/bin/environment-to-ini")
+                    .hasPackageName("code.gitea.io/gitea (devel)")
                     .hasSeverity(Severity.ERROR)
-                    .hasCategory("Critical")
+                    .hasCategory("go-module")
                     .hasType("GHSA-pg38-r834-g45j")
                     .hasMessage("Improper Privilege Management in Gitea")
                     .hasDescription(p().with(a()
@@ -59,8 +62,9 @@ class GrypeParserTest extends AbstractParserTest {
 
             softly.assertThat(report.get(13))
                     .hasFileName("/lib/apk/db/installed")
+                    .hasPackageName("curl 8.2.1-r0")
                     .hasSeverity(Severity.WARNING_HIGH)
-                    .hasCategory("High")
+                    .hasCategory("apk")
                     .hasType("CVE-2023-38039")
                     .hasMessage("Unknown")
                     .hasDescription(p().with(a()

--- a/src/test/java/edu/hm/hafner/analysis/parser/GrypeParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/GrypeParserTest.java
@@ -29,6 +29,18 @@ class GrypeParserTest extends AbstractParserTest {
                         .withHref("https://nvd.nist.gov/vuln/detail/CVE-2015-5345")
                         .withText("https://nvd.nist.gov/vuln/detail/CVE-2015-5345")).render());
 
+        softly.assertThat(report.get(1))
+                .hasFileName("tomcat-jdbc/8.0.28/tomcat-jdbc-8.0.28.jar")
+                .hasPackageName("tomcat-jdbc")
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasCategory("java-archive")
+                .hasType("CVE-2015-5346")
+                .hasMessage(
+                        "Session fixation vulnerability in Apache Tomcat 7.x before 7.0.66, 8.x before 8.0.30, and 9.x before 9.0.0.M2, when different session settings are used for deployments of multiple versions of the same web application, might allow remote attackers to hijack web sessions by leveraging use of a requestedSessionSSL field for an unintended request, related to CoyoteAdapter.java and Request.java.")
+                .hasDescription(p().with(a()
+                        .withHref("https://nvd.nist.gov/vuln/detail/CVE-2015-5346")
+                        .withText("https://nvd.nist.gov/vuln/detail/CVE-2015-5346")).render());
+
         softly.assertThat(report.get(2))
                 .hasFileName("tomcat-jdbc/8.0.28/tomcat-jdbc-8.0.28.jar")
                 .hasPackageName("tomcat-jdbc 8.0.28")

--- a/src/test/resources/edu/hm/hafner/analysis/parser/grype-report.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/grype-report.json
@@ -254,7 +254,6 @@
    "artifact": {
     "id": "c1c07c89ccdbbc49",
     "name": "tomcat-jdbc",
-    "version": "8.0.28",
     "type": "java-archive",
     "locations": [
      {


### PR DESCRIPTION
The warnings-ng reports for Grype are missing important information, namely the vulnerable artifact's name and its type. This makes it difficult to see the affected packages when reviewing the report as the file path often doesn't contain the artifact name (e.g. for RPMs in a Docker image the file path reported by Grype is just "/var/lib/rpm/Packages"; only the artifact name reveals the actual RPM name like curl etc.).

This PR adds the artifact name from the Grype JSON report as package name and changes the report's category to the artifact type (instead of duplicating the severity information there). I chose package over module name as the package is visible in the warnings-ng issue list while the module isn't.

### Testing done
The existing JUnit test for the GrypeParser has been adjusted to also verify the package name and the changed category.
Note that due to the added package name the report in test method `assertThatVulnerabilityWithoutDescriptionCanBeParsed` doesn't contain duplicates any more.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
