### PR TITLE
Fix timeout problems in CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,22 +293,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-        <version>11.1.0</version>
-        <configuration>
-          <nvdApiServerId>nvd.nist.gov</nvdApiServerId>
-          <format>JSON</format>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <configuration>

--- a/src/test/java/edu/hm/hafner/analysis/parser/AntJavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AntJavacParserTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the class {@link AntJavacParser}.
  */
 class AntJavacParserTest extends AbstractParserTest {
+    private static final int ALLOWED_TIMEOUT_IN_SECONDS = 5;
+
     AntJavacParserTest() {
         super("ant-javac.txt");
     }
@@ -37,7 +39,7 @@ class AntJavacParserTest extends AbstractParserTest {
      */
     @Test
     void issue55805() {
-        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> parse("issue55805.txt"));
+        assertTimeoutPreemptively(Duration.ofSeconds(ALLOWED_TIMEOUT_IN_SECONDS), () -> parse("issue55805.txt"));
     }
 
     /**


### PR DESCRIPTION
Make the build more robust:

- Remove dependency check: this is part of a profile now (parent pom)
- Increase timeout for test of JENKINS-55805