### PR TITLE
[Jenkins-70153] Add support for gradle build-tools warnings (w:)

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -30,6 +30,8 @@ public class JavacParser extends AbstractMavenLogParser {
             = "^(?:\\S+\\s+)?"                          // optional preceding arbitrary number of characters that are not a
                                                         // whitespace followed by whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:|e:)\\s+)" // optional [WARNING] or [ERROR] or w: or e:
+            + "(?:"
+            // --- Matches filename/line ---
             + "(((\\/?[a-zA-Z]|file):)?[^\\[\\(:]*):"   // group 2: filename starting path with C:\ or /C:\ or file:/// or /
             + "("                                       // start group 5
             + "(\\s*[\\[\\(]?)?"                        // optional ( or [
@@ -39,7 +41,11 @@ public class JavacParser extends AbstractMavenLogParser {
             + "[\\]\\)]?\\s*:?\\s?"                     // optional ) or ] or whitespace or :
             + ")"                                       // end group 5
             + "(?:\\[(\\w+)\\])?"                       // group 9: optional category
-            + "\\s*(.*)$";                              // group 10: message
+            + "\\s*(.*)"                                // group 10: message
+            + "|"
+            // --- Matches quoted messages ---
+            + "(['\"])(.*?)\\11\\s*(.*)" 		        // group 11: opening quote; group 12: quoted text; group 13: rest of message
+            + ")$";
 
     private static final String SEVERITY_ERROR = "ERROR";
     private static final String SEVERITY_ERROR_SHORT = "e:";

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -28,7 +28,7 @@ public class JavacParser extends AbstractMavenLogParser {
 
     private static final String JAVAC_WARNING_PATTERN
             = "^(?:\\S+\\s+)?"                          // optional preceding arbitrary number of characters that are not a
-                                                        // whitespace followed by whitespace. This can be used for timestamps.
+            // whitespace followed by whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:|e:)\\s+)" // optional [WARNING] or [ERROR] or w: or e:
             + "(?:"
             // --- Matches filename/line ---

--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -44,7 +44,7 @@ public class JavacParser extends AbstractMavenLogParser {
             + "\\s*(.*)"                                // group 10: message
             + "|"
             // --- Matches quoted messages ---
-            + "(['\"])(.*?)\\11\\s*(.*)" 		        // group 11: opening quote; group 12: quoted text; group 13: rest of message
+            + "(['\"])(.*?)\\11\\s*(.*)"                // group 11: opening quote; group 12: quoted text; group 13: rest of message
             + ")$";
 
     private static final String SEVERITY_ERROR = "ERROR";

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -385,4 +385,16 @@ class JavacParserTest extends AbstractParserTest {
                 .hasFileName("file:///project/src/main/java/com/app/ui/model/Activity.kt")
                 .hasMessage("'PackageStats' is deprecated. Deprecated in Java");
     }
+
+    /**
+     * Parses gradle build-tools warnings.
+     *
+     * @see <a href="https://issues.jenkins.io/browse/JENKINS-70153">Issue 70153</a>
+     */
+    @Test
+    void issue70153() {
+        var warnings = parse("issue70153.txt");
+
+        assertThat(warnings).hasSize(4);
+    }
 }

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -396,5 +396,31 @@ class JavacParserTest extends AbstractParserTest {
         var warnings = parse("issue70153.txt");
 
         assertThat(warnings).hasSize(4);
+
+        assertThat(warnings.get(0))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(0)
+                .hasColumnStart(0);
+
+        assertThat(warnings.get(1))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(35)
+                .hasColumnStart(35)
+                .hasFileName("/var/lib/jenkins/workspace/.../CountryFavoriteRepositoryImpl.kt")
+                .hasMessage("Type mismatch: inferred type is CountryFavoriteDto? but CountryFavoriteDto was expected");
+
+        assertThat(warnings.get(2))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(86)
+                .hasColumnStart(39)
+                .hasFileName("/var/lib/jenkins/workspace/.../CountryFavoriteUseCase.kt")
+                .hasMessage("Name shadowed: favoriteCountry");
+
+        assertThat(warnings.get(3))
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasLineStart(48)
+                .hasColumnStart(30)
+                .hasFileName("/var/lib/jenkins/workspace/.../CountryDetailActivity.kt")
+                .hasMessage("'getParcelableExtra(String!): T?' is deprecated. Deprecated in Java");
     }
 }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/issue70153.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/issue70153.txt
@@ -1,0 +1,5 @@
+> Task :travel:compileDebugKotlin
+w: '-Xjvm-default=compatibility' is deprecated, please use '-Xjvm-default=all|all-compatibility'
+w: /var/lib/jenkins/workspace/.../CountryFavoriteRepositoryImpl.kt: (35, 35): Type mismatch: inferred type is CountryFavoriteDto? but CountryFavoriteDto was expected
+w: /var/lib/jenkins/workspace/.../CountryFavoriteUseCase.kt: (86, 39): Name shadowed: favoriteCountry
+w: /var/lib/jenkins/workspace/.../CountryDetailActivity.kt: (48, 30): 'getParcelableExtra(String!): T?' is deprecated. Deprecated in Java


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done
[Closes](https://issues.jenkins.io/browse/JENKINS-70153)

Added support for gradle build-tools warnings (w:) by modifying the Pattern in the `JavacParser`. Now it matches the filename/line format along with quoted messages as mentioned in the issue. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
