### PR TITLE
[JENKINS-73363] Add support for protoLint JSON format

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/ProtoLintJsonParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ProtoLintJsonParser.java
@@ -1,0 +1,62 @@
+package edu.hm.hafner.analysis.parser;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+
+/**
+ * Parser for ProtoLint JSON reports.
+ *
+ * <p>The recommended report format is JSON. The JSON report contains more information (affected rule, severity,
+ * basedir) as the plaintext format. For full feature set please use protoLint &gt;= 0.50.2.
+ *
+ * <p>We still support plaintext reports and JSON reports generated with protoLint &lt; 0.50.2 as well.
+ *
+ * @author github@profhenry.de
+ * @see <a href="https://github.com/yoheimuta/protolint">https://github.com/yoheimuta/protolint</a>
+ */
+public class ProtoLintJsonParser extends JsonIssueParser {
+    private static final long serialVersionUID = 573706779074579673L;
+
+    @Override
+    protected void parseJsonObject(final Report report, final JSONObject jsonReport, final IssueBuilder issueBuilder) {
+        String basedir = jsonReport.optString("basedir");
+        JSONArray results = jsonReport.optJSONArray("lints", new JSONArray(0));
+
+        parseResults(report, basedir, results, issueBuilder);
+    }
+
+    private void parseResults(final Report report, final String basedir, final JSONArray jsonReport, final IssueBuilder issueBuilder) {
+        for (int i = 0; i < jsonReport.length(); i++) {
+            JSONObject finding = (JSONObject) jsonReport.get(i);
+            report.add(convertToIssue(basedir, finding, issueBuilder));
+        }
+    }
+
+    private Issue convertToIssue(final String basedir, final JSONObject finding, final IssueBuilder issueBuilder) {
+        // The filename is always relative to the working dir the protoLint process was started with.
+        // In order to get the absolute filename we need to prepend the basedir which is available with protoLint >= 0.50.2
+        String filename = finding.getString("filename");
+        if (!basedir.isEmpty()) {
+            filename = basedir + "/" + filename;
+        }
+        return issueBuilder.setFileName(filename)
+                .setLineStart(finding.getInt("line"))
+                .setColumnStart(finding.getInt("column"))
+                .setMessage(finding.getString("message"))
+                .setSeverity(mapSeverity(finding.optString("severity")))
+                .setType(finding.getString("rule"))
+                .buildAndClean();
+    }
+
+    private Severity mapSeverity(final String aProtoLintSeverity) {
+        // ProtoLint knows the following severities
+        // https://github.com/yoheimuta/protolint/blob/master/linter/rule/rule.go#L9
+        // which can be mapped with the provided mapping method 
+        return Severity.guessFromString(aProtoLintSeverity);
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/parser/ProtoLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ProtoLintParser.java
@@ -10,7 +10,9 @@ import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.LookaheadStream;
 
 /**
- * Parser for ProtoLint.
+ * Parser for ProtoLint plaintext reports.
+ *
+ * <p>The recommended report format is now JSON! This parser is just used as fallback.
  *
  * @author David Hart
  * @see <a href="https://github.com/yoheimuta/protolint">https://github.com/yoheimuta/protolint</a>

--- a/src/main/java/edu/hm/hafner/analysis/registry/ProtoLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ProtoLintDescriptor.java
@@ -1,14 +1,25 @@
 package edu.hm.hafner.analysis.registry;
 
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.code;
+import static j2html.TagCreator.join;
+import static j2html.TagCreator.text;
+
+import java.util.Collection;
+
 import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.parser.ProtoLintJsonParser;
 import edu.hm.hafner.analysis.parser.ProtoLintParser;
 
 /**
  * A descriptor for ProtoLint.
  *
+ * <p>We use a composite parser for supporting JSON (preferred) and plaintext (fallback) format.
+ *
  * @author Lorenz Munsch
+ * @author github@profhenry.de
  */
-class ProtoLintDescriptor extends ParserDescriptor {
+class ProtoLintDescriptor extends CompositeParserDescriptor {
     private static final String ID = "protolint";
     private static final String NAME = "ProtoLint";
 
@@ -17,8 +28,17 @@ class ProtoLintDescriptor extends ParserDescriptor {
     }
 
     @Override
-    public IssueParser createParser(final Option... options) {
-        return new ProtoLintParser();
+    protected Collection<? extends IssueParser> createParsers() {
+        return asList(new ProtoLintJsonParser(), new ProtoLintParser());
+    }
+
+    @Override
+    public String getHelp() {
+        return join(text("Use protolint with options"),
+                code("-reporter=json -output_file=protolint-report.json"),
+                text(", see"),
+                a("protoLint CLI options").withHref("https://github.com/yoheimuta/protolint?tab=readme-ov-file#usage"),
+                text("for usage details.")).render();
     }
 
     @Override

--- a/src/test/java/edu/hm/hafner/analysis/parser/ProtoLintJsonParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/ProtoLintJsonParserTest.java
@@ -1,0 +1,83 @@
+package edu.hm.hafner.analysis.parser;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+import edu.hm.hafner.analysis.registry.AbstractParserTest;
+
+import static edu.hm.hafner.analysis.assertions.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for {@link ProtoLintJsonParser}.
+ *
+ * @author github@profhenry.de
+ */
+class ProtoLintJsonParserTest extends AbstractParserTest {
+    ProtoLintJsonParserTest() {
+        super("protolint_0.50.2.json");
+    }
+
+    @Override
+    public void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        assertThat(report).hasSize(462);
+
+        softly.assertThat(report.get(4))
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasLineStart(3)
+                .hasColumnStart(5)
+                .hasMessage("Found an incorrect indentation style \"    \". \"  \" is correct.")
+                .hasFileName("/home/jwiesner/Development/github/profhenry/protolint/_example/proto/issue_111/multipleFixersApplicable.proto")
+                .hasType("INDENT");
+
+        softly.assertThat(report.get(12))
+                .hasSeverity(Severity.ERROR)
+                .hasLineStart(3)
+                .hasColumnStart(5)
+                .hasMessage("EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"")
+                .hasFileName("/home/jwiesner/Development/github/profhenry/protolint/_example/proto/issue_111/multipleFixersApplicable.proto")
+                .hasType("ENUM_FIELD_NAMES_PREFIX");
+
+        softly.assertThat(report.get(224))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(207)
+                .hasColumnStart(3)
+                .hasMessage("Field \"amount\" should have a comment")
+                .hasFileName("/home/jwiesner/Development/github/profhenry/protolint/_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto")
+                .hasType("FIELDS_HAVE_COMMENT");
+    }
+
+    @Override
+    public IssueParser createParser() {
+        return new ProtoLintJsonParser();
+    }
+
+    @Test
+    @DisplayName("Parsing json report generated with protolint 0.49.8")
+    void json0498() {
+        Report report = parse("protolint_0.49.8.json");
+
+        assertThat(report).hasSize(352);
+
+        try (SoftAssertions softly = new SoftAssertions()) {
+            softly.assertThat(report.get(2))
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasLineStart(3)
+                    .hasColumnStart(5)
+                    .hasMessage("Found an incorrect indentation style \"    \". \"  \" is correct.")
+                    .hasFileName("_example/proto/issue_111/multipleFixersApplicable.proto")
+                    .hasType("INDENT");
+
+            softly.assertThat(report.get(10))
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasLineStart(3)
+                    .hasColumnStart(5)
+                    .hasMessage("EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"")
+                    .hasFileName("_example/proto/issue_111/multipleFixersApplicable.proto")
+                    .hasType("ENUM_FIELD_NAMES_PREFIX");
+        }
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -807,10 +807,16 @@ class ParsersTest extends ResourceTest {
         findIssuesOfTool(0, "java", "eclipse.txt");
     }
 
-    /** Runs the ProtoLint parser on an output file that contains 10 issues. */
+    /** Runs the ProtoLint parser on a plaintext output file that contains 2591 issues. */
     @Test
     void shouldFindAllProtoLintIssues() {
         findIssuesOfTool(2591, "protolint", "protolint.txt");
+    }
+
+    /** Runs the ProtoLint parser on a json output file that contains 462 issues. */
+    @Test
+    void shouldFindAllProtoLintIssuesJsonFormat() {
+        findIssuesOfTool(462, "protolint", "protolint_0.50.2.json");
     }
 
     /** Runs the HadoLint parser on an output file that contains 5 issues. */

--- a/src/test/resources/edu/hm/hafner/analysis/parser/protolint_0.49.8.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/protolint_0.49.8.json
@@ -1,0 +1,2468 @@
+{
+  "lints": [
+    {
+      "filename": "_example/proto/invalidFileName.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File name \"invalidFileName.proto\" should be lower_snake_case.proto like \"invalid_file_name.proto\".",
+      "rule": "FILE_NAMES_LOWER_SNAKE_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File name \"multipleFixersApplicable.proto\" should be lower_snake_case.proto like \"multiple_fixers_applicable.proto\".",
+      "rule": "FILE_NAMES_LOWER_SNAKE_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 3,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 4,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 6,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 10,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 11,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 13,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 3,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"STARTED\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 6,
+      "column": 9,
+      "message": "EnumField name \"RUNNING\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 10,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS_2\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 12,
+      "column": 5,
+      "message": "EnumField name \"STARTED\" should have the prefix \"ENUM_ALLOWING_ALIAS_2\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 13,
+      "column": 5,
+      "message": "EnumField name \"RUNNING\" should have the prefix \"ENUM_ALLOWING_ALIAS_2\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 3,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 10,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 2,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias\" must be UpperCamelCase like \"EnumAllowingAlias\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 9,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias2\" must be UpperCamelCase like \"EnumAllowingAlias2\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File name \"grpc-gateway_a_bit_of_everything.proto\" should be lower_snake_case.proto like \"grpc_gateway_a_bit_of_everything.proto\".",
+      "rule": "FILE_NAMES_LOWER_SNAKE_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 3,
+      "column": 1,
+      "message": "The order of Package is invalid. Check if the file is ordered in the correct manner.",
+      "rule": "ORDER"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 187,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 201,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 200,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 202,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 206,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 205,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 207,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 209,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 208,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 211,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 210,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 213,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 212,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 214,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 217,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 216,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 218,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 219,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 221,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 222,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 223,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 224,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 225,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 226,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 227,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 228,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 229,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 230,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 231,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 232,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 233,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 234,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 235,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 236,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 237,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 238,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 239,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 240,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 241,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 242,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 243,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 244,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 245,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 247,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 248,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 249,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 251,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 253,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 256,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 255,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 259,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 258,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 262,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 261,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 265,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 264,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 268,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 267,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 271,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 270,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 273,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 278,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 283,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 282,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 284,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 285,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 286,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 287,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 288,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 289,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 290,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 291,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 292,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 293,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 294,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 295,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 296,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 297,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 298,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 302,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 306,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 307,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 314,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 313,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 316,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 315,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 321,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 322,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 329,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 340,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 337,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 338,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 339,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 341,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 344,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 345,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 346,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 350,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 351,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 352,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 355,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 356,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 357,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 361,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 362,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 363,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 377,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 379,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 380,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 383,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 404,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 405,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 406,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 409,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 418,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 419,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 420,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 423,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 431,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 424,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 425,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 426,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 427,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 428,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 429,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 430,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 432,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 442,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 484,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 485,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 486,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 490,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 491,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 492,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 493,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 496,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 497,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 498,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 501,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 502,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 503,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 507,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 508,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 509,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 513,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 514,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 515,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 518,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 519,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 520,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 523,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 524,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 525,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 529,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 530,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 531,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 534,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 537,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 542,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 543,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 546,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 549,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 27,
+      "column": 1,
+      "message": "The line length is 90, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 106,
+      "column": 1,
+      "message": "The line length is 92, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 138,
+      "column": 1,
+      "message": "The line length is 99, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 158,
+      "column": 1,
+      "message": "The line length is 81, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 190,
+      "column": 1,
+      "message": "The line length is 100, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 217,
+      "column": 1,
+      "message": "The line length is 125, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 221,
+      "column": 1,
+      "message": "The line length is 186, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 223,
+      "column": 1,
+      "message": "The line length is 166, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 258,
+      "column": 1,
+      "message": "The line length is 89, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 259,
+      "column": 1,
+      "message": "The line length is 207, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 262,
+      "column": 1,
+      "message": "The line length is 177, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 264,
+      "column": 1,
+      "message": "The line length is 83, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 265,
+      "column": 1,
+      "message": "The line length is 192, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 267,
+      "column": 1,
+      "message": "The line length is 90, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 268,
+      "column": 1,
+      "message": "The line length is 206, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 270,
+      "column": 1,
+      "message": "The line length is 82, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 271,
+      "column": 1,
+      "message": "The line length is 170, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 273,
+      "column": 1,
+      "message": "The line length is 113, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 276,
+      "column": 1,
+      "message": "The line length is 85, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 279,
+      "column": 1,
+      "message": "The line length is 127, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 330,
+      "column": 1,
+      "message": "The line length is 125, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 342,
+      "column": 1,
+      "message": "The line length is 391, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 419,
+      "column": 1,
+      "message": "The line length is 87, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 421,
+      "column": 1,
+      "message": "The line length is 521, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 431,
+      "column": 1,
+      "message": "The line length is 123, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 462,
+      "column": 1,
+      "message": "The line length is 90, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 497,
+      "column": 1,
+      "message": "The line length is 81, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 516,
+      "column": 1,
+      "message": "The line length is 82, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 519,
+      "column": 1,
+      "message": "The line length is 84, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 521,
+      "column": 1,
+      "message": "The line length is 92, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 530,
+      "column": 1,
+      "message": "The line length is 99, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 540,
+      "column": 1,
+      "message": "The line length is 94, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 5,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 6,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 7,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 9,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 10,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 11,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 12,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 13,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 211,
+      "column": 4,
+      "message": "EnumField name \"FALSE\" should have the prefix \"DEEP_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 213,
+      "column": 4,
+      "message": "EnumField name \"TRUE\" should have the prefix \"DEEP_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 314,
+      "column": 2,
+      "message": "EnumField name \"ZERO\" should have the prefix \"NUMERIC_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 316,
+      "column": 2,
+      "message": "EnumField name \"ONE\" should have the prefix \"NUMERIC_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 211,
+      "column": 4,
+      "message": "EnumField name \"FALSE\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 314,
+      "column": 2,
+      "message": "EnumField name \"ZERO\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 251,
+      "column": 2,
+      "message": "Field name \"nonConventionalNameValue\" must be underscore_separated_names like \"non_conventional_name_value\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 222,
+      "column": 2,
+      "message": "Repeated field name \"nested\" must be pluralized name \"nesteds\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 241,
+      "column": 2,
+      "message": "Repeated field name \"repeated_string_value\" must be pluralized name \"repeated_string_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 256,
+      "column": 2,
+      "message": "Repeated field name \"repeated_enum_value\" must be pluralized name \"repeated_enum_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 259,
+      "column": 2,
+      "message": "Repeated field name \"repeated_enum_annotation\" must be pluralized name \"repeated_enum_annotations\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 265,
+      "column": 2,
+      "message": "Repeated field name \"repeated_string_annotation\" must be pluralized name \"repeated_string_annotations\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 268,
+      "column": 2,
+      "message": "Repeated field name \"repeated_nested_annotation\" must be pluralized name \"repeated_nested_annotations\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 283,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_float_value\" must be pluralized name \"path_repeated_float_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 284,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_double_value\" must be pluralized name \"path_repeated_double_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 285,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_int64_value\" must be pluralized name \"path_repeated_int64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 286,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_uint64_value\" must be pluralized name \"path_repeated_uint64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 287,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_int32_value\" must be pluralized name \"path_repeated_int32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 288,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_fixed64_value\" must be pluralized name \"path_repeated_fixed64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 289,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_fixed32_value\" must be pluralized name \"path_repeated_fixed32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 290,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_bool_value\" must be pluralized name \"path_repeated_bool_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 291,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_string_value\" must be pluralized name \"path_repeated_string_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 292,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_bytes_value\" must be pluralized name \"path_repeated_bytes_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 293,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_uint32_value\" must be pluralized name \"path_repeated_uint32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 294,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_enum_value\" must be pluralized name \"path_repeated_enum_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 295,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sfixed32_value\" must be pluralized name \"path_repeated_sfixed32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 296,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sfixed64_value\" must be pluralized name \"path_repeated_sfixed64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 297,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sint32_value\" must be pluralized name \"path_repeated_sint32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 298,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sint64_value\" must be pluralized name \"path_repeated_sint64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 541,
+      "column": 1,
+      "message": "Service name \"camelCaseServiceName\" must be UpperCamelCase like \"CamelCaseServiceName\"",
+      "rule": "SERVICE_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 6,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 4,
+      "column": 5,
+      "message": "EnumField name \"NEGATIVE_CONSTANT\" should have the prefix \"TEST_NEGATIVE_VALUE\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"ZERO_CONSTANT\" should have the prefix \"TEST_NEGATIVE_VALUE\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 6,
+      "column": 5,
+      "message": "EnumField name \"POSITIVE_CONSTANT\" should have the prefix \"TEST_NEGATIVE_VALUE\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"ZERO_CONSTANT\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 4,
+      "column": 1,
+      "message": "Found an incorrect indentation style \"\". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 7,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"   \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Message name \"xyz\" must be UpperCamelCase like \"Xyz\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 9,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 10,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 11,
+      "column": 7,
+      "message": "Found an incorrect indentation style \"      \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 13,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 17,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 17,
+      "column": 1,
+      "message": "The line length is 84, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias\" must be UpperCamelCase like \"EnumAllowingAlias\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 13,
+      "column": 5,
+      "message": "Repeated field name \"inner_message\" must be pluralized name \"inner_messages\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Message name \"outer\" must be UpperCamelCase like \"Outer\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 10,
+      "column": 5,
+      "message": "Message name \"inner\" must be UpperCamelCase like \"Inner\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 17,
+      "column": 5,
+      "message": "RPC name \"search\" must be UpperCamelCase like \"Search\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 8,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 1,
+      "message": "The line length is 165, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 1,
+      "message": "The line length is 139, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 8,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 1,
+      "message": "The line length is 109, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 1,
+      "message": "The line length is 86, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 5,
+      "message": "RPC name \"findCurrentOrgSubscription\" must be UpperCamelCase like \"FindCurrentOrgSubscription\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "RPC name \"findPartialPayEligibleSubscription\" must be UpperCamelCase like \"FindPartialPayEligibleSubscription\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 11,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 16,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 18,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 19,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 20,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 21,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 22,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 24,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 26,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 27,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 28,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 29,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 11,
+      "column": 5,
+      "message": "Field name \"Identifier\" must be underscore_separated_names like \"identifier\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Field name \"SomeValue\" must be underscore_separated_names like \"some_value\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 16,
+      "column": 5,
+      "message": "Field name \"SomeInt\" must be underscore_separated_names like \"some_int\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Quoted string should be \"other.proto\" but was 'other.proto'.",
+      "rule": "QUOTE_CONSISTENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 8,
+      "column": 1,
+      "message": "The order of Import is invalid. Check if the file is ordered in the correct manner.",
+      "rule": "ORDER"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 18,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 19,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 20,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 21,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 24,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 26,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 25,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 27,
+      "column": 7,
+      "message": "Found an incorrect indentation style \"      \". \"    \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 28,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 29,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 30,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 31,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 34,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 34,
+      "column": 30,
+      "message": "Found a possible incorrect indentation style. Inserting a new line is recommended.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 35,
+      "column": 32,
+      "message": "Found a possible incorrect indentation style. Inserting a new line is recommended.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 47,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 48,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 3,
+      "column": 1,
+      "message": "The line length is 91, but it must be shorter than 80",
+      "rule": "MAX_LINE_LENGTH"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 4,
+      "column": 1,
+      "message": "Package name \"examplePb\" must not contain any uppercase letter. Consider to change like \"examplepb\".",
+      "rule": "PACKAGE_NAME_LOWER_CASE"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 9,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 14,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 15,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 19,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 20,
+      "column": 5,
+      "message": "EnumField name \"STARTED\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 21,
+      "column": 5,
+      "message": "EnumField name \"RUNNING\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 19,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 17,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias\" must be UpperCamelCase like \"EnumAllowingAlias\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 36,
+      "column": 3,
+      "message": "Field \"inner_message\" should avoid required for proto3",
+      "rule": "PROTO3_FIELDS_AVOID_REQUIRED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 37,
+      "column": 3,
+      "message": "Group \"Result\" should be avoided for proto3",
+      "rule": "PROTO3_GROUPS_AVOID"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 40,
+      "column": 3,
+      "message": "Group \"Result\" should be avoided for proto3",
+      "rule": "PROTO3_GROUPS_AVOID"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 43,
+      "column": 3,
+      "message": "Group \"Regular\" should be avoided for proto3",
+      "rule": "PROTO3_GROUPS_AVOID"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 29,
+      "column": 5,
+      "message": "Repeated field name \"inner_message\" must be pluralized name \"inner_messages\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 40,
+      "column": 3,
+      "message": "Repeated group name \"Result\" must be pluralized name \"Results\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 42,
+      "column": 3,
+      "message": "Repeated field name \"paper\" must be pluralized name \"papers\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 43,
+      "column": 3,
+      "message": "Repeated group name \"Regular\" must be pluralized name \"Regulars\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 23,
+      "column": 1,
+      "message": "Message name \"outer\" must be UpperCamelCase like \"Outer\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 26,
+      "column": 5,
+      "message": "Message name \"inner\" must be UpperCamelCase like \"Inner\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 47,
+      "column": 5,
+      "message": "RPC name \"search\" must be UpperCamelCase like \"Search\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE"
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/protolint_0.50.2.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/protolint_0.50.2.json
@@ -1,0 +1,3701 @@
+{
+  "basedir": "/home/jwiesner/Development/github/profhenry/protolint",
+  "lints": [
+    {
+      "filename": "_example/proto/invalidFileName.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/invalidFileName.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File name \"invalidFileName.proto\" should be lower_snake_case.proto like \"invalid_file_name.proto\".",
+      "rule": "FILE_NAMES_LOWER_SNAKE_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File name \"multipleFixersApplicable.proto\" should be lower_snake_case.proto like \"multiple_fixers_applicable.proto\".",
+      "rule": "FILE_NAMES_LOWER_SNAKE_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 3,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 4,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 6,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 10,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 11,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 13,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 3,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"STARTED\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 6,
+      "column": 9,
+      "message": "EnumField name \"RUNNING\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 10,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS_2\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 12,
+      "column": 5,
+      "message": "EnumField name \"STARTED\" should have the prefix \"ENUM_ALLOWING_ALIAS_2\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 13,
+      "column": 5,
+      "message": "EnumField name \"RUNNING\" should have the prefix \"ENUM_ALLOWING_ALIAS_2\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 3,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 10,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 3,
+      "column": 5,
+      "message": "EnumField \"UNKNOWN\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField \"STARTED\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 6,
+      "column": 9,
+      "message": "EnumField \"RUNNING\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 10,
+      "column": 5,
+      "message": "EnumField \"UNKNOWN\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 12,
+      "column": 5,
+      "message": "EnumField \"STARTED\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 13,
+      "column": 5,
+      "message": "EnumField \"RUNNING\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 2,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias\" must be UpperCamelCase like \"EnumAllowingAlias\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 9,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias2\" must be UpperCamelCase like \"EnumAllowingAlias2\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 2,
+      "column": 1,
+      "message": "Enum \"enumAllowingAlias\" should have a comment",
+      "rule": "ENUMS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_111/multipleFixersApplicable.proto",
+      "line": 9,
+      "column": 1,
+      "message": "Enum \"enumAllowingAlias2\" should have a comment",
+      "rule": "ENUMS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File name \"grpc-gateway_a_bit_of_everything.proto\" should be lower_snake_case.proto like \"grpc_gateway_a_bit_of_everything.proto\".",
+      "rule": "FILE_NAMES_LOWER_SNAKE_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 3,
+      "column": 1,
+      "message": "The order of Package is invalid. Check if the file is ordered in the correct manner.",
+      "rule": "ORDER",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 187,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 201,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 200,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 202,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 206,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 205,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 207,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 209,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 208,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 211,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 210,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 213,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 212,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"\t\t\t\". \"      \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 214,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 217,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 216,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 218,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 219,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 221,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 222,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 223,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 224,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 225,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 226,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 227,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 228,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 229,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 230,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 231,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 232,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 233,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 234,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 235,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 236,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 237,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 238,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 239,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 240,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 241,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 242,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 243,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 244,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 245,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 247,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 248,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 249,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 251,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 253,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 256,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 255,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 259,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 258,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 262,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 261,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 265,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 264,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 268,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 267,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 271,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 270,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 273,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 278,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 283,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 282,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 284,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 285,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 286,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 287,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 288,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 289,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 290,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 291,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 292,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 293,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 294,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 295,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 296,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 297,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 298,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 302,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 306,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 307,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 314,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 313,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 316,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 315,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 321,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 322,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 329,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 340,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 337,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 338,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 339,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 341,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 344,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 345,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 346,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 350,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 351,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 352,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 355,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 356,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 357,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 361,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 362,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 363,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 377,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 379,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 380,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 383,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 404,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 405,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 406,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 409,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 418,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 419,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 420,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 423,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 431,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 424,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 425,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 426,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 427,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 428,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 429,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 430,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 432,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 442,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 484,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 485,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 486,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 490,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 491,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 492,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 493,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 496,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 497,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 498,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 501,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 502,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 503,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 507,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 508,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 509,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 513,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 514,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 515,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 518,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 519,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 520,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 523,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 524,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 525,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 529,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 530,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 531,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 534,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 537,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 542,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 543,
+      "column": 3,
+      "message": "Found an incorrect indentation style \"\t\t\". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 546,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 549,
+      "column": 2,
+      "message": "Found an incorrect indentation style \"\t\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 217,
+      "column": 1,
+      "message": "The line length is 125, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 221,
+      "column": 1,
+      "message": "The line length is 186, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 223,
+      "column": 1,
+      "message": "The line length is 166, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 259,
+      "column": 1,
+      "message": "The line length is 207, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 262,
+      "column": 1,
+      "message": "The line length is 177, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 265,
+      "column": 1,
+      "message": "The line length is 192, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 268,
+      "column": 1,
+      "message": "The line length is 206, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 271,
+      "column": 1,
+      "message": "The line length is 170, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 279,
+      "column": 1,
+      "message": "The line length is 127, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 330,
+      "column": 1,
+      "message": "The line length is 125, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 342,
+      "column": 1,
+      "message": "The line length is 391, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 421,
+      "column": 1,
+      "message": "The line length is 521, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 431,
+      "column": 1,
+      "message": "The line length is 123, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 5,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 6,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 7,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 9,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 10,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 11,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 12,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 13,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 211,
+      "column": 4,
+      "message": "EnumField name \"FALSE\" should have the prefix \"DEEP_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 213,
+      "column": 4,
+      "message": "EnumField name \"TRUE\" should have the prefix \"DEEP_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 314,
+      "column": 2,
+      "message": "EnumField name \"ZERO\" should have the prefix \"NUMERIC_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 316,
+      "column": 2,
+      "message": "EnumField name \"ONE\" should have the prefix \"NUMERIC_ENUM\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 211,
+      "column": 4,
+      "message": "EnumField name \"FALSE\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 314,
+      "column": 2,
+      "message": "EnumField name \"ZERO\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 251,
+      "column": 2,
+      "message": "Field name \"nonConventionalNameValue\" must be underscore_separated_names like \"non_conventional_name_value\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 207,
+      "column": 3,
+      "message": "Field \"amount\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 219,
+      "column": 2,
+      "message": "Field \"single_nested\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 221,
+      "column": 2,
+      "message": "Field \"uuid\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 222,
+      "column": 2,
+      "message": "Field \"nested\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 223,
+      "column": 2,
+      "message": "Field \"float_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 224,
+      "column": 2,
+      "message": "Field \"double_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 225,
+      "column": 2,
+      "message": "Field \"int64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 226,
+      "column": 2,
+      "message": "Field \"uint64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 227,
+      "column": 2,
+      "message": "Field \"int32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 228,
+      "column": 2,
+      "message": "Field \"fixed64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 229,
+      "column": 2,
+      "message": "Field \"fixed32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 230,
+      "column": 2,
+      "message": "Field \"bool_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 231,
+      "column": 2,
+      "message": "Field \"string_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 232,
+      "column": 2,
+      "message": "Field \"bytes_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 233,
+      "column": 2,
+      "message": "Field \"uint32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 234,
+      "column": 2,
+      "message": "Field \"enum_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 235,
+      "column": 2,
+      "message": "Field \"path_enum_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 236,
+      "column": 2,
+      "message": "Field \"nested_path_enum_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 237,
+      "column": 2,
+      "message": "Field \"sfixed32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 238,
+      "column": 2,
+      "message": "Field \"sfixed64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 239,
+      "column": 2,
+      "message": "Field \"sint32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 240,
+      "column": 2,
+      "message": "Field \"sint64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 241,
+      "column": 2,
+      "message": "Field \"repeated_string_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 243,
+      "column": 3,
+      "message": "Field \"oneof_empty\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 244,
+      "column": 3,
+      "message": "Field \"oneof_string\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 247,
+      "column": 2,
+      "message": "Field \"map_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 248,
+      "column": 2,
+      "message": "Field \"mapped_string_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 249,
+      "column": 2,
+      "message": "Field \"mapped_nested_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 251,
+      "column": 2,
+      "message": "Field \"nonConventionalNameValue\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 253,
+      "column": 2,
+      "message": "Field \"timestamp_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 273,
+      "column": 2,
+      "message": "Field \"int64_override_type\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 284,
+      "column": 2,
+      "message": "Field \"path_repeated_double_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 285,
+      "column": 2,
+      "message": "Field \"path_repeated_int64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 286,
+      "column": 2,
+      "message": "Field \"path_repeated_uint64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 287,
+      "column": 2,
+      "message": "Field \"path_repeated_int32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 288,
+      "column": 2,
+      "message": "Field \"path_repeated_fixed64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 289,
+      "column": 2,
+      "message": "Field \"path_repeated_fixed32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 290,
+      "column": 2,
+      "message": "Field \"path_repeated_bool_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 291,
+      "column": 2,
+      "message": "Field \"path_repeated_string_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 292,
+      "column": 2,
+      "message": "Field \"path_repeated_bytes_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 293,
+      "column": 2,
+      "message": "Field \"path_repeated_uint32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 294,
+      "column": 2,
+      "message": "Field \"path_repeated_enum_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 295,
+      "column": 2,
+      "message": "Field \"path_repeated_sfixed32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 296,
+      "column": 2,
+      "message": "Field \"path_repeated_sfixed64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 297,
+      "column": 2,
+      "message": "Field \"path_repeated_sint32_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 298,
+      "column": 2,
+      "message": "Field \"path_repeated_sint64_value\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 302,
+      "column": 2,
+      "message": "Field \"name\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 306,
+      "column": 2,
+      "message": "Field \"id\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 307,
+      "column": 2,
+      "message": "Field \"data\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 321,
+      "column": 2,
+      "message": "Field \"abe\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 322,
+      "column": 2,
+      "message": "Field \"update_mask\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 222,
+      "column": 2,
+      "message": "Repeated field name \"nested\" must be pluralized name \"nesteds\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 241,
+      "column": 2,
+      "message": "Repeated field name \"repeated_string_value\" must be pluralized name \"repeated_string_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 256,
+      "column": 2,
+      "message": "Repeated field name \"repeated_enum_value\" must be pluralized name \"repeated_enum_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 259,
+      "column": 2,
+      "message": "Repeated field name \"repeated_enum_annotation\" must be pluralized name \"repeated_enum_annotations\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 265,
+      "column": 2,
+      "message": "Repeated field name \"repeated_string_annotation\" must be pluralized name \"repeated_string_annotations\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 268,
+      "column": 2,
+      "message": "Repeated field name \"repeated_nested_annotation\" must be pluralized name \"repeated_nested_annotations\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 283,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_float_value\" must be pluralized name \"path_repeated_float_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 284,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_double_value\" must be pluralized name \"path_repeated_double_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 285,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_int64_value\" must be pluralized name \"path_repeated_int64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 286,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_uint64_value\" must be pluralized name \"path_repeated_uint64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 287,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_int32_value\" must be pluralized name \"path_repeated_int32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 288,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_fixed64_value\" must be pluralized name \"path_repeated_fixed64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 289,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_fixed32_value\" must be pluralized name \"path_repeated_fixed32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 290,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_bool_value\" must be pluralized name \"path_repeated_bool_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 291,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_string_value\" must be pluralized name \"path_repeated_string_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 292,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_bytes_value\" must be pluralized name \"path_repeated_bytes_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 293,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_uint32_value\" must be pluralized name \"path_repeated_uint32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 294,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_enum_value\" must be pluralized name \"path_repeated_enum_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 295,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sfixed32_value\" must be pluralized name \"path_repeated_sfixed32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 296,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sfixed64_value\" must be pluralized name \"path_repeated_sfixed64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 297,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sint32_value\" must be pluralized name \"path_repeated_sint32_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 298,
+      "column": 2,
+      "message": "Repeated field name \"path_repeated_sint64_value\" must be pluralized name \"path_repeated_sint64_values\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 301,
+      "column": 1,
+      "message": "Message \"Body\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 305,
+      "column": 1,
+      "message": "Message \"MessageWithBody\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 345,
+      "column": 2,
+      "message": "RPC \"CreateBody\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 351,
+      "column": 2,
+      "message": "RPC \"Lookup\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 356,
+      "column": 2,
+      "message": "RPC \"Update\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 362,
+      "column": 2,
+      "message": "RPC \"UpdateV2\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 379,
+      "column": 2,
+      "message": "RPC \"Delete\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 405,
+      "column": 2,
+      "message": "RPC \"GetQuery\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 419,
+      "column": 2,
+      "message": "RPC \"GetRepeatedQuery\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 485,
+      "column": 2,
+      "message": "RPC \"DeepPathEcho\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 491,
+      "column": 2,
+      "message": "RPC \"NoBindings\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 492,
+      "column": 2,
+      "message": "RPC \"Timeout\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 497,
+      "column": 2,
+      "message": "RPC \"ErrorWithDetails\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 502,
+      "column": 2,
+      "message": "RPC \"GetMessageWithBody\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 508,
+      "column": 2,
+      "message": "RPC \"PostWithEmptyBody\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 514,
+      "column": 2,
+      "message": "RPC \"CheckGetQueryParams\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 519,
+      "column": 2,
+      "message": "RPC \"CheckNestedEnumGetQueryParams\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 524,
+      "column": 2,
+      "message": "RPC \"CheckPostQueryParams\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 530,
+      "column": 2,
+      "message": "RPC \"OverwriteResponseContentType\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 542,
+      "column": 2,
+      "message": "RPC \"Empty\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 549,
+      "column": 2,
+      "message": "RPC \"NoBindings\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 541,
+      "column": 1,
+      "message": "Service name \"camelCaseServiceName\" must be UpperCamelCase like \"CamelCaseServiceName\"",
+      "rule": "SERVICE_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_128/grpc-gateway_a_bit_of_everything.proto",
+      "line": 548,
+      "column": 1,
+      "message": "Service \"AnotherServiceWithNoBindings\" should have a comment",
+      "rule": "SERVICES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 1,
+      "column": 1,
+      "message": "Syntax should be \"proto3\" but was \"proto2\".",
+      "rule": "SYNTAX_CONSISTENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 6,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 4,
+      "column": 5,
+      "message": "EnumField name \"NEGATIVE_CONSTANT\" should have the prefix \"TEST_NEGATIVE_VALUE\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"ZERO_CONSTANT\" should have the prefix \"TEST_NEGATIVE_VALUE\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 6,
+      "column": 5,
+      "message": "EnumField name \"POSITIVE_CONSTANT\" should have the prefix \"TEST_NEGATIVE_VALUE\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"ZERO_CONSTANT\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 4,
+      "column": 5,
+      "message": "EnumField \"NEGATIVE_CONSTANT\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField \"ZERO_CONSTANT\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 6,
+      "column": 5,
+      "message": "EnumField \"POSITIVE_CONSTANT\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_140/negative_enum_field.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Enum \"TestNegativeValue\" should have a comment",
+      "rule": "ENUMS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_218/bom.proto",
+      "line": 1,
+      "column": 2,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 4,
+      "column": 1,
+      "message": "Found an incorrect indentation style \"\". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 7,
+      "column": 4,
+      "message": "Found an incorrect indentation style \"   \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Message name \"xyz\" must be UpperCamelCase like \"Xyz\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Message \"xyz\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 9,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 10,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 11,
+      "column": 7,
+      "message": "Found an incorrect indentation style \"      \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 13,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 17,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 5,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias\" must be UpperCamelCase like \"EnumAllowingAlias\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 13,
+      "column": 5,
+      "message": "Repeated field name \"inner_message\" must be pluralized name \"inner_messages\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Message name \"outer\" must be UpperCamelCase like \"Outer\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 10,
+      "column": 5,
+      "message": "Message name \"inner\" must be UpperCamelCase like \"Inner\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment2.proto",
+      "line": 17,
+      "column": 5,
+      "message": "RPC name \"search\" must be UpperCamelCase like \"Search\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_292/trailingcomment3.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 8,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 1,
+      "message": "The line length is 165, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 1,
+      "message": "The line length is 139, but it must be shorter than 120",
+      "rule": "MAX_LINE_LENGTH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "RPC \"findPartialPayEligibleSubscription\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/disabled_rpc_names_upper_camel_case.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Service \"OrgSubscriptionGrpcManager\" should have a comment",
+      "rule": "SERVICES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 5,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 8,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 5,
+      "message": "RPC name \"findCurrentOrgSubscription\" must be UpperCamelCase like \"FindCurrentOrgSubscription\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "RPC name \"findPartialPayEligibleSubscription\" must be UpperCamelCase like \"FindPartialPayEligibleSubscription\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 4,
+      "column": 5,
+      "message": "RPC \"findCurrentOrgSubscription\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 6,
+      "column": 5,
+      "message": "RPC \"findPartialPayEligibleSubscription\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_368/invalid_rpc_names_upper_camel_case.proto",
+      "line": 3,
+      "column": 1,
+      "message": "Service \"OrgSubscriptionGrpcManager\" should have a comment",
+      "rule": "SERVICES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 11,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 16,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 18,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 19,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 20,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 21,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 22,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 24,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 26,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 27,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 28,
+      "column": 9,
+      "message": "Found an incorrect indentation style \"        \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 29,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 11,
+      "column": 5,
+      "message": "Field name \"Identifier\" must be underscore_separated_names like \"identifier\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Field name \"SomeValue\" must be underscore_separated_names like \"some_value\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 16,
+      "column": 5,
+      "message": "Field name \"SomeInt\" must be underscore_separated_names like \"some_int\"",
+      "rule": "FIELD_NAMES_LOWER_SNAKE_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 11,
+      "column": 5,
+      "message": "Field \"Identifier\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 12,
+      "column": 5,
+      "message": "Field \"SomeValue\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 16,
+      "column": 5,
+      "message": "Field \"SomeInt\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 19,
+      "column": 9,
+      "message": "Field \"one_msg\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 20,
+      "column": 9,
+      "message": "Field \"one_int\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 21,
+      "column": 9,
+      "message": "Field \"two_int\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 26,
+      "column": 9,
+      "message": "Field \"three_int\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 27,
+      "column": 9,
+      "message": "Field \"four_int\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 28,
+      "column": 9,
+      "message": "Field \"five_regex\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 10,
+      "column": 1,
+      "message": "Message \"ExternalMsg\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/issue_88/oneof_options.proto",
+      "line": 15,
+      "column": 1,
+      "message": "Message \"OneOfMessage3\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 1,
+      "column": 1,
+      "message": "File should start with a doc comment",
+      "rule": "FILE_HAS_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Quoted string should be \"other.proto\" but was 'other.proto'.",
+      "rule": "QUOTE_CONSISTENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 8,
+      "column": 1,
+      "message": "The order of Import is invalid. Check if the file is ordered in the correct manner.",
+      "rule": "ORDER",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 18,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 19,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 20,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 21,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 24,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 26,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 25,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 27,
+      "column": 7,
+      "message": "Found an incorrect indentation style \"      \". \"    \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 28,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 29,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 30,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 31,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 34,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 34,
+      "column": 30,
+      "message": "Found a possible incorrect indentation style. Inserting a new line is recommended.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 35,
+      "column": 32,
+      "message": "Found a possible incorrect indentation style. Inserting a new line is recommended.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 47,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 48,
+      "column": 5,
+      "message": "Found an incorrect indentation style \"    \". \"  \" is correct.",
+      "rule": "INDENT",
+      "severity": "note"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 4,
+      "column": 1,
+      "message": "Package name \"examplePb\" must not contain any uppercase letter. Consider to change like \"examplepb\".",
+      "rule": "PACKAGE_NAME_LOWER_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 8,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 9,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 14,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 15,
+      "column": 1,
+      "message": "Imports are not sorted.",
+      "rule": "IMPORTS_SORTED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 19,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 20,
+      "column": 5,
+      "message": "EnumField name \"STARTED\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 21,
+      "column": 5,
+      "message": "EnumField name \"RUNNING\" should have the prefix \"ENUM_ALLOWING_ALIAS\"",
+      "rule": "ENUM_FIELD_NAMES_PREFIX",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 19,
+      "column": 5,
+      "message": "EnumField name \"UNKNOWN\" with zero value should have the suffix \"UNSPECIFIED\"",
+      "rule": "ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 19,
+      "column": 5,
+      "message": "EnumField \"UNKNOWN\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 20,
+      "column": 5,
+      "message": "EnumField \"STARTED\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 21,
+      "column": 5,
+      "message": "EnumField \"RUNNING\" should have a comment",
+      "rule": "ENUM_FIELDS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 17,
+      "column": 1,
+      "message": "Enum name \"enumAllowingAlias\" must be UpperCamelCase like \"EnumAllowingAlias\"",
+      "rule": "ENUM_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 17,
+      "column": 1,
+      "message": "Enum \"enumAllowingAlias\" should have a comment",
+      "rule": "ENUMS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 27,
+      "column": 7,
+      "message": "Field \"ival\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 29,
+      "column": 5,
+      "message": "Field \"inner_message\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 30,
+      "column": 5,
+      "message": "Field \"enum_field\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 31,
+      "column": 5,
+      "message": "Field \"my_map\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 32,
+      "column": 3,
+      "message": "Field \"reason_for_error\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 33,
+      "column": 3,
+      "message": "Field \"end_of_support_version\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 36,
+      "column": 3,
+      "message": "Field \"inner_message\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 38,
+      "column": 5,
+      "message": "Field \"url\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 42,
+      "column": 3,
+      "message": "Field \"paper\" should have a comment",
+      "rule": "FIELDS_HAVE_COMMENT",
+      "severity": "warning"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 36,
+      "column": 3,
+      "message": "Field \"inner_message\" should avoid required for proto3",
+      "rule": "PROTO3_FIELDS_AVOID_REQUIRED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 37,
+      "column": 3,
+      "message": "Group \"Result\" should be avoided for proto3",
+      "rule": "PROTO3_GROUPS_AVOID",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 40,
+      "column": 3,
+      "message": "Group \"Result\" should be avoided for proto3",
+      "rule": "PROTO3_GROUPS_AVOID",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 43,
+      "column": 3,
+      "message": "Group \"Regular\" should be avoided for proto3",
+      "rule": "PROTO3_GROUPS_AVOID",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 29,
+      "column": 5,
+      "message": "Repeated field name \"inner_message\" must be pluralized name \"inner_messages\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 40,
+      "column": 3,
+      "message": "Repeated group name \"Result\" must be pluralized name \"Results\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 42,
+      "column": 3,
+      "message": "Repeated field name \"paper\" must be pluralized name \"papers\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 43,
+      "column": 3,
+      "message": "Repeated group name \"Regular\" must be pluralized name \"Regulars\"",
+      "rule": "REPEATED_FIELD_NAMES_PLURALIZED",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 23,
+      "column": 1,
+      "message": "Message name \"outer\" must be UpperCamelCase like \"Outer\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 26,
+      "column": 5,
+      "message": "Message name \"inner\" must be UpperCamelCase like \"Inner\"",
+      "rule": "MESSAGE_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 23,
+      "column": 1,
+      "message": "Message \"outer\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 34,
+      "column": 5,
+      "message": "Message \"AccountForAdmin\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 35,
+      "column": 3,
+      "message": "Message \"SpecialEndOfSupport\" should have a comment",
+      "rule": "MESSAGES_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 47,
+      "column": 5,
+      "message": "RPC name \"search\" must be UpperCamelCase like \"Search\"",
+      "rule": "RPC_NAMES_UPPER_CAMEL_CASE",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 47,
+      "column": 5,
+      "message": "RPC \"search\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 48,
+      "column": 5,
+      "message": "RPC \"Search\" should have a comment",
+      "rule": "RPCS_HAVE_COMMENT",
+      "severity": "error"
+    },
+    {
+      "filename": "_example/proto/simple.proto",
+      "line": 46,
+      "column": 1,
+      "message": "Service \"SearchApi\" should have a comment",
+      "rule": "SERVICES_HAVE_COMMENT",
+      "severity": "error"
+    }
+  ]
+}


### PR DESCRIPTION
Pull request for https://issues.jenkins.io/browse/JENKINS-73363

Plaintext format is still supported. Unit test was added.