### PR TITLE
Skip subreport messages when copying and merging reports

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/Report.java
+++ b/src/main/java/edu/hm/hafner/analysis/Report.java
@@ -336,8 +336,8 @@ public class Report implements Iterable<Issue>, Serializable {
             }
             else {
                 reportsToAdd.addAll(report.subReports);
-                infoMessages.addAll(report.getInfoMessages());
-                errorMessages.addAll(report.getErrorMessages());
+                infoMessages.addAll(report.infoMessages);
+                errorMessages.addAll(report.errorMessages);
             }
         }
 
@@ -870,8 +870,8 @@ public class Report implements Iterable<Issue>, Serializable {
         destination.name = source.getName();
         destination.originReportFile = source.getOriginReportFile();
         destination.duplicatesSize += source.duplicatesSize; // not recursively
-        destination.infoMessages.addAll(source.getInfoMessages());
-        destination.errorMessages.addAll(source.getErrorMessages());
+        destination.infoMessages.addAll(source.infoMessages);
+        destination.errorMessages.addAll(source.errorMessages);
         destination.countersByKey = Stream.concat(
                 destination.countersByKey.entrySet().stream(), source.countersByKey.entrySet().stream())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Integer::sum));


### PR DESCRIPTION
Example duplication:

```
Parsing console log (workspace: '/var/data/workspace/history-coverage-model')
Successfully parsed console log
-> found 0 issues (skipped 0 duplicates)
Skipping post processing
No filter has been set, publishing all 0 issues
Extracting repository forensics for 0 affected files (files in repository: 184)
-> 0 affected files processed
Successfully parsed console log
-> found 0 issues (skipped 0 duplicates)
Successfully parsed console log
-> found 0 issues (skipped 0 duplicates)
Successfully parsed console log
-> found 0 issues (skipped 0 duplicates)
Parsing console log (workspace: '/var/data/workspace/history-coverage-model')
Skipping post processing
No filter has been set, publishing all 0 issues
Extracting repository forensics for 0 affected files (files in repository: 184)
-> 0 affected files processed
Obtaining reference build from reference recorder
-> Found 'history-coverage-model #44'

```