### PR TITLE
Ignore files that cause an exception while determining the prefix

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
+++ b/src/main/java/edu/hm/hafner/analysis/FingerprintGenerator.java
@@ -53,7 +53,12 @@ public class FingerprintGenerator {
     }
 
     private boolean hasAllowedExtension(final String fileName) {
-        return !NON_SOURCE_CODE_EXTENSIONS.contains(StringUtils.lowerCase(FilenameUtils.getExtension(fileName)));
+        try {
+            return !NON_SOURCE_CODE_EXTENSIONS.contains(StringUtils.lowerCase(FilenameUtils.getExtension(fileName)));
+        }
+        catch (IllegalArgumentException exception) {
+            return false; // if the file name is invalid, we assume that it is not a source code file
+        }
     }
 
     private int computeFingerprint(final Issue issue, final FullTextFingerprint algorithm, final Charset charset,

--- a/src/test/java/edu/hm/hafner/analysis/FingerprintGeneratorTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/FingerprintGeneratorTest.java
@@ -144,7 +144,7 @@ class FingerprintGeneratorTest extends ResourceTest {
     @ParameterizedTest(name = "[{index}] Skip non source code file {0}")
     @ValueSource(strings = {"library.o", "program.exe", "library.dll", "program.so", "library.a", "program.lib",
             "library.jar", "library.war", "program.zip", "library.7z", "program.tar.gz", "library.tar.bz2",
-            "UPPER_CASE.EXE", "prefix::suffix.txt"})
+            "UPPER_CASE.EXE"})
     void shouldUseFallbackFingerprintOnNonSourceFiles(final String fileName) {
         var report = createReportWithOneIssueFor(fileName);
 

--- a/src/test/java/edu/hm/hafner/analysis/FingerprintGeneratorTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/FingerprintGeneratorTest.java
@@ -144,8 +144,22 @@ class FingerprintGeneratorTest extends ResourceTest {
     @ParameterizedTest(name = "[{index}] Skip non source code file {0}")
     @ValueSource(strings = {"library.o", "program.exe", "library.dll", "program.so", "library.a", "program.lib",
             "library.jar", "library.war", "program.zip", "library.7z", "program.tar.gz", "library.tar.bz2",
-            "UPPER_CASE.EXE"})
+            "UPPER_CASE.EXE", "prefix::suffix.txt"})
     void shouldUseFallbackFingerprintOnNonSourceFiles(final String fileName) {
+        var report = createReportWithOneIssueFor(fileName);
+
+        FingerprintGenerator generator = new FingerprintGenerator();
+        generator.run(createFullTextFingerprint("fingerprint-two.txt"),
+                report, CHARSET_AFFECTED_FILE);
+
+        assertThatIssueHasDefaultFingerprint(report);
+    }
+
+    @ParameterizedTest(name = "[{index}] Skip illegal source code files on Windows {0}")
+    @ValueSource(strings = {"prefix::suffix.txt", ":"})
+    void shouldUseFallbackFingerprintOnIllegalFilenamesOnWindows(final String fileName) {
+        assumeThatTestIsRunningOnWindows();
+
         var report = createReportWithOneIssueFor(fileName);
 
         FingerprintGenerator generator = new FingerprintGenerator();


### PR DESCRIPTION
Processing file names with colons will produce a IAE omn Windows: those files can be ignored during fingerprinting.

```
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 23d30129-9137-4261-a261-7f362ba83618 java.lang.IllegalArgumentException: NTFS ADS separator (':') in file name is forbidden.
	at org.apache.commons.io.FilenameUtils.indexOfExtension(FilenameUtils.java:955)
	at org.apache.commons.io.FilenameUtils.getExtension(FilenameUtils.java:614)
	at edu.hm.hafner.analysis.FingerprintGenerator.hasAllowedExtension(FingerprintGenerator.java:56)
	at edu.hm.hafner.analysis.FingerprintGenerator.run(FingerprintGenerator.java:43)
	at io.jenkins.plugins.analysis.core.steps.IssuesScanner$ReportPostProcessor.createFingerprints(IssuesScanner.java:363)
	at io.jenkins.plugins.analysis.core.steps.IssuesScanner$ReportPostProcessor.invoke(IssuesScanner.java:290)
	at io.jenkins.plugins.analysis.core.steps.IssuesScanner$ReportPostProcessor.invoke(IssuesScanner.java:247)
	at hudson.FilePath.act(FilePath.java:1236)
	at hudson.FilePath.act(FilePath.java:1219)
	at io.jenkins.plugins.analysis.core.steps.IssuesScanner.postProcessReport(IssuesScanner.java:139)
	at io.jenkins.plugins.analysis.core.steps.IssuesScanner.scan(IssuesScanner.java:115)
	at io.jenkins.plugins.analysis.core.steps.IssuesRecorder.scanWithTool(IssuesRecorder.java:687)
	at io.jenkins.plugins.analysis.core.steps.IssuesRecorder.record(IssuesRecorder.java:649)
	at io.jenkins.plugins.analysis.core.steps.IssuesRecorder.perform(IssuesRecorder.java:617)
	at io.jenkins.plugins.analysis.core.steps.RecordIssuesStep$Execution.run(RecordIssuesStep.java:611)
	at io.jenkins.plugins.analysis.core.steps.RecordIssuesStep$Execution.run(RecordIssuesStep.java:568)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```