### PR TITLE
Fix PMD logo path

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/registry/PmdDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PmdDescriptor.java
@@ -38,7 +38,7 @@ class PmdDescriptor extends ParserDescriptor {
 
     @Override
     public String getIconUrl() {
-        return "https://github.com/pmd/pmd/blob/master/docs/images/logo/PMD_small.svg";
+        return "https://raw.githubusercontent.com/pmd/pmd/master/docs/images/logo/PMD_small.svg";
     }
 
     @Override


### PR DESCRIPTION
Fix the path to the image so that it can be used in markdown comments.