### PR TITLE
Skip false positives in javac parser

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JavacParser.java
@@ -1,10 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.Serial;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.regex.Matcher;
-
 import org.apache.commons.lang3.RegExUtils;
 
 import edu.hm.hafner.analysis.Issue;
@@ -12,6 +7,11 @@ import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.LookaheadStream;
+
+import java.io.Serial;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
 
 import static edu.hm.hafner.analysis.Categories.*;
 
@@ -28,9 +28,8 @@ public class JavacParser extends AbstractMavenLogParser {
 
     private static final String JAVAC_WARNING_PATTERN
             = "^(?:\\S+\\s+)?"                          // optional preceding arbitrary number of characters that are not a
-            // whitespace followed by whitespace. This can be used for timestamps.
+                                                        // whitespace followed by whitespace. This can be used for timestamps.
             + "(?:(?:\\[(WARNING|ERROR)\\]|w:|e:)\\s+)" // optional [WARNING] or [ERROR] or w: or e:
-            + "(?:"
             // --- Matches filename/line ---
             + "(((\\/?[a-zA-Z]|file):)?[^\\[\\(:]*):"   // group 2: filename starting path with C:\ or /C:\ or file:/// or /
             + "("                                       // start group 5
@@ -41,11 +40,7 @@ public class JavacParser extends AbstractMavenLogParser {
             + "[\\]\\)]?\\s*:?\\s?"                     // optional ) or ] or whitespace or :
             + ")"                                       // end group 5
             + "(?:\\[(\\w+)\\])?"                       // group 9: optional category
-            + "\\s*(.*)"                                // group 10: message
-            + "|"
-            // --- Matches quoted messages ---
-            + "(['\"])(.*?)\\11\\s*(.*)"                // group 11: opening quote; group 12: quoted text; group 13: rest of message
-            + ")$";
+            + "\\s*(.*)";                               // group 10: message
 
     private static final String SEVERITY_ERROR = "ERROR";
     private static final String SEVERITY_ERROR_SHORT = "e:";

--- a/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/JavacParserTest.java
@@ -1,8 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.time.Duration;
-import java.util.Iterator;
-
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.Categories;
@@ -11,6 +8,9 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.assertions.SoftAssertions;
 import edu.hm.hafner.analysis.registry.AbstractParserTest;
+
+import java.time.Duration;
+import java.util.Iterator;
 
 import static edu.hm.hafner.analysis.assertions.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,6 +26,13 @@ class JavacParserTest extends AbstractParserTest {
     @Override
     protected JavacParser createParser() {
         return new JavacParser();
+    }
+
+    @Test
+    void shouldIgnoreSurefireMessages() {
+        var report = parseStringContent("[\u001B[1;33mWARNING\u001B[m] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ edu.hm.hafner:analysis-model:${revision}${changelist}, /home/runner/work/analysis-model/analysis-model/pom.xml, line 303, column 15");
+
+        assertThat(report).isEmpty();
     }
 
     @Test
@@ -76,7 +83,7 @@ class JavacParserTest extends AbstractParserTest {
     }
 
     /**
-     * Parses a warning log with two warning generated on windows.
+     * Parses a warning log with two warnings generated on windows.
      *
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-66737">Issue 66738</a>
      */
@@ -395,28 +402,26 @@ class JavacParserTest extends AbstractParserTest {
     void issue70153() {
         var warnings = parse("issue70153.txt");
 
-        assertThat(warnings).hasSize(4);
+        assertThat(warnings).hasSize(3);
 
-        assertThat(warnings.get(0))
-                .hasSeverity(Severity.WARNING_NORMAL)
-                .hasLineStart(0)
-                .hasColumnStart(0);
-
-        assertThat(warnings.get(1))
+        int index = 0;
+        assertThat(warnings.get(index))
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasLineStart(35)
                 .hasColumnStart(35)
                 .hasFileName("/var/lib/jenkins/workspace/.../CountryFavoriteRepositoryImpl.kt")
                 .hasMessage("Type mismatch: inferred type is CountryFavoriteDto? but CountryFavoriteDto was expected");
 
-        assertThat(warnings.get(2))
+        index++;
+        assertThat(warnings.get(index))
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasLineStart(86)
                 .hasColumnStart(39)
                 .hasFileName("/var/lib/jenkins/workspace/.../CountryFavoriteUseCase.kt")
                 .hasMessage("Name shadowed: favoriteCountry");
 
-        assertThat(warnings.get(3))
+        index++;
+        assertThat(warnings.get(index))
                 .hasSeverity(Severity.WARNING_NORMAL)
                 .hasLineStart(48)
                 .hasColumnStart(30)


### PR DESCRIPTION
We get too many false positives when we scan for warnings that start with the correct prefix and span the whole line. So for now, we ignore all those warnings without a filename and message match.

See failed quality gates in this PR 🥲 
