### PR TITLE
Fixes SimulinkCheckParser fingerprinting issue

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/SimulinkCheckParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SimulinkCheckParser.java
@@ -31,7 +31,7 @@ public class SimulinkCheckParser extends IssueParser {
     private static final String INCOMPLETE = "div.IncompleteCheck";
     private static final String EMPTY_BASE_URI = "";
     private static final String REPORT_CONTENT = "div.ReportContent";
-    private static final String MODEL_NAME_SELECTOR = "b > font";
+    private static final String MODEL_NAME_SELECTOR = "b:contains(Model Advisor Report - ) > font";
     private static final Pattern TEXT_PATTERN = Pattern.compile("^(SW[0-9]*-[0-9]*)(\\W*)(.*)");
     private static final String SW_PREFIX = "SW";
 
@@ -50,7 +50,7 @@ public class SimulinkCheckParser extends IssueParser {
             var report = new Report();
 
             var modelNameElement = systemElement.selectFirst(MODEL_NAME_SELECTOR);
-            var system = modelNameElement.text();
+            var system = (modelNameElement == null) ? systemElement.id() : modelNameElement.text();
             parseIssues(report, document, issueBuilder, system, WARNING);
             parseIssues(report, document, issueBuilder, system, FAILED);
             parseIssues(report, document, issueBuilder, system, NOT_RUN);

--- a/src/main/java/edu/hm/hafner/analysis/parser/SimulinkCheckParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SimulinkCheckParser.java
@@ -31,6 +31,7 @@ public class SimulinkCheckParser extends IssueParser {
     private static final String INCOMPLETE = "div.IncompleteCheck";
     private static final String EMPTY_BASE_URI = "";
     private static final String REPORT_CONTENT = "div.ReportContent";
+    private static final String MODEL_NAME_SELECTOR = "b > font";
     private static final Pattern TEXT_PATTERN = Pattern.compile("^(SW[0-9]*-[0-9]*)(\\W*)(.*)");
     private static final String SW_PREFIX = "SW";
 
@@ -48,7 +49,8 @@ public class SimulinkCheckParser extends IssueParser {
             }
             var report = new Report();
 
-            var system = systemElement.id();
+            var modelNameElement = systemElement.selectFirst(MODEL_NAME_SELECTOR);
+            var system = modelNameElement.text();
             parseIssues(report, document, issueBuilder, system, WARNING);
             parseIssues(report, document, issueBuilder, system, FAILED);
             parseIssues(report, document, issueBuilder, system, NOT_RUN);

--- a/src/test/java/edu/hm/hafner/analysis/parser/SimulinkCheckParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/SimulinkCheckParserTest.java
@@ -53,5 +53,9 @@ class SimulinkCheckParserTest extends AbstractParserTest {
                 .hasModuleName("SW01-181.NestedComments");
         softly.assertThat(report.get(9))
                 .hasModuleName("SW02-430.CompareFloatEquality");
+
+        for (int i = 0; i < report.size(); i++) {
+            softly.assertThat(report.get(i)).hasFileName("sldemo_mdladv.slx");
+        }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This pull request fixes the issue with the SimulinkCheckParser where model file extensions (e.g., .slx, .mdl , etc) were missing in the filenames passed to the IssueBuilder. Previously, the parser extracted only the model name without its extension, causing fingerprinting errors during processing of Simulink Check Tool reports.  (https://issues.jenkins.io/browse/JENKINS-72838)
### Testing done
Created a freestyle Project and parsed a static html report with the model present in the workspace.

<img width="945" alt="fingerprint" src="https://github.com/user-attachments/assets/a719aaa5-be96-4a4a-978c-169cd226bd16" />



<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
