### PR TITLE
Write the latest version of the library as property into the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <scmTag>HEAD</scmTag>
     <revision>13.2.0</revision>
     <changelist>-SNAPSHOT</changelist>
+    <previousVersion>13.1.0</previousVersion>
 
     <module.name>edu.hm.hafner.analysis.model</module.name>
 
@@ -392,6 +393,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.18.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <oldVersion>${previousVersion}</oldVersion>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -453,6 +471,7 @@
           <plugin>
             <artifactId>maven-release-plugin</artifactId>
             <configuration>
+              <preparationGoals>build-helper:parse-version versions:set-property -Dproperty=previousVersion -DnewVersion=${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</preparationGoals>
               <completionGoals>incrementals:reincrementalify</completionGoals>
             </configuration>
           </plugin>


### PR DESCRIPTION
RevApi compares our code to the latest released version of this library. To find this version, it depends on the artifacts deployed to Maven repositories. Unfortunately, the analysis-model is released in two different repositories, making it impossible to auto-detect. Therefore, we need to write the latest version into the POM (during the release process) and provide this version as property for RevApi.

Fixes jenkins-infra/helpdesk#4543
