### PR TITLE
Use a flag to mark the issues that are part of modified code

### DIFF
--- a/doc/dependency-graph.puml
+++ b/doc/dependency-graph.puml
@@ -6,7 +6,7 @@ skinparam rectangle {
   BackgroundColor<<runtime>> lightBlue
   BackgroundColor<<provided>> lightGray
 }
-rectangle "analysis-model\n\n11.16.0" as edu_hm_hafner_analysis_model_jar
+rectangle "analysis-model\n\n11.18.0-SNAPSHOT" as edu_hm_hafner_analysis_model_jar
 rectangle "jsoup\n\n1.17.2" as org_jsoup_jsoup_jar
 rectangle "commons-io\n\n2.15.1" as commons_io_commons_io_jar
 rectangle "commons-digester3\n\n3.2" as org_apache_commons_commons_digester3_jar

--- a/src/main/java/edu/hm/hafner/analysis/IssueDifference.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueDifference.java
@@ -188,20 +188,6 @@ public class IssueDifference {
     }
 
     /**
-     * Returns the new issues that are part of the changed code lines. I.e., all issues that are part of the current
-     * report but that have not been shown up in the previous report. If the difference is computed for a specific
-     * set of changed files, then this set contains only the new issues that are part of the changes. Otherwise, this
-     * set will be empty.
-     *
-     * @return the new issues
-     * @see IssueDifference#getNewIssues()
-     */
-    @SuppressFBWarnings("EI")
-    public Report getNewIssuesInChangedCode() {
-        return newIssuesInChangedCode;
-    }
-
-    /**
      * Returns the fixed issues. I.e., all issues that are part of the previous report but that are not present in the
      * current report anymore.
      *

--- a/src/main/java/edu/hm/hafner/analysis/IssuesInModifiedCodeMarker.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssuesInModifiedCodeMarker.java
@@ -1,0 +1,43 @@
+package edu.hm.hafner.analysis;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import edu.hm.hafner.util.PathUtil;
+
+/**
+ * Computes old, new, and fixed issues based on the reports of two consecutive static analysis runs for the same
+ * software artifact.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("PMD.DataClass")
+public class IssuesInModifiedCodeMarker {
+    private static final PathUtil PATH_UTIL = new PathUtil();
+
+    /**
+     * Finds and marks all issues that are part the changes in a source control diff.
+     *
+     * @param report
+     *         the report with the issues to scan
+     * @param modifiedLinesInFilesMapping
+     *         a mapping modified lines within files
+     */
+    public void markIssuesInModifiedCode(final Report report, final Map<String, Set<Integer>> modifiedLinesInFilesMapping) {
+        for (Entry<String, Set<Integer>> include : modifiedLinesInFilesMapping.entrySet()) {
+            report.filter(issue -> affectsChangedLineInFile(issue, include.getKey(), include.getValue()))
+                    .stream()
+                    .forEach(Issue::markAsPartOfModifiedCode);
+        }
+    }
+
+    private boolean affectsChangedLineInFile(final Issue issue, final String fileName, final Set<Integer> lines) {
+        var normalizedPath = PATH_UTIL.getRelativePath(fileName);
+
+        if (!issue.getFileName().endsWith(normalizedPath)) { // check only the suffix
+            return false;
+        }
+        return lines.stream().anyMatch(issue::affectsLine);
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/LineRange.java
+++ b/src/main/java/edu/hm/hafner/analysis/LineRange.java
@@ -1,6 +1,8 @@
 package edu.hm.hafner.analysis;
 
 import java.io.Serializable;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
@@ -67,6 +69,19 @@ public final class LineRange implements Serializable {
     }
 
     /**
+     * Returns the lines of this line lange in a sorted set.
+     *
+     * @return the containing lines, one by one
+     */
+    public NavigableSet<Integer> getLines() {
+        var lines = new TreeSet<Integer>();
+        for (int line = getStart(); line <= getEnd(); line++) {
+            lines.add(line);
+        }
+        return lines;
+    }
+
+    /**
      * Returns whether the specified line is contained in this range.
      *
      * @param line the line to check
@@ -74,6 +89,15 @@ public final class LineRange implements Serializable {
      */
     public boolean contains(final int line) {
         return line >= start && line <= end;
+    }
+
+    /**
+     * Returns whether this range is just a single line.
+     *
+     * @return {@code true} if this range is just a single line, {@code false} otherwise
+     */
+    public boolean isSingleLine() {
+        return start == end;
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/IssuesInModifiedCodeMarkerTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/IssuesInModifiedCodeMarkerTest.java
@@ -1,0 +1,95 @@
+package edu.hm.hafner.analysis;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static edu.hm.hafner.analysis.assertions.Assertions.*;
+
+class IssuesInModifiedCodeMarkerTest {
+    @Test
+    void shouldNotMarkAnythingForEmptyMap() {
+        var report = createReportWithTwoIssues();
+
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(false, false);
+
+        var marker = new IssuesInModifiedCodeMarker();
+        marker.markIssuesInModifiedCode(report, Map.of());
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(false, false);
+    }
+
+    @Test
+    void shouldNotMarkIfFileMatchesButLinesNot() {
+        var report = createReportWithTwoIssues();
+
+        var marker = new IssuesInModifiedCodeMarker();
+
+        marker.markIssuesInModifiedCode(report, Map.of("/part/of/modified/code.txt", Set.of(10)));
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(false, false);
+    }
+
+    @Test
+    void shouldNotMarkIfLineMatchesButFileNot() {
+        var report = createReportWithTwoIssues();
+
+        var marker = new IssuesInModifiedCodeMarker();
+
+        marker.markIssuesInModifiedCode(report, Map.of("/wrong/path/code.txt", Set.of(12, 20)));
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(false, false);
+    }
+
+    @Test
+    void shouldMarkIssuesIfOneFileAndLinesMatch() {
+        var report = createReportWithTwoIssues();
+
+        var marker = new IssuesInModifiedCodeMarker();
+
+        marker.markIssuesInModifiedCode(report, Map.of("/part/of/modified/code.txt", Set.of(10, 20)));
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(true, false);
+    }
+
+    @Test
+    void shouldMarkIssuesIfAllFilesAndLinesMatch() {
+        var report = createReportWithTwoIssues();
+
+        var marker = new IssuesInModifiedCodeMarker();
+
+        marker.markIssuesInModifiedCode(report, Map.of(
+                "/part/of/modified/code.txt", Set.of(12),
+                "/part/of/additional/modified/code.txt", Set.of(20)));
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(true, true);
+    }
+
+    @Test
+    void shouldMarkIssuesIfFilesPrefixMatches() {
+        var report = createReportWithTwoIssues();
+
+        var marker = new IssuesInModifiedCodeMarker();
+
+        marker.markIssuesInModifiedCode(report, Map.of(
+                "modified/code.txt", Set.of(12, 20)));
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(true, true);
+    }
+
+    @Test
+    void shouldMarkIssuesIfFileNameUsesWindowsPath() {
+        var report = createReportWithTwoIssues();
+
+        var marker = new IssuesInModifiedCodeMarker();
+
+        marker.markIssuesInModifiedCode(report, Map.of(
+                "modified\\code.txt", Set.of(12, 20)));
+        assertThat(report.get()).extracting(Issue::isPartOfModifiedCode).containsExactly(true, true);
+    }
+
+    private Report createReportWithTwoIssues() {
+        var report = new Report();
+        try (var builder = new IssueBuilder()) {
+            builder.setLineStart(12).setLineEnd(20);
+            report.add(builder.setFileName("/part/of/modified/code.txt").build());
+            report.add(builder.setFileName("/part/of/additional/modified/code.txt").build());
+        }
+        return report;
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/LineRangeTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/LineRangeTest.java
@@ -4,24 +4,36 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-import static org.assertj.core.api.Assertions.*;
+import static edu.hm.hafner.analysis.assertions.Assertions.*;
 
 class LineRangeTest {
     @Test
+    void shouldRefuseIllegalValue() {
+        assertThat(new LineRange(-5, 1)).hasStart(0).hasEnd(0).isSingleLine();
+    }
+
+    @Test
     void shouldFindLinesInsideAndOutsideOfLineRange() {
-        assertThat(new LineRange(1, 2).contains(0)).isFalse();
-        assertThat(new LineRange(1, 2).contains(1)).isTrue();
-        assertThat(new LineRange(1, 2).contains(2)).isTrue();
-        assertThat(new LineRange(1, 2).contains(3)).isFalse();
+        var lineRange = new LineRange(1, 2);
 
-        assertThat(new LineRange(2, 1).contains(0)).isFalse();
-        assertThat(new LineRange(2, 1).contains(1)).isTrue();
-        assertThat(new LineRange(2, 1).contains(2)).isTrue();
-        assertThat(new LineRange(2, 1).contains(3)).isFalse();
+        assertThat(lineRange.contains(0)).isFalse();
+        assertThat(lineRange.contains(1)).isTrue();
+        assertThat(lineRange.contains(2)).isTrue();
+        assertThat(lineRange.contains(3)).isFalse();
+        assertThat(lineRange).hasStart(1).hasEnd(2).hasLines(1, 2).hasToString("[1-2]");
 
-        assertThat(new LineRange(2).contains(1)).isFalse();
-        assertThat(new LineRange(2).contains(2)).isTrue();
-        assertThat(new LineRange(2).contains(3)).isFalse();
+        var wrongOrder = new LineRange(2, 1);
+        assertThat(wrongOrder.contains(0)).isFalse();
+        assertThat(wrongOrder.contains(1)).isTrue();
+        assertThat(wrongOrder.contains(2)).isTrue();
+        assertThat(wrongOrder.contains(3)).isFalse();
+        assertThat(wrongOrder).hasStart(1).hasEnd(2).hasLines(1, 2).hasToString("[1-2]");
+
+        var point = new LineRange(2);
+        assertThat(point.contains(1)).isFalse();
+        assertThat(point.contains(2)).isTrue();
+        assertThat(point.contains(3)).isFalse();
+        assertThat(point).hasStart(2).hasEnd(2).hasLines(2).hasToString("[2-2]");
     }
 
     @Test


### PR DESCRIPTION
It makes more sense to use a flag to mark the issues that are part of modified code. 

Replaces the implementations of
- #1006 
- #1005 
