### PR TITLE
Handle levels of ansible-lint warnings

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AnsibleLintParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnsibleLintParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.LookaheadParser;
+import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.LookaheadStream;
 
 /**
@@ -23,7 +24,7 @@ public class AnsibleLintParser extends LookaheadParser {
     @Serial
     private static final long serialVersionUID = 8481090596321427484L;
 
-    private static final String ANSIBLE_LINT_WARNING_PATTERN = "(?<file>.*)\\:(?<lineno>[0-9]*)\\:\\s*(\\[(?<cat>[a-zA-Z0-9\\-\\[\\]]+)\\]|(?<newcat>[^\\[][a-zA-Z0-9\\[\\]\\-]+)):?\\s(?<msg>.*)";
+    private static final String ANSIBLE_LINT_WARNING_PATTERN = "(?<file>.*)\\:(?<lineno>[0-9]*)\\:\\s*(\\[(?<cat>[a-zA-Z0-9\\-\\[\\]]+)\\]|(?<newcat>[^\\[][a-zA-Z0-9\\[\\]\\-]+)):?\\s(?<msg>.*?)(?<warn>\\s\\(warning\\))?$";
 
     /**
      * Creates a new instance of {@link AnsibleLintParser}.
@@ -56,6 +57,7 @@ public class AnsibleLintParser extends LookaheadParser {
                 .setLineStart(matcher.group("lineno"))
                 .setCategory(cat)
                 .setMessage(matcher.group("msg"))
+                .setSeverity(matcher.group("warn") != null ? Severity.WARNING_LOW : Severity.WARNING_NORMAL)
                 .buildOptional();
     }
 }

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnsibleLintParserTest.java
@@ -20,7 +20,7 @@ class AnsibleLintParserTest extends AbstractParserTest {
 
     @Override
     protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
-        assertThat(report).hasSize(12);
+        assertThat(report).hasSize(13);
 
         Iterator<Issue> iterator = report.iterator();
         softly.assertThat(iterator.next())
@@ -88,7 +88,7 @@ class AnsibleLintParserTest extends AbstractParserTest {
                 .hasFileName("/workspace/templates.yml");
 
         softly.assertThat(iterator.next())
-                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasSeverity(Severity.WARNING_LOW)
                 .hasCategory("no-changed-when")
                 .hasLineStart(41)
                 .hasLineEnd(41)
@@ -100,7 +100,14 @@ class AnsibleLintParserTest extends AbstractParserTest {
                 .hasCategory("fqcn[action]")
                 .hasLineStart(79)
                 .hasLineEnd(79)
-                .hasMessage("Use FQCN for module actions, such `<namespace>.<collection>.apache2_conf`. (warning)")
+                .hasMessage("Use FQCN for module actions, such `<namespace>.<collection>.apache2_conf`.")
+                .hasFileName("roles/apache2/tasks/main.yml");
+        softly.assertThat(iterator.next())
+                .hasSeverity(Severity.WARNING_LOW)
+                .hasCategory("fqcn[action]")
+                .hasLineStart(79)
+                .hasLineEnd(79)
+                .hasMessage("Use FQCN for module actions, such `<namespace>.<collection>.apache2_conf`.")
                 .hasFileName("roles/apache2/tasks/main.yml");
         softly.assertThat(iterator.next())
                 .hasSeverity(Severity.WARNING_NORMAL)

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -637,10 +637,10 @@ class ParsersTest extends ResourceTest {
         findIssuesOfTool(9, "aspectj", "ajc.txt");
     }
 
-    /** Runs the AnsibleLint parser on an output file that contains 12 issues. */
+    /** Runs the AnsibleLint parser on an output file that contains 13 issues. */
     @Test
     void shouldFindAllAnsibleLintIssues() {
-        findIssuesOfTool(12, "ansiblelint", "ansibleLint.txt");
+        findIssuesOfTool(13, "ansiblelint", "ansibleLint.txt");
     }
 
     /**

--- a/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/ansibleLint.txt
@@ -10,7 +10,8 @@
 /workspace/upgrade.yml:38: no-handler Tasks that run when changed should likely be handlers
 /workspace/templates.yml:11: risky-file-permissions File permissions unset or incorrect
 
-/workspace/roles/create_service/tasks/main.yml:41: no-changed-when: Commands should not change things if nothing needs doing.
+/workspace/roles/create_service/tasks/main.yml:41: no-changed-when: Commands should not change things if nothing needs doing. (warning)
 
+roles/apache2/tasks/main.yml:79: fqcn[action]: Use FQCN for module actions, such `<namespace>.<collection>.apache2_conf`.
 roles/apache2/tasks/main.yml:79: fqcn[action]: Use FQCN for module actions, such `<namespace>.<collection>.apache2_conf`. (warning)
 roles/bitbucket_srv/tasks/main.yml:45: literal-compare: Don't compare to literal True/False.


### PR DESCRIPTION
In ansible-lint it is possible to set a [`warn-list` for lower level warnings](https://ansible.readthedocs.io/projects/lint/usage/#ignoring-rules).
It is shown as such in parseable output with a [` (warning)` at the end of the line](https://github.com/ansible/ansible-lint/blob/3553b2a8126e31db0e61296961e4c1f8577386f6/src/ansiblelint/formatters/__init__.py#L102).
In SARIF output it is of level `warning` (instead of `error`).
So to be consistent, it is more logic to be parsed as `WARNING_LOW`, like the `warning` from SARIF.

This PR detect the presence of the final ` (warning)` and use it to lower the severity to `WARNING_LOW`.
As a bonus, this ` (warning)` is no more in the warning message.

### Testing done

Unit test for ansible-lint parser has been updated accordingly to the new parsing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
