### PR TITLE
Add parser categories

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/registry/ClairDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ClairDescriptor.java
@@ -33,4 +33,9 @@ class ClairDescriptor extends ParserDescriptor {
     public String getUrl() {
         return "https://github.com/arminc/clair-scanner";
     }
+
+    @Override
+    public Type getType() {
+        return Type.VULNERABILITY;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/CodeCheckerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/CodeCheckerDescriptor.java
@@ -4,7 +4,7 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.parser.CodeCheckerParser;
 
 /**
- * A descriptor for the Codechecker parser.
+ * A descriptor for the CodeChecker parser.
  *
  */
 class CodeCheckerDescriptor extends ParserDescriptor {

--- a/src/main/java/edu/hm/hafner/analysis/registry/DryDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/DryDescriptor.java
@@ -67,4 +67,9 @@ public abstract class DryDescriptor extends ParserDescriptor {
     public String getDescription(final Issue issue) {
         return getDuplicateCode(issue.getAdditionalProperties());
     }
+
+    @Override
+    public Type getType() {
+        return Type.DUPLICATION;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/ErrorProneDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ErrorProneDescriptor.java
@@ -28,4 +28,9 @@ class ErrorProneDescriptor extends CompositeParserDescriptor {
     public String getUrl() {
         return "https://errorprone.info";
     }
+
+    @Override
+    public Type getType() {
+        return Type.BUG;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/FindBugsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FindBugsDescriptor.java
@@ -49,4 +49,9 @@ class FindBugsDescriptor extends ParserDescriptor {
     public String getDescription(final Issue issue) {
         return messages.get().getMessage(issue.getType());
     }
+
+    @Override
+    public Type getType() {
+        return Type.BUG;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/FlawfinderDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/FlawfinderDescriptor.java
@@ -30,4 +30,9 @@ class FlawfinderDescriptor extends ParserDescriptor {
     public String getUrl() {
         return "https://dwheeler.com/flawfinder/";
     }
+
+    @Override
+    public Type getType() {
+        return Type.VULNERABILITY;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/OwaspDependencyCheckDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/OwaspDependencyCheckDescriptor.java
@@ -33,4 +33,9 @@ class OwaspDependencyCheckDescriptor extends ParserDescriptor {
     public String getIconUrl() {
         return "https://raw.githubusercontent.com/jeremylong/DependencyCheck/main/src/site/resources/images/logo.svg";
     }
+
+    @Override
+    public Type getType() {
+        return Type.VULNERABILITY;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserDescriptor.java
@@ -48,6 +48,16 @@ public abstract class ParserDescriptor {
     }
 
     /**
+     * Returns the type of the parser. The type is used to customize parsers in the UI.
+     * This default implementation returns {@link Type#WARNING}.
+     *
+     * @return the type of the parser
+     */
+    public Type getType() {
+        return Type.WARNING;
+    }
+
+    /**
      * Creates a new {@link IssueParser} instance.
      *
      * @param options
@@ -138,7 +148,9 @@ public abstract class ParserDescriptor {
         /** A parser that scans the output of a build tool to find bugs. */
         BUG,
         /** A parser that scans the output of a build tool to find vulnerabilities. */
-        VULNERABILITY
+        VULNERABILITY,
+        /** A parser that scans the output of a build tool to find vulnerabilities. */
+        DUPLICATION
     }
 
     /**

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserDescriptor.java
@@ -50,6 +50,7 @@ public abstract class ParserDescriptor {
     /**
      * Returns the type of the parser. The type is used to customize parsers in the UI.
      * This default implementation returns {@link Type#WARNING}.
+     * Override this method if your parser is of a different type.
      *
      * @return the type of the parser
      */

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserDescriptor.java
@@ -130,6 +130,18 @@ public abstract class ParserDescriptor {
     }
 
     /**
+     * Returns the type of the parser. The type is used to customize parsers in the UI.
+     */
+    public enum Type {
+        /** A parser that scans the output of a build tool to find warnings. */
+        WARNING,
+        /** A parser that scans the output of a build tool to find bugs. */
+        BUG,
+        /** A parser that scans the output of a build tool to find vulnerabilities. */
+        VULNERABILITY
+    }
+
+    /**
      * A parser configuration option. Basically an immutable key and value pair.
      */
     public static class Option extends SimpleImmutableEntry<String, String> {

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -265,11 +265,11 @@ public class ParserRegistry {
                     + "\n"
                     + "The static analysis model supports the following report formats.\n"
                     + "\n"
-                    + "If your tool is not yet supported you can\n"
+                    + "If your tool is not yet supported, you can\n"
                     + "1. export the issues of your tool to the native XML or JSON format (or any other format).\n"
                     + "2. provide a [pull request](https://github.com/jenkinsci/analysis-model/pulls) with a new parser.\n"
                     + "\n"
-                    + "If your tool is supported, but some properties are missing (icon, URL, etc.), please file a\n"
+                    + "If your tool is supported, but some properties are missing (icon, URL, etc.), please file a "
                     + "[pull request](https://github.com/jenkinsci/analysis-model/pulls).\n"
                     + "\n");
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/PnpmAuditDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/PnpmAuditDescriptor.java
@@ -41,4 +41,9 @@ class PnpmAuditDescriptor extends ParserDescriptor {
     public String getIconUrl() {
         return "https://pnpm.io/img/pnpm-no-name-with-frame.svg";
     }
+
+    @Override
+    public Type getType() {
+        return Type.VULNERABILITY;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/SemgrepDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SemgrepDescriptor.java
@@ -35,4 +35,9 @@ class SemgrepDescriptor extends ParserDescriptor {
     public String getIconUrl() {
         return "https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep.svg";
     }
+
+    @Override
+    public Type getType() {
+        return Type.VULNERABILITY;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/SpotBugsDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/SpotBugsDescriptor.java
@@ -27,4 +27,9 @@ class SpotBugsDescriptor extends FindBugsDescriptor {
     public String getIconUrl() {
         return "https://raw.githubusercontent.com/spotbugs/spotbugs.github.io/master/images/logos/spotbugs_icon_only_zoom_256px.png";
     }
+
+    @Override
+    public Type getType() {
+        return Type.BUG;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/TrivyDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/TrivyDescriptor.java
@@ -41,4 +41,9 @@ class TrivyDescriptor extends ParserDescriptor {
     public String getIconUrl() {
         return "https://github.com/aquasecurity/trivy/blob/main/docs/imgs/logo.png?raw=true";
     }
+
+    @Override
+    public Type getType() {
+        return Type.VULNERABILITY;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/YoctoScannerDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/YoctoScannerDescriptor.java
@@ -41,4 +41,9 @@ class YoctoScannerDescriptor extends ParserDescriptor {
     public String getIconUrl() {
         return "https://upload.wikimedia.org/wikipedia/commons/0/00/Yocto_Project_logo.svg";
     }
+
+    @Override
+    public Type getType() {
+        return Type.VULNERABILITY;
+    }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/ZptLintDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ZptLintDescriptor.java
@@ -4,7 +4,7 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.parser.violations.ZptLintAdapter;
 
 /**
- * A descriptor for the Yui Compressor parser.
+ * A descriptor for the ZPT Lint parser.
  *
  * @author Lorenz Munsch
  */

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
@@ -11,7 +11,6 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.registry.ParserDescriptor.Option;
-import edu.hm.hafner.analysis.registry.ParserDescriptor.Type;
 import edu.hm.hafner.util.ResourceTest;
 
 import static edu.hm.hafner.analysis.assertions.Assertions.*;
@@ -61,8 +60,8 @@ class ParserRegistryTest extends ResourceTest {
         var parserRegistry = new ParserRegistry();
 
         assertThat(parserRegistry).hasIds(SPOTBUGS, CHECKSTYLE, PMD).hasNames("SpotBugs", "CheckStyle", "PMD");
-        assertThat(parserRegistry.get(SPOTBUGS)).hasId(SPOTBUGS).hasName("SpotBugs").hasType(Type.BUG);
-        assertThat(parserRegistry.get("owasp-dependency-check")).hasName("OWASP Dependency Check").hasType(Type.VULNERABILITY);
+        assertThat(parserRegistry.get(SPOTBUGS)).hasId(SPOTBUGS).hasName("SpotBugs").hasType(ParserDescriptor.Type.BUG);
+        assertThat(parserRegistry.get("owasp-dependency-check")).hasName("OWASP Dependency Check").hasType(ParserDescriptor.Type.VULNERABILITY);
         assertThat(parserRegistry.contains(SPOTBUGS)).isTrue();
         assertThat(parserRegistry.contains("nothing")).isFalse();
         List<ParserDescriptor> descriptors = parserRegistry.getAllDescriptors();
@@ -74,7 +73,7 @@ class ParserRegistryTest extends ResourceTest {
     void shouldConfigureCpdParser() {
         var parserRegistry = new ParserRegistry();
         var cpdDescriptor = parserRegistry.get("cpd");
-        assertThat(cpdDescriptor).hasType(Type.DUPLICATION).hasName("CPD");
+        assertThat(cpdDescriptor).hasType(ParserDescriptor.Type.DUPLICATION).hasName("CPD");
 
         IssueParser parser = cpdDescriptor.createParser();
 

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
@@ -2,6 +2,7 @@ package edu.hm.hafner.analysis.registry;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +22,13 @@ import static edu.hm.hafner.analysis.assertions.Assertions.*;
  * @author Ullrich Hafner
  */
 class ParserRegistryTest extends ResourceTest {
+    // Note for parser developers: if you add a new parser,
+    // please check if you are using the correct type and increment the corresponding count
+    private static final long WARNING_PARSERS_COUNT = 127L;
+    private static final long BUG_PARSERS_COUNT = 3L;
+    private static final long VULNERABILITY_PARSERS_COUNT = 7L;
+    private static final long DUPLICATION_PARSERS_COUNT = 3L;
+
     public static final String SPOTBUGS = "spotbugs";
     public static final String CHECKSTYLE = "checkstyle";
     public static final String PMD = "pmd";
@@ -31,6 +39,21 @@ class ParserRegistryTest extends ResourceTest {
 
         assertThatExceptionOfType(NoSuchElementException.class)
                 .isThrownBy(() -> parserRegistry.get("-"));
+    }
+
+    /**
+     * Ensures that new parsers have the correct type assigned.
+     */
+    @Test
+    void shouldAssignCorrectParserType() {
+        var parserRegistry = new ParserRegistry();
+        var typeCountMap = parserRegistry.getAllDescriptors().stream()
+                .collect(Collectors.groupingBy(ParserDescriptor::getType, Collectors.counting()));
+        assertThat(typeCountMap)
+                .containsEntry(Type.WARNING, WARNING_PARSERS_COUNT)
+                .containsEntry(Type.BUG, BUG_PARSERS_COUNT)
+                .containsEntry(Type.VULNERABILITY, VULNERABILITY_PARSERS_COUNT)
+                .containsEntry(Type.DUPLICATION, DUPLICATION_PARSERS_COUNT);
     }
 
     @Test

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
@@ -10,6 +10,7 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.registry.ParserDescriptor.Option;
+import edu.hm.hafner.analysis.registry.ParserDescriptor.Type;
 import edu.hm.hafner.util.ResourceTest;
 
 import static edu.hm.hafner.analysis.assertions.Assertions.*;
@@ -37,7 +38,8 @@ class ParserRegistryTest extends ResourceTest {
         var parserRegistry = new ParserRegistry();
 
         assertThat(parserRegistry).hasIds(SPOTBUGS, CHECKSTYLE, PMD).hasNames("SpotBugs", "CheckStyle", "PMD");
-        assertThat(parserRegistry.get(SPOTBUGS)).hasId(SPOTBUGS).hasName("SpotBugs");
+        assertThat(parserRegistry.get(SPOTBUGS)).hasId(SPOTBUGS).hasName("SpotBugs").hasType(Type.BUG);
+        assertThat(parserRegistry.get("owasp-dependency-check")).hasName("OWASP Dependency Check").hasType(Type.VULNERABILITY);
         assertThat(parserRegistry.contains(SPOTBUGS)).isTrue();
         assertThat(parserRegistry.contains("nothing")).isFalse();
         List<ParserDescriptor> descriptors = parserRegistry.getAllDescriptors();
@@ -49,6 +51,7 @@ class ParserRegistryTest extends ResourceTest {
     void shouldConfigureCpdParser() {
         var parserRegistry = new ParserRegistry();
         var cpdDescriptor = parserRegistry.get("cpd");
+        assertThat(cpdDescriptor).hasType(Type.DUPLICATION).hasName("CPD");
 
         IssueParser parser = cpdDescriptor.createParser();
 

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
@@ -50,10 +50,10 @@ class ParserRegistryTest extends ResourceTest {
         var typeCountMap = parserRegistry.getAllDescriptors().stream()
                 .collect(Collectors.groupingBy(ParserDescriptor::getType, Collectors.counting()));
         assertThat(typeCountMap)
-                .containsEntry(Type.WARNING, WARNING_PARSERS_COUNT)
-                .containsEntry(Type.BUG, BUG_PARSERS_COUNT)
-                .containsEntry(Type.VULNERABILITY, VULNERABILITY_PARSERS_COUNT)
-                .containsEntry(Type.DUPLICATION, DUPLICATION_PARSERS_COUNT);
+                .containsEntry(ParserDescriptor.Type.WARNING, WARNING_PARSERS_COUNT)
+                .containsEntry(ParserDescriptor.Type.BUG, BUG_PARSERS_COUNT)
+                .containsEntry(ParserDescriptor.Type.VULNERABILITY, VULNERABILITY_PARSERS_COUNT)
+                .containsEntry(ParserDescriptor.Type.DUPLICATION, DUPLICATION_PARSERS_COUNT);
     }
 
     @Test


### PR DESCRIPTION
The plugin started with warnings only, but now we can scan for warnings, bugs, vulnerabilities, etc. It makes sense to categorize all parsers so we can automatically set icons and texts for the selected parser.