### PR TITLE
Fix parsing of clang warnings with "C/C++:" prefix

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
+++ b/src/main/java/edu/hm/hafner/analysis/IssueBuilder.java
@@ -3,6 +3,7 @@ package edu.hm.hafner.analysis;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -623,8 +624,13 @@ public class IssueBuilder implements AutoCloseable {
         catch (URISyntaxException e) {
             // Catch and ignore as system paths are not URI and we need to check them separately.
         }
-        Path path = Paths.get(stringPath);
-        return path.isAbsolute();
+        try {
+            Path path = Paths.get(stringPath);
+            return path.isAbsolute();
+        }
+        catch (InvalidPathException e) {
+            return true;
+        }
     }
 
     private static String normalizeFileName(@CheckForNull final String platformFileName) {

--- a/src/main/java/edu/hm/hafner/analysis/parser/ClangParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ClangParser.java
@@ -18,7 +18,7 @@ import edu.hm.hafner.util.LookaheadStream;
 public class ClangParser extends LookaheadParser {
     private static final long serialVersionUID = -3015592762345283182L;
 
-    private static final String CLANG_WARNING_PATTERN = "^\\s*(?:\\d+%)?([^%]*?):(\\d+):(?:(\\d+):)?" + "(?:"
+    private static final String CLANG_WARNING_PATTERN = "^\\s*(?:\\d+%)?(C\\/C\\+\\+: )?([^%]*?):(\\d+):(?:(\\d+):)?" + "(?:"
             + "(?:\\{\\d+:\\d+-\\d+:\\d+\\})+:)?\\s*(warning|[^\\[\\]]*error):" + "\\s*(.*?)(?:\\[([^\\[]*)\\])?$";
     private static final Pattern IGNORE_FORMAT = Pattern.compile("^-\\[.*\\].*$");
 
@@ -32,17 +32,17 @@ public class ClangParser extends LookaheadParser {
     @Override
     protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
             final IssueBuilder builder) {
-        String message = matcher.group(5);
+        String message = matcher.group(6);
         if (IGNORE_FORMAT.matcher(message).matches()) {
             return Optional.empty();
         }
 
-        return builder.setFileName(matcher.group(1))
-                .setLineStart(matcher.group(2))
-                .setColumnStart(matcher.group(3))
-                .setCategory(matcher.group(6))
+        return builder.setFileName(matcher.group(2))
+                .setLineStart(matcher.group(3))
+                .setColumnStart(matcher.group(4))
+                .setCategory(matcher.group(7))
                 .setMessage(message)
-                .setSeverity(mapPriority(matcher.group(4)))
+                .setSeverity(mapPriority(matcher.group(5)))
                 .buildOptional();
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/ClangParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/ClangParserTest.java
@@ -196,4 +196,38 @@ class ClangParserTest extends AbstractParserTest {
                     .hasSeverity(Severity.WARNING_NORMAL);
         }
     }
+
+    @Test
+    void assertThatClangPathsAreCorrectForAllPlatforms() {
+        Report warnings = parse("llvm-clang.txt");
+
+        assertThat(warnings).hasSize(3);
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            softly.assertThat(warnings.get(0)).hasLineStart(35)
+                    .hasLineEnd(35)
+                    .hasColumnStart(15)
+                    .hasColumnEnd(15)
+                    .hasMessage("unused parameter 'parameter1'")
+                    .hasFileName("/project/src/cpp/MyClass.cpp")
+                    .hasCategory("-Wunused-parameter")
+                    .hasSeverity(Severity.WARNING_NORMAL);
+            softly.assertThat(warnings.get(1)).hasLineStart(35)
+                    .hasLineEnd(35)
+                    .hasColumnStart(15)
+                    .hasColumnEnd(15)
+                    .hasMessage("unused parameter 'parameter1'")
+                    .hasFileName("C:/project/src/cpp/MyClass.cpp")
+                    .hasCategory("-Wunused-parameter")
+                    .hasSeverity(Severity.WARNING_NORMAL);
+            softly.assertThat(warnings.get(2)).hasLineStart(35)
+                    .hasLineEnd(35)
+                    .hasColumnStart(15)
+                    .hasColumnEnd(15)
+                    .hasMessage("unused parameter 'parameter1'")
+                    .hasFileName("MyClass.cpp")
+                    .hasCategory("-Wunused-parameter")
+                    .hasSeverity(Severity.WARNING_NORMAL);
+        }
+    }
 }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/llvm-clang.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/llvm-clang.txt
@@ -1,0 +1,5 @@
+C/C++: /project/src/cpp/MyClass.cpp:35:15: warning: unused parameter 'parameter1' [-Wunused-parameter]
+
+C/C++: C:\project\src\cpp\MyClass.cpp:35:15: warning: unused parameter 'parameter1' [-Wunused-parameter]
+
+C/C++: MyClass.cpp:35:15: warning: unused parameter 'parameter1' [-Wunused-parameter]


### PR DESCRIPTION
The prefix was detected as part of the file name
leading to a java.nio.file.InvalidPathException
in IssueBuilder.isAbsolutePath().
In addition to fixing the path parsing in ClangParser
the Exception thrown in the IssueBuilder.isAbsolutePath()
is also catched.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
