### PR TITLE
Add YoctoScannerParser

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/YoctoScannerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/YoctoScannerParser.java
@@ -1,0 +1,125 @@
+package edu.hm.hafner.analysis.parser;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+
+import static j2html.TagCreator.*;
+
+/**
+ * Parser for Yocto Scanner CLI (scannercli) tool.
+ *
+ * @author Juri Duval
+ */
+public class YoctoScannerParser extends JsonIssueParser {
+    private static final String VALUE_NOT_SET = "-";
+    private static final long serialVersionUID = 1L;
+    private static final Double INVALID_SCORE = -1.0;
+
+    @Override
+    protected void parseJsonObject(final Report report, final JSONObject jsonReport, final IssueBuilder issueBuilder) {
+        JSONArray packages = jsonReport.optJSONArray("package");
+        if (packages != null) {
+            parseResources(report, packages, issueBuilder);
+        }
+    }
+
+    private void parseResources(final Report report, final JSONArray packages, final IssueBuilder issueBuilder) {
+        for (int i = 0; i < packages.length(); i++) {
+            final Object item = packages.get(i);
+            if (item instanceof JSONObject) {
+                final JSONObject resourceWrapper = (JSONObject) item;
+                if (!resourceWrapper.isNull("issue")) {
+                    parseVulnerabilities(report, issueBuilder, resourceWrapper);
+                }
+            }
+        }
+    }
+
+    private void parseVulnerabilities(final Report report, final IssueBuilder issueBuilder,
+            final JSONObject resourceWrapper) {
+        final JSONArray vulnerabilities = resourceWrapper.getJSONArray("issue");
+        for (Object vulnerability : vulnerabilities) {
+            if (vulnerability instanceof JSONObject) {
+                final JSONObject obj = (JSONObject) vulnerability;
+                final String status = obj.getString("status");
+                if (status.equals("Unpatched")) {
+                    report.add(convertToIssue(resourceWrapper, obj, issueBuilder));
+                }
+            }
+        }
+    }
+
+    private Issue convertToIssue(final JSONObject resource, final JSONObject vulnerability,
+            final IssueBuilder issueBuilder) {
+        final String packageName = resource.getString("name");
+        return issueBuilder
+                .setPackageName(packageName)
+                .setSeverity(mapSeverity(vulnerability))
+                .setMessage(vulnerability.optString("id", "UNKNOWN"))
+                .setDescription(formatDescription(packageName, resource, vulnerability))
+                .buildAndClean();
+    }
+
+    private Severity mapSeverity(final JSONObject vulnerability) {
+        Double score_v2 = INVALID_SCORE;
+        Double score_v3 = INVALID_SCORE;
+        Double score = INVALID_SCORE;
+
+        if (vulnerability.has("scorev2")) {
+            score_v2 = vulnerability.getDouble("scorev2");
+        }
+
+        if (vulnerability.has("scorev3")) {
+            score_v3 = vulnerability.getDouble("scorev3");
+        }
+
+        if (score_v3 == 0.0) {
+            if (score_v2 != 0.0) {
+                score = score_v2;
+            }
+        } else {
+            score = score_v3;
+        }
+
+        if (score < 0) {
+            return Severity.ERROR;
+        }
+
+        if (score == 0.0) {
+            return Severity.WARNING_LOW;
+        }
+
+        if (score < 4.0) {
+            return Severity.WARNING_LOW;
+        }
+
+        if (score >= 4.0 && score < 7.0) {
+            return Severity.WARNING_NORMAL;
+        }
+
+        if (score >= 7 && score <= 10)
+            return Severity.WARNING_HIGH;
+
+        return Severity.ERROR;
+    }
+
+    private String formatDescription(final String packageName, final JSONObject resource, final JSONObject vulnerability) {
+        final String version = resource.optString("version", VALUE_NOT_SET);
+        final String layer = resource.optString("layer", "UNKOWN");
+        final String vector = vulnerability.optString("vector", "UNKOWN");
+        final String link = vulnerability.optString("link", "UNKOWN");
+        final String description = vulnerability.optString("summary", "");
+
+        return join(div(b("Package: "), text(packageName)),
+                div(b("Version: "), text(version)),
+                div(b("Link: "), text(link)),
+                div(b("Yocto Layer: "), text(layer)),
+                div(b("Vector: "), text(vector)),
+                p(text(description))).render();
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -171,6 +171,7 @@ public class ParserRegistry {
             new VeraCodePipelineScannerDescriptor(),
             new XlcDescriptor(),
             new YamlLintDescriptor(),
+            new YoctoScannerDescriptor(),
             new XmlLintDescriptor(),
             new YuiCompressorDescriptor(),
             new ZptLintDescriptor()

--- a/src/main/java/edu/hm/hafner/analysis/registry/YoctoScannerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/YoctoScannerDescriptor.java
@@ -1,0 +1,44 @@
+package edu.hm.hafner.analysis.registry;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.parser.YoctoScannerParser;
+
+import static j2html.TagCreator.*;
+
+/**
+ * A descriptor for Yocto Scanner.
+ *
+ * @author Juri Duval
+ */
+class YoctoScannerDescriptor extends ParserDescriptor {
+    private static final String ID = "Yocto cli";
+    private static final String NAME = "Yocto Scanner";
+
+    YoctoScannerDescriptor() {
+        super(ID, NAME);
+    }
+
+    @Override
+    public IssueParser createParser(final Option... options) {
+        return new YoctoScannerParser();
+    }
+
+    @Override
+    public String getHelp() {
+        return join(text("Use commandline"),
+                code("bitbake <your product image>"),
+                text(", add INHERIT += \"cve-check\" in your local.conf"),
+                a("Yocto Scanner").withHref("https://docs.yoctoproject.org/dev/dev-manual/vulnerabilities.html"),
+                text("for usage details.")).render();
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://docs.yoctoproject.org/dev/dev-manual/vulnerabilities.html";
+    }
+
+    @Override
+    public String getIconUrl() {
+        return "https://www.yoctoproject.org/wp-content/uploads/sites/32/2023/09/YoctoProject_Logo_RGB_White_small.svg";
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/parser/YoctoScannerParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/YoctoScannerParserTest.java
@@ -1,0 +1,53 @@
+package edu.hm.hafner.analysis.parser;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.ParsingException;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+import edu.hm.hafner.analysis.registry.AbstractParserTest;
+
+import static edu.hm.hafner.analysis.assertions.Assertions.*;
+
+/**
+ * Tests the class {@link YoctoScannerParser}.
+ */
+class YoctoScannerParserTest extends AbstractParserTest {
+
+    YoctoScannerParserTest() {
+        super("yocto_scanner_result.json");
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        softly.assertThat(report).hasSize(25);
+
+        softly.assertThat(report.get(0))
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasPackageName("acl")
+                .hasMessage("CVE-2009-4411");
+        softly.assertThat(report.get(3))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasPackageName("automake-native")
+                .hasMessage("CVE-2012-3386");
+    }
+
+    @Test
+    void shouldHandleEmptyResultsJenkins67296() {
+        Report report = parse("issue67296.json");
+
+        assertThat(report).isEmpty();
+    }
+
+    @Test
+    void brokenInput() {
+        assertThatThrownBy(() -> parse("eclipse.txt")).isInstanceOf(ParsingException.class);
+    }
+
+    @Override
+    protected IssueParser createParser() {
+        return new YoctoScannerParser();
+    }
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/yocto_scanner_result.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/yocto_scanner_result.json
@@ -1,0 +1,416 @@
+{
+  "version": "1",
+  "package": [
+    {
+      "name": "acl",
+      "layer": "meta",
+      "version": "2.3.2",
+      "products": [
+        {
+          "product": "acl",
+          "cvesInRecord": "Yes"
+        }
+      ],
+      "issue": [
+        {
+          "id": "CVE-2009-4411",
+          "summary": "The (1) setfacl and (2) getfacl commands in XFS acl 2.2.47, when running in recursive (-R) mode, follow symbolic links even when the --physical (aka -P) or -L option is specified, which might allow local users to modify the ACL for arbitrary files or directories via a symlink attack.",
+          "scorev2": "3.7",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:H/Au:N/C:P/I:P/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2009-4411"
+        }
+      ]
+    },
+    {
+      "name": "acl-native",
+      "layer": "meta",
+      "version": "2.3.2",
+      "products": [
+        {
+          "product": "acl",
+          "cvesInRecord": "Yes"
+        }
+      ],
+      "issue": [
+        {
+          "id": "CVE-2009-4411",
+          "summary": "The (1) setfacl and (2) getfacl commands in XFS acl 2.2.47, when running in recursive (-R) mode, follow symbolic links even when the --physical (aka -P) or -L option is specified, which might allow local users to modify the ACL for arbitrary files or directories via a symlink attack.",
+          "scorev2": "3.7",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:H/Au:N/C:P/I:P/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2009-4411"
+        }
+      ]
+    },
+    {
+      "name": "attr",
+      "layer": "meta",
+      "version": "2.5.1",
+      "products": [
+        {
+          "product": "attr",
+          "cvesInRecord": "No"
+        }
+      ],
+      "issue": []
+    },
+    {
+      "name": "attr-native",
+      "layer": "meta",
+      "version": "2.5.1",
+      "products": [
+        {
+          "product": "attr",
+          "cvesInRecord": "No"
+        }
+      ],
+      "issue": []
+    },
+    {
+      "name": "autoconf-archive-native",
+      "layer": "meta",
+      "version": "2023.02.20",
+      "products": [
+        {
+          "product": "autoconf-archive",
+          "cvesInRecord": "No"
+        }
+      ],
+      "issue": []
+    },
+    {
+      "name": "autoconf-native",
+      "layer": "meta",
+      "version": "2.72e",
+      "products": [
+        {
+          "product": "autoconf",
+          "cvesInRecord": "No"
+        }
+      ],
+      "issue": []
+    },
+    {
+      "name": "automake-native",
+      "layer": "meta",
+      "version": "1.16.5",
+      "products": [
+        {
+          "product": "automake",
+          "cvesInRecord": "Yes"
+        }
+      ],
+      "issue": [
+        {
+          "id": "CVE-2009-4029",
+          "summary": "The (1) dist or (2) distcheck rules in GNU Automake 1.11.1, 1.10.3, and release branches branch-1-4 through branch-1-9, when producing a distribution tarball for a package that uses Automake, assign insecure permissions (777) to directories in the build tree, which introduces a race condition that allows local users to modify the contents of package files, introduce Trojan horse programs, or conduct other attacks before the build is complete.",
+          "scorev2": "4.4",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2009-4029"
+        },
+        {
+          "id": "CVE-2012-3386",
+          "summary": "The \"make distcheck\" rule in GNU Automake before 1.11.6 and 1.12.x before 1.12.2 grants world-writable permissions to the extraction directory, which introduces a race condition that allows local users to execute arbitrary code via unspecified vectors.",
+          "scorev2": "4.4",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:M/Au:N/C:P/I:P/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2012-3386"
+        }
+      ]
+    },
+    {
+      "name": "avahi",
+      "layer": "meta",
+      "version": "0.8",
+      "products": [
+        {
+          "product": "avahi",
+          "cvesInRecord": "Yes"
+        }
+      ],
+      "issue": [
+        {
+          "id": "CVE-2006-2288",
+          "summary": "Avahi before 0.6.10 allows local users to cause a denial of service (mDNS/DNS-SD service disconnect) via unspecified mDNS name conflicts.",
+          "scorev2": "3.6",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:N/I:P/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2006-2288"
+        },
+        {
+          "id": "CVE-2006-2289",
+          "summary": "Buffer overflow in avahi-core in Avahi before 0.6.10 allows local users to execute arbitrary code via unknown vectors.",
+          "scorev2": "2.1",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2006-2289"
+        },
+        {
+          "id": "CVE-2006-5461",
+          "summary": "Avahi before 0.6.15 does not verify the sender identity of netlink messages to ensure that they come from the kernel instead of another process, which allows local users to spoof network changes to Avahi.",
+          "scorev2": "2.1",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2006-5461"
+        },
+        {
+          "id": "CVE-2006-6870",
+          "summary": "The consume_labels function in avahi-core/dns.c in Avahi before 0.6.16 allows remote attackers to cause a denial of service (infinite loop) via a crafted compressed DNS response with a label that points to itself.",
+          "scorev2": "5.0",
+          "scorev3": "0.0",
+          "vector": "NETWORK",
+          "vectorString": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2006-6870"
+        },
+        {
+          "id": "CVE-2007-3372",
+          "summary": "The Avahi daemon in Avahi before 0.6.20 allows attackers to cause a denial of service (exit) via empty TXT data over D-Bus, which triggers an assert error.",
+          "scorev2": "2.1",
+          "scorev3": "0.0",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-3372"
+        },
+        {
+          "id": "CVE-2008-5081",
+          "summary": "The originates_from_local_legacy_unicast_socket function (avahi-core/server.c) in avahi-daemon in Avahi before 0.6.24 allows remote attackers to cause a denial of service (crash) via a crafted mDNS packet with a source port of 0, which triggers an assertion failure.",
+          "scorev2": "5.0",
+          "scorev3": "0.0",
+          "vector": "NETWORK",
+          "vectorString": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2008-5081"
+        },
+        {
+          "id": "CVE-2010-2244",
+          "summary": "The AvahiDnsPacket function in avahi-core/socket.c in avahi-daemon in Avahi 0.6.16 and 0.6.25 allows remote attackers to cause a denial of service (assertion failure and daemon exit) via a DNS packet with an invalid checksum followed by a DNS packet with a valid checksum, a different vulnerability than CVE-2008-5081.",
+          "scorev2": "4.3",
+          "scorev3": "0.0",
+          "vector": "NETWORK",
+          "vectorString": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-2244"
+        },
+        {
+          "id": "CVE-2011-1002",
+          "summary": "avahi-core/socket.c in avahi-daemon in Avahi before 0.6.29 allows remote attackers to cause a denial of service (infinite loop) via an empty mDNS (1) IPv4 or (2) IPv6 UDP packet to port 5353.  NOTE: this vulnerability exists because of an incorrect fix for CVE-2010-2244.",
+          "scorev2": "5.0",
+          "scorev3": "0.0",
+          "vector": "NETWORK",
+          "vectorString": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-1002"
+        },
+        {
+          "id": "CVE-2017-6519",
+          "summary": "avahi-daemon in Avahi through 0.6.32 and 0.7 inadvertently responds to IPv6 unicast queries with source addresses that are not on-link, which allows remote attackers to cause a denial of service (traffic amplification) and may cause information leakage by obtaining potentially sensitive  information from the responding device via port-5353 UDP packets.  NOTE: this may overlap CVE-2015-2809.",
+          "scorev2": "6.4",
+          "scorev3": "9.1",
+          "vector": "NETWORK",
+          "vectorString": "AV:N/AC:L/Au:N/C:P/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-6519"
+        },
+        {
+          "id": "CVE-2021-26720",
+          "summary": "avahi-daemon-check-dns.sh in the Debian avahi package through 0.8-4 is executed as root via /etc/network/if-up.d/avahi-daemon, and allows a local attacker to cause a denial of service or create arbitrary empty files via a symlink attack on files under /run/avahi-daemon. NOTE: this only affects the packaging for Debian GNU/Linux (used indirectly by SUSE), not the upstream Avahi product.",
+          "scorev2": "4.6",
+          "scorev3": "7.8",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+          "status": "Ignored",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-26720",
+          "detail": "not-applicable-platform",
+          "description": "Issue only affects Debian/SUSE"
+        },
+        {
+          "id": "CVE-2021-3468",
+          "summary": "A flaw was found in avahi in versions 0.6 up to 0.8. The event used to signal the termination of the client connection on the avahi Unix socket is not correctly handled in the client_work function, allowing a local attacker to trigger an infinite loop. The highest threat from this vulnerability is to the availability of the avahi service, which becomes unresponsive after this flaw is triggered.",
+          "scorev2": "2.1",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-3468"
+        },
+        {
+          "id": "CVE-2021-3502",
+          "summary": "A flaw was found in avahi 0.8-5. A reachable assertion is present in avahi_s_host_name_resolver_start function allowing a local attacker to crash the avahi service by requesting hostname resolutions through the avahi socket or dbus methods for invalid hostnames. The highest threat from this vulnerability is to the service availability.",
+          "scorev2": "2.1",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-3502"
+        },
+        {
+          "id": "CVE-2023-1981",
+          "summary": "A vulnerability was found in the avahi library. This flaw allows an unprivileged user to make a dbus call, causing the avahi daemon to crash.",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-1981"
+        },
+        {
+          "id": "CVE-2023-38469",
+          "summary": "A vulnerability was found in Avahi, where a reachable assertion exists in avahi_dns_packet_append_record.",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-38469"
+        },
+        {
+          "id": "CVE-2023-38470",
+          "summary": "A vulnerability was found in Avahi. A reachable assertion exists in the avahi_escape_label() function.",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-38470"
+        },
+        {
+          "id": "CVE-2023-38471",
+          "summary": "A vulnerability was found in Avahi. A reachable assertion exists in the dbus_set_host_name function.",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-38471"
+        },
+        {
+          "id": "CVE-2023-38472",
+          "summary": "A vulnerability was found in Avahi. A reachable assertion exists in the avahi_rdata_parse() function.",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-38472"
+        },
+        {
+          "id": "CVE-2023-38473",
+          "summary": "A vulnerability was found in Avahi. A reachable assertion exists in the avahi_alternative_host_name() function.",
+          "scorev2": "0.0",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-38473"
+        }
+      ]
+    },
+    {
+      "name": "texinfo-dummy-native",
+      "layer": "meta",
+      "version": "1.0",
+      "products": [
+        {
+          "product": "texinfo-dummy",
+          "cvesInRecord": "No"
+        }
+      ],
+      "issue": []
+    },
+    {
+      "name": "u-boot-fslc",
+      "layer": "meta-freescale",
+      "version": "2024.07+fslc+git",
+      "products": [
+        {
+          "product": "u-boot-fslc",
+          "cvesInRecord": "No"
+        }
+      ],
+      "issue": []
+    },
+    {
+      "name": "udev-rules-imx",
+      "layer": "meta-freescale",
+      "version": "1.0",
+      "products": [
+        {
+          "product": "udev-rules-imx",
+          "cvesInRecord": "No"
+        }
+      ],
+      "issue": []
+    },
+    {
+      "name": "zstd-native",
+      "layer": "meta",
+      "version": "1.5.5",
+      "products": [
+        {
+          "product": "zstandard",
+          "cvesInRecord": "Yes"
+        }
+      ],
+      "issue": [
+        {
+          "id": "CVE-2019-11922",
+          "summary": "A race condition in the one-pass compression functions of Zstandard prior to version 1.3.8 could allow an attacker to write bytes out of bounds if an output buffer smaller than the recommended size was used.",
+          "scorev2": "6.8",
+          "scorev3": "8.1",
+          "vector": "NETWORK",
+          "vectorString": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-11922"
+        },
+        {
+          "id": "CVE-2021-24031",
+          "summary": "In the Zstandard command-line utility prior to v1.4.1, output files were created with default permissions. Correct file permissions (matching the input) would only be set at completion time. Output files could therefore be readable or writable to unintended parties.",
+          "scorev2": "2.1",
+          "scorev3": "5.5",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-24031"
+        },
+        {
+          "id": "CVE-2021-24032",
+          "summary": "Beginning in v1.4.1 and prior to v1.4.9, due to an incomplete fix for CVE-2021-24031, the Zstandard command-line utility created output files with default permissions and restricted those permissions immediately afterwards. Output files could therefore momentarily be readable or writable to unintended parties.",
+          "scorev2": "1.9",
+          "scorev3": "4.7",
+          "vector": "LOCAL",
+          "vectorString": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-24032"
+        },
+        {
+          "id": "CVE-2022-4899",
+          "summary": "A vulnerability was found in zstd v1.4.10, where an attacker can supply empty string as an argument to the command line tool to cause buffer overrun.",
+          "scorev2": "0.0",
+          "scorev3": "7.5",
+          "vector": "NETWORK",
+          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "status": "Unpatched",
+          "link": "https://nvd.nist.gov/vuln/detail/CVE-2022-4899"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Yocto project support CVE security vulnerabilities using cve-check in the specific image or target you are building, add the following setting to your configuration:

INHERIT += "cve-check"

status of each CVE: Patched, Unpatched or Ignored

The scanner look only for Unpatched package and calculate the severity using the score_v2 or score_v3

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
