### PR TITLE
Fix parsing for mixture of Kotlin and CMake output

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
@@ -1,6 +1,10 @@
 package edu.hm.hafner.analysis;
 
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -142,6 +146,9 @@ public class IssueBuilder implements AutoCloseable {
             return UNDEFINED_TREE_STRING;
         }
         else {
+            if (directory != null && isAbsolutePath(normalizeFileName(unsafeFileName))) {
+                return fileNameBuilder.intern(normalizeFileName(unsafeFileName));
+            }
             return fileNameBuilder.intern(normalizeFileName(
                     new PathUtil().createAbsolutePath(directory, unsafeFileName)));
         }
@@ -576,6 +583,20 @@ public class IssueBuilder implements AutoCloseable {
 
         moduleName = null;
         additionalProperties = null;
+    }
+
+    private static boolean isAbsolutePath(final String stringPath) {
+        try {
+            URI uri = new URI(stringPath);
+            if (uri.isAbsolute()) {
+                return true;
+            }
+        }
+        catch (URISyntaxException e) {
+            // Catch and ignore as system paths are not URI and we need to check them separately.
+        }
+        Path path = Paths.get(stringPath);
+        return path.isAbsolute();
     }
 
     private static String normalizeFileName(@CheckForNull final String platformFileName) {

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -342,5 +342,41 @@ class JavacParserTest extends AbstractParserTest {
                 .hasFileName("file:///project/src/main/java/com/app/ui/model/Activity.kt")
                 .hasMessage("'PackageStats' is deprecated. Deprecated in Java");
     }
+
+     /**
+     * Parses a warning log written by Gradle containing 3 Kotlin warnings and 1 error.
+     * Having a cmake directory switch log in between. Following duplicated Kotlin errors should still be treated as duplicates.
+     */
+    @Test
+    void kotlinAndCmakeDirectoryOuptut() {
+        Report warnings = parse("kotlin-cmake.txt");
+
+        assertThat(warnings).hasSize(5);
+
+        assertThat(warnings.get(0)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(214)
+                .hasColumnStart(35)
+                .hasFileName("/project/app/src/main/java/ui/Activity.kt");
+        assertThat(warnings.get(1)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(424)
+                .hasColumnStart(29)
+                .hasFileName("/project/app/src/main/java/ui/Activity.kt");
+        assertThat(warnings.get(2)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(425)
+                .hasColumnStart(29)
+                .hasFileName("/project/app/src/main/java/ui/Activity.kt")
+                .hasCategory("Deprecation")
+                .hasMessage("deprecated: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */");
+        assertThat(warnings.get(3)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(200)
+                .hasColumnStart(2)
+                .hasFileName("C:/project/app/src/main/java/ui/Activity.kt");
+        assertThat(warnings.get(4)).hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(8)
+                .hasColumnStart(27)
+                .hasCategory("Deprecation")
+                .hasFileName("file:///project/src/main/java/com/app/ui/model/Activity.kt")
+                .hasMessage("'PackageStats' is deprecated. Deprecated in Java");
+    }
 }
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-cmake.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/kotlin-cmake.txt
@@ -1,0 +1,14 @@
+> Configure project :app
+Configuration 'compile' in project ':app' is deprecated. Use 'implementation' instead.
+registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
+app: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.android.databinding:compiler:3.0.1'.
+w: /project/app/src/main/java/ui/Activity.kt: (214, 35): Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: /project/app/src/main/java/ui/Activity.kt:424:29 Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+e: /project/app/src/main/java/ui/Activity.kt:425:29 deprecated: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: C:\project\app\src\main\java\ui\Activity.kt:200:2 'PackageStats' is deprecated. Deprecated in Java
+[2023-12-20T15:50:19.997Z] w: file:///project/src/main/java/com/app/ui/model/Activity.kt:8:27 'PackageStats' is deprecated. Deprecated in Java
+[2023-12-20T15:50:18.292Z] C/C++: -- Build files have been written to: /project/.cxx/Debug/365u2g4u/arm64-v8a
+C/C++: /project/src/cpp/MyClass.cpp:35:15: warning: unused parameter 'parameter1' [-Wunused-parameter]
+[2023-12-20T15:50:20.997Z] w: file:///project/src/main/java/com/app/ui/model/Activity.kt:8:27 'PackageStats' is deprecated. Deprecated in Java
+w: /project/app/src/main/java/ui/Activity.kt:424:29 Unchecked cast: Serializable! to kotlin.collections.HashMap<String, String> /* = java.util.HashMap<String, String> */
+w: C:\project\app\src\main\java\ui\Activity.kt:200:2 'PackageStats' is deprecated. Deprecated in Java


### PR DESCRIPTION
For projects with a mixture of Kotlin and CMake compiles the output of both can be mixed depending on the order of the tasks. The working path defined by the CMake output should not be used for warnings which already print out absolute paths e.g. Kotlin warnings. It should only be used if the path is a relative path.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
