### PR TITLE
[EA] Add support for categories separated by a brace

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/EmbeddedEngineerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/EmbeddedEngineerParser.java
@@ -28,7 +28,7 @@ public class EmbeddedEngineerParser extends IssueParser {
             "^\\[([^\\]]*)\\]\\s(?<severity>Warn)\\s-\\s(?<description>[^']*)'(?<module>[^']*)"
                     + "'\\s(?<details>\\(?[^{]*)(?<serial>[^)]*\\})");
     private static final Pattern WARNING_PATTERN = Pattern.compile(
-            "^\\[([^\\]]*)\\]\\s(?<severity>Error|Warn)\\s-\\s(?<category>.+):\\s(?<description>.+)");
+            "^\\[([^\\]]*)\\]\\s(?<severity>Error|Warn)\\s-\\s(?<category>[^:]*)" + "(:\\s|\\s\\()(?<description>.+)");
 
     @Override
     public Report parse(final ReaderFactory reader) throws ParsingException {

--- a/src/test/java/edu/hm/hafner/analysis/parser/EmbeddedEngineerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/EmbeddedEngineerParserTest.java
@@ -22,7 +22,7 @@ class EmbeddedEngineerParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        softly.assertThat(report).hasSize(8);
+        softly.assertThat(report).hasSize(9);
         softly.assertThat(report.get(0))
                 .hasModuleName("index_module")
                 .hasDescription("Complex type definition without referenced element found 'index_module' (uint8_t); {98CF1FE6-EC9C-43f1-e476-40EFCD63cA8D}")
@@ -45,6 +45,10 @@ class EmbeddedEngineerParserTest extends AbstractParserTest {
                 .hasCategory("Error loading plugins from")
                 .hasDescription("Error loading plugins from C:\\file1\\idc\\sample_ext.x64.dll")
                 .hasSeverity(Severity.ERROR);
+        softly.assertThat(report.get(8))
+                .hasCategory("Out parameters")
+                .hasDescription("Out parameters 'Model_ptr_2345') are not supported. Please use 'return' or 'inout' parameters; {98CF1FE6-EC9C-43f1-e476-40EFCD63cA8D}")
+                .hasSeverity(Severity.WARNING_NORMAL);
     }
 }
 

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ea.log
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ea.log
@@ -8,3 +8,4 @@
 [2023-03-10 12:04:25.0777] Warn - Code generation for element 'Module1' passed. Could not start code generation ; {ffeee99-9BD1-12345678}
 [2023-03-10 12:04:25.1377] Warn - SampleValidation: no requirement linked to final node 'Module1_Node'.
 [2023-03-10 12:04:22.1045] Error - Error loading plugins from: C:\file1\idc\sample_ext.x64.dll
+[2024-01-05 10:52:27.3199] Warn - Out parameters ('Model_ptr_2345') are not supported. Please use 'return' or 'inout' parameters; {98CF1FE6-EC9C-43f1-e476-40EFCD63cA8D}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Current implementation does not take warnings in the following structure into account:
[2024-01-05 10:52:27.3199] Warn - Out parameters ('Model_ptr_2345') are not supported. Please use 'return' or 'inout' parameters; {98CF1FE6-EC9C-43f1-e476-40EFCD63cA8D}
For this purpose only the WARNING_PATTERN was modified to capture new category. 
### Testing done

The current change was tested by adding additional test case to the EmbeddedEngineerParserTest file.
Tests were executed using [warnings-ng-plugin-devenv] development environment. 
 Screenshots of the test results:
<img width="572" alt="test_1" src="https://github.com/jenkinsci/analysis-model/assets/97677328/c66c6892-3d23-47fa-af08-e2ed95af8bd2">

<img width="573" alt="test_2" src="https://github.com/jenkinsci/analysis-model/assets/97677328/a913170d-e303-4d37-916e-48e443c8a8a4">
 

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

