### PR TITLE
[JENKINS-68415] Skip archives, jar-files and executables from fingerprinting

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
+++ b/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
@@ -7,7 +7,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.MalformedInputException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.NoSuchFileException;
+import java.util.Set;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import edu.hm.hafner.util.FilteredLog;
@@ -19,6 +21,9 @@ import edu.hm.hafner.util.VisibleForTesting;
  * @author Ullrich Hafner
  */
 public class FingerprintGenerator {
+    private static final Set<String> NON_SOURCE_CODE_EXTENSIONS = Set.of(
+            "o", "exe", "dll", "so", "a", "lib", "jar", "war", "zip", "7z", "gz", "bz2");
+
     /**
      * Creates fingerprints for the specified set of issues.
      *
@@ -34,12 +39,20 @@ public class FingerprintGenerator {
         int sum = 0;
         for (Issue issue : report) {
             if (!issue.hasFingerprint()) {
-                sum += computeFingerprint(issue, algorithm, charset, log);
+                if (hasAllowedExtension(issue.getFileName())) {
+                    sum += computeFingerprint(issue, algorithm, charset, log);
+                }
+                else {
+                    issue.setFingerprint(createDefaultFingerprint(issue));
+                }
             }
         }
-        log.logSummary();
         report.mergeLogMessages(log);
         report.logInfo("-> created fingerprints for %d issues (skipped %d issues)", sum, report.size() - sum);
+    }
+
+    private boolean hasAllowedExtension(final String fileName) {
+        return !NON_SOURCE_CODE_EXTENSIONS.contains(FilenameUtils.getExtension(fileName));
     }
 
     private int computeFingerprint(final Issue issue, final FullTextFingerprint algorithm, final Charset charset,

--- a/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
+++ b/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
@@ -10,6 +10,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.Set;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import edu.hm.hafner.util.FilteredLog;
@@ -52,7 +53,7 @@ public class FingerprintGenerator {
     }
 
     private boolean hasAllowedExtension(final String fileName) {
-        return !NON_SOURCE_CODE_EXTENSIONS.contains(FilenameUtils.getExtension(fileName));
+        return !NON_SOURCE_CODE_EXTENSIONS.contains(StringUtils.lowerCase(FilenameUtils.getExtension(fileName)));
     }
 
     private int computeFingerprint(final Issue issue, final FullTextFingerprint algorithm, final Charset charset,

--- a/src/test/java/edu/hm/hafner/analysis/FingerprintGeneratorTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/FingerprintGeneratorTest.java
@@ -59,7 +59,7 @@ class FingerprintGeneratorTest extends ResourceTest {
 
             String alreadySet = "already-set";
             report.add(issueBuilder.setFingerprint(alreadySet).setMessage(AFFECTED_FILE_NAME).build());
-            generator.run(createFullTextFingerprint("fingerprint-one.txt", "fingerprint-two.txt"),
+            generator.run(createFullTextFingerprint("fingerprint-two.txt"),
                     report, CHARSET_AFFECTED_FILE);
 
             assertThat(report.get(0).hasFingerprint()).isTrue();
@@ -86,7 +86,7 @@ class FingerprintGeneratorTest extends ResourceTest {
     void shouldAssignIdenticalFingerprint() {
         Report report = createTwoIssues();
         FingerprintGenerator generator = new FingerprintGenerator();
-        FullTextFingerprint fingerprint = createFullTextFingerprint("fingerprint-one.txt", "fingerprint-one.txt");
+        FullTextFingerprint fingerprint = createFullTextFingerprint("fingerprint-one.txt");
 
         generator.run(fingerprint, report, CHARSET_AFFECTED_FILE);
 
@@ -119,7 +119,7 @@ class FingerprintGeneratorTest extends ResourceTest {
     void shouldAssignDifferentFingerprint() {
         Report report = createTwoIssues();
         FingerprintGenerator generator = new FingerprintGenerator();
-        FullTextFingerprint fingerprint = createFullTextFingerprint("fingerprint-one.txt", "fingerprint-two.txt");
+        FullTextFingerprint fingerprint = createFullTextFingerprint("fingerprint-two.txt");
 
         generator.run(fingerprint, report, CHARSET_AFFECTED_FILE);
 
@@ -143,12 +143,13 @@ class FingerprintGeneratorTest extends ResourceTest {
 
     @ParameterizedTest(name = "[{index}] Skip non source code file {0}")
     @ValueSource(strings = {"library.o", "program.exe", "library.dll", "program.so", "library.a", "program.lib",
-            "library.jar", "library.war", "program.zip", "library.7z", "program.tar.gz", "library.tar.bz2"})
+            "library.jar", "library.war", "program.zip", "library.7z", "program.tar.gz", "library.tar.bz2",
+            "UPPER_CASE.EXE"})
     void shouldUseFallbackFingerprintOnNonSourceFiles(final String fileName) {
         var report = createReportWithOneIssueFor(fileName);
 
         FingerprintGenerator generator = new FingerprintGenerator();
-        generator.run(createFullTextFingerprint("fingerprint-one.txt", "fingerprint-two.txt"),
+        generator.run(createFullTextFingerprint("fingerprint-two.txt"),
                 report, CHARSET_AFFECTED_FILE);
 
         assertThatIssueHasDefaultFingerprint(report);
@@ -167,8 +168,9 @@ class FingerprintGeneratorTest extends ResourceTest {
         assertThat(report.get(0)).hasFingerprint(FingerprintGenerator.createDefaultFingerprint(report.get(0)));
     }
 
-    private FullTextFingerprint createFullTextFingerprint(final String firstFile, final String secondFile) {
-        FileSystem fileSystem = stubFileSystem(firstFile, secondFile);
+    private FullTextFingerprint createFullTextFingerprint(final String secondFile) {
+        FileSystem fileSystem = stubFileSystem("fingerprint-one.txt", secondFile);
+
         return new FullTextFingerprint(fileSystem);
     }
 


### PR DESCRIPTION
For files with extension `"o", "exe", "dll", "so", "a", "lib", "jar", "war", "zip", "7z", "gz", "bz2"` it does not make sense to compute a fingerprint.

See [JENKINS-68415](https://issues.jenkins.io/browse/JENKINS-68415)