### PR TITLE
Automatically update supported formats after each commit

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -128,7 +128,9 @@ jobs:
           status: ${{ steps.metrics.outputs.bugs }}
           color: 'orange'
           path: badges/bugs.svg
-      - name: Commit updated badges
+      - name: Build and test with Maven
+        run: mvn -V --color always -ntp test -Dtest=UpdateSupportedFormats#run
+      - name: Commit updated files
         continue-on-error: true
         run: |
           git config --local user.email "action@github.com"
@@ -137,6 +139,8 @@ jobs:
           git commit -m "Update badges with results from latest autograding" || true
           git add doc/dependency-graph.puml
           git commit -m "Update dependency graph to latest versions from POM" || true
+          git add SUPPORTED-FORMATS.md
+          git commit -m "Generate list of supported formats" || true
       - name: Push updated badges to GitHub repository
         uses: ad-m/github-push-action@master
         if: ${{ success() }}

--- a/SUPPORTED-FORMATS.md
+++ b/SUPPORTED-FORMATS.md
@@ -1,4 +1,4 @@
-<!--- DO NOT EDIT -- Generated at 2024-01-19T13:09:41.295584 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
+<!--- DO NOT EDIT -- Generated at 2024-01-26T12:24:59.996137 - Run the `main` method of `ParserRegistry` to regenerate after changing parsers -- DO NOT EDIT --->
 # Supported Report Formats
 
 The static analysis model supports the following report formats.

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -251,7 +251,7 @@ public class ParserRegistry {
      * @throws IOException
      *         of the file `SUPPORTED-FORMATS.md` cannot be written locally
      */
-    public static void main(final String[] unused) throws IOException {
+    public static void main(final String... unused) throws IOException {
         List<ParserDescriptor> descriptors = new ParserRegistry().getAllDescriptors();
         descriptors.sort(Comparator.comparing(ParserDescriptor::getName));
 

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
@@ -1,6 +1,5 @@
 package edu.hm.hafner.analysis.registry;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -89,10 +88,5 @@ class ParserRegistryTest extends ResourceTest {
         assertThat(confidenceReport.getSizeOf(Severity.WARNING_HIGH)).isEqualTo(expectedHighSize);
         assertThat(confidenceReport.getSizeOf(Severity.WARNING_NORMAL)).isEqualTo(expectedNormalSize);
         assertThat(confidenceReport.getSizeOf(Severity.WARNING_LOW)).isEqualTo(expectedLowSize);
-    }
-
-    @Test
-    void shouldCreateSupportedFormats() throws IOException {
-        ParserRegistry.main(new String[0]);
     }
 }

--- a/src/test/java/edu/hm/hafner/analysis/registry/UpdateSupportedFormats.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/UpdateSupportedFormats.java
@@ -1,0 +1,18 @@
+package edu.hm.hafner.analysis.registry;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Updates the list with the supported formats.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings({"NewClassNamingConvention", "PMD.ClassNamingConventions"})
+class UpdateSupportedFormats {
+    @Test
+    void run() throws IOException {
+        ParserRegistry.main(new String[0]);
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/registry/UpdateSupportedFormats.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/UpdateSupportedFormats.java
@@ -13,6 +13,6 @@ import org.junit.jupiter.api.Test;
 class UpdateSupportedFormats {
     @Test
     void run() throws IOException {
-        ParserRegistry.main(new String[0]);
+        ParserRegistry.main();
     }
 }


### PR DESCRIPTION
This will bring the list of supported formats automatically up-to-date.