### PR TITLE
Use the PMD square image.

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/registry/PmdDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PmdDescriptor.java
@@ -38,7 +38,7 @@ class PmdDescriptor extends ParserDescriptor {
 
     @Override
     public String getIconUrl() {
-        return "https://raw.githubusercontent.com/pmd/pmd/master/docs/images/logo/pmd-logo-300px.png";
+        return "https://docs.pmd-code.org/latest/images/logo/pmd-logo-300px-squared.png";
     }
 
     @Override


### PR DESCRIPTION
Use the square logo of PMD that provides a better scaling result. This icon still provides a poor rendering for actions (20x20) but it is better than the old one.

Before: 

<img src="https://raw.githubusercontent.com/pmd/pmd/master/docs/images/logo/pmd-logo-300px.png" alt="PMD" height="18" width="18"> &nbsp; PMD: No warnings found

After:

<img src="https://docs.pmd-code.org/latest/images/logo/pmd-logo-300px-squared.png" alt="PMD" height="18" width="18"> &nbsp; PMD: 1 warning found (0 error, 0 high, 1 normal, 0 low)


