### PR TITLE
[JENKINS-72887] Add coverity parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons.text.version>1.11.0</commons.text.version>
     <j2html.version>1.4.0</j2html.version>
     <slf4j.version>2.0.12</slf4j.version>
-    <violations-lib.version>1.156.8</violations-lib.version>
+    <violations-lib.version>1.157.0</violations-lib.version>
     <jsoup.version>1.17.2</jsoup.version>
     <json.version>20240303</json.version>
     <json-smart.version>2.5.1</json-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons.text.version>1.11.0</commons.text.version>
     <j2html.version>1.4.0</j2html.version>
     <slf4j.version>2.0.12</slf4j.version>
-    <violations-lib.version>1.157.0</violations-lib.version>
+    <violations-lib.version>1.157.1</violations-lib.version>
     <jsoup.version>1.17.2</jsoup.version>
     <json.version>20240303</json.version>
     <json-smart.version>2.5.1</json-smart.version>

--- a/src/main/java/edu/hm/hafner/analysis/parser/violations/CoverityAdapter.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/violations/CoverityAdapter.java
@@ -1,0 +1,17 @@
+package edu.hm.hafner.analysis.parser.violations;
+
+import se.bjurr.violations.lib.parsers.CoverityParser;
+
+/**
+ * Parses Coverity JSON V7 report files.
+ *
+ * @author Jobin Jose
+ */
+public class CoverityAdapter extends AbstractViolationAdapter {
+    private static final long serialVersionUID = -8210423965588732109L;
+
+    @Override
+    CoverityParser createParser() {
+        return new CoverityParser();
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/CoverityDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CoverityDescriptor.java
@@ -1,0 +1,28 @@
+package edu.hm.hafner.analysis.registry;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.parser.violations.CoverityAdapter;
+
+/**
+ * A descriptor for Coverity.
+ *
+ * @author Ullrich Hafner
+ */
+class CoverityDescriptor extends ParserDescriptor {
+    private static final String ID = "coverity";
+    private static final String NAME = "Coverity Scan";
+
+    CoverityDescriptor() {
+        super(ID, NAME);
+    }
+
+    @Override
+    public IssueParser createParser(final Option... options) {
+        return new CoverityAdapter();
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://scan.coverity.com/";
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -62,6 +62,7 @@ public class ParserRegistry {
             new CodeGeneratorDescriptor(),
             new CodeNarcDescriptor(),
             new CoolfluxChessccDescriptor(),
+            new CoverityDescriptor(),
             new CpdDescriptor(),
             new CppCheckDescriptor(),
             new CppLintDescriptor(),

--- a/src/test/java/edu/hm/hafner/analysis/parser/violations/CoverityAdapterTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/violations/CoverityAdapterTest.java
@@ -1,0 +1,30 @@
+package edu.hm.hafner.analysis.parser.violations;
+
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+import edu.hm.hafner.analysis.registry.AbstractParserTest;
+
+class CoverityAdapterTest extends AbstractParserTest {
+    CoverityAdapterTest() {
+        super("coverity.json");
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        softly.assertThat(report).hasSize(1);
+        var issue = report.get(0);
+        softly.assertThat(issue)
+                .hasFileName("C:/Workspace/workspace/Build_jenkins_development/somefile.cs")
+                .hasCategory("Integer handling issues")
+                .hasType("constant_expression_result/bit_and_with_zero")
+                .hasLineStart(79)
+                .hasSeverity(Severity.WARNING_NORMAL);
+        softly.assertThat(issue.getMessage()).startsWith("Bitwise-and ('&amp;') operation applied to zero always produces zero.");
+    }
+
+    @Override
+    protected CoverityAdapter createParser() {
+        return new CoverityAdapter();
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/registry/AbstractParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/AbstractParserTest.java
@@ -81,13 +81,15 @@ public abstract class AbstractParserTest extends ResourceTest {
     void shouldRegisterParser() {
         assumeThat(createParser().getClass().getPackageName()).startsWith("edu.hm.hafner.analysis"); // only test our own parsers
 
-        Set<Class<?>> parsers = new ParserRegistry().getAllDescriptors()
+        var parserRegistry = new ParserRegistry();
+
+        Set<Class<?>> parsers = parserRegistry.getAllDescriptors()
                 .stream()
                 .map(ParserDescriptor::createParser)
                 .map(IssueParser::getClass)
                 .collect(Collectors.toSet());
 
-        var compositeParsers = new ParserRegistry().getAllDescriptors().stream()
+        var compositeParsers = parserRegistry.getAllDescriptors().stream()
                 .filter(descriptor -> descriptor instanceof CompositeParserDescriptor)
                 .map(descriptor -> (CompositeParserDescriptor) descriptor)
                 .map(CompositeParserDescriptor::createParsers)
@@ -99,6 +101,12 @@ public abstract class AbstractParserTest extends ResourceTest {
         assertThat(parsers)
                 .as("Every parser should be registered in the ParserRegistry")
                 .contains(createParser().getClass());
+
+        parserRegistry.getAllDescriptors()
+                .stream()
+                .map(ParserDescriptor::getUrl)
+                .forEach(url ->
+                        assertThat(url).matches("https?://.*|^$"));
     }
 
     protected void assertThatReportHasSeverities(final Report report, final int expectedSizeError,

--- a/src/test/resources/edu/hm/hafner/analysis/parser/violations/coverity.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/violations/coverity.json
@@ -1,0 +1,62 @@
+{
+  "type": "Coverity issues",
+  "formatVersion": 7,
+  "suppressedIssueCount": 0,
+  "issues": [
+    {
+      "mergeKey": "884ed7531feed32eb916d9038a3b9bd6",
+      "occurrenceCountForMK": 1,
+      "occurrenceNumberInMK": 1,
+      "referenceOccurrenceCountForMK": null,
+      "checkerName": "CONSTANT_EXPRESSION_RESULT",
+      "subcategory": "bit_and_with_zero",
+      "type": "constant_expression_result",
+      "subtype": "bit_and_with_zero",
+      "code-language": "c#",
+      "extra": "status",
+      "domain": "STATIC_CS",
+      "language": "C#",
+      "mainEventFilePathname": "C:\\Workspace\\workspace\\Build_jenkins_development\\somefile.cs",
+      "strippedMainEventFilePathname": "\\workspace\\Build_jenkins_development\\Architecture\\somefile.cs",
+      "mainEventLineNumber": 79,
+      "properties": {},
+      "functionDisplayName": "somename",
+      "functionMangledName": "somename",
+      "localStatus": null,
+      "ordered": false,
+      "events": [
+        {
+          "covLStrEventDescription": "{CovLStrv2{{t{{0} is always 0.}{{code{status & System.Printing.PrintJobStatus.None}}}}{t{ This occurs as a value.}}}}",
+          "eventDescription": "\"status & System.Printing.PrintJobStatus.None\" is always 0. This occurs as a value.",
+          "eventNumber": 1,
+          "eventTreePosition": "1",
+          "eventSet": 0,
+          "eventTag": "bit_and_with_zero",
+          "filePathname": "C:\\Workspace\\workspace\\Build_jenkins_development\\somefile.cs",
+          "strippedFilePathname": "\\workspace\\Build_jenkins_development\\Architecture\\somefile.cs",
+          "lineNumber": 79,
+          "main": true,
+          "moreInformationId": null,
+          "remediation": false,
+          "events": null
+        }
+      ],
+      "stateOnServer": null,
+      "checkerProperties": {
+        "category": "Integer handling issues",
+        "categoryDescription": "Integer handling issues",
+        "cweCategory": "569",
+        "issueKinds": ["QUALITY"],
+        "eventSetCaptions": [],
+        "impact": "Medium",
+        "impactDescription": "Medium",
+        "subcategoryLocalEffect": "The expression's value is always zero; construct may indicate an inadvertent logic error.",
+        "subcategoryShortDescription": "Bitwise-and with zero",
+        "subcategoryLongDescription": "Bitwise-and ('&amp;') operation applied to zero always produces zero"
+      }
+    }
+  ],
+  "desktopAnalysisSettings": null,
+  "error": null,
+  "warnings": []
+}


### PR DESCRIPTION
Add support for [Coverity](https://scan.coverity.com/) JSON reports.

```[tasklist]
- [x] Add Coverity parser adapter using violations-lib library.
- [x] Link to Jira issue: https://issues.jenkins.io/browse/JENKINS-72887
- [x] Add a small test case that reads a report and verifies the content (Example can be taken from https://github.com/tomasbjerre/violations-lib/blob/6c14711cba4dccaa5191ed648cb6013af9affb8d/src/test/java/se/bjurr/violations/lib/CoverityTest.java)
- [x] Register the parser in the Parser registry
- [x] Add URL, HELP, ICON if available.
```

