### PR TITLE
Show the filename when throwing an exception

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/FileReaderFactory.java
+++ b/src/main/java/edu/hm/hafner/analysis/FileReaderFactory.java
@@ -1,5 +1,12 @@
 package edu.hm.hafner.analysis;
 
+import org.apache.commons.io.input.BOMInputStream;
+
+import com.google.errorprone.annotations.MustBeClosed;
+
+import edu.hm.hafner.util.SecureXmlParserFactory;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,13 +18,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-
-import org.apache.commons.io.input.BOMInputStream;
-
-import com.google.errorprone.annotations.MustBeClosed;
-
-import edu.hm.hafner.util.SecureXmlParserFactory;
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
  * Provides a {@link ReaderFactory} that returns readers for a given file.
@@ -73,7 +73,7 @@ public class FileReaderFactory extends ReaderFactory {
             throw new ParsingException(exception, "Can't find file '%s'", fileName);
         }
         catch (IOException | UncheckedIOException exception) {
-            throw new ParsingException(exception, "Can't parse file '%s'", fileName);
+            throw new ParsingException(exception, "Can't open file '%s'", fileName);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/ParsingException.java
+++ b/src/main/java/edu/hm/hafner/analysis/ParsingException.java
@@ -1,10 +1,10 @@
 package edu.hm.hafner.analysis;
 
-import java.io.Serial;
-
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.google.errorprone.annotations.FormatMethod;
+
+import java.io.Serial;
 
 /**
  * Indicates that during parsing a non-recoverable error has been occurred.
@@ -23,6 +23,18 @@ public class ParsingException extends RuntimeException {
      */
     public ParsingException(final Throwable cause) {
         super(createMessage(cause, "Exception occurred during parsing"), cause);
+    }
+
+    /**
+     * Constructs a new {@link ParsingException} with the specified cause.
+     *
+     * @param cause
+     *         the cause (which is saved for later retrieval by the {@link #getCause()} method).
+     * @param reader
+     *         the reader factory that caused the exception
+     */
+    public ParsingException(final Throwable cause, final ReaderFactory reader) {
+        super(createMessage(cause, "%s: Exception occurred during parsing".formatted(reader.getFileName())), cause);
     }
 
     /**
@@ -61,6 +73,28 @@ public class ParsingException extends RuntimeException {
     @FormatMethod
     public ParsingException(final String messageFormat, final Object... args) {
         super(messageFormat.formatted(args));
+    }
+
+    /**
+     * Constructs a new {@link ParsingException} with the specified message. Prefixes the message with the file name
+     * of the reader factory.
+     *
+     * @param reader
+     *         the reader factory that caused the exception
+     * @param messageFormat
+     *         the message as a format string as described in <a href="../util/Formatter.html#syntax">Format string
+     *         syntax</a>
+     * @param args
+     *         Arguments referenced by the format specifiers in the format string.  If there are more arguments than
+     *         format specifiers, the extra arguments are ignored.  The number of arguments is variable and may be zero.
+     *         The maximum number of arguments is limited by the maximum dimension of a Java array as defined by
+     *         <cite>The Java&trade; Virtual Machine Specification</cite>. The behaviour on a {@code null} argument
+     *         depends on the <a href="../util/Formatter.html#syntax">conversion</a>.
+     */
+    @FormatMethod
+    @SuppressWarnings("InconsistentOverloads")
+    public ParsingException(final ReaderFactory reader, final String messageFormat, final Object... args) {
+        super("%s: %s".formatted(reader.getFileName(), messageFormat.formatted(args)));
     }
 
     private static String createMessage(final Throwable cause, final String message) {

--- a/src/main/java/edu/hm/hafner/analysis/ReaderFactory.java
+++ b/src/main/java/edu/hm/hafner/analysis/ReaderFactory.java
@@ -94,7 +94,7 @@ public abstract class ReaderFactory {
             }
         }
         catch (UncheckedIOException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, this);
         }
     }
 
@@ -105,7 +105,7 @@ public abstract class ReaderFactory {
                 closeable.close();
             }
             catch (Exception e) {
-                throw new ParsingException(e);
+                throw new ParsingException(e, this);
             }
         };
     }
@@ -127,7 +127,7 @@ public abstract class ReaderFactory {
             return lines.collect(Collectors.joining("\n"));
         }
         catch (UncheckedIOException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, this);
         }
     }
 
@@ -144,7 +144,7 @@ public abstract class ReaderFactory {
             return parserFactory.readDocument(reader, getCharset());
         }
         catch (IOException | SecureXmlParserFactory.ParsingException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, this);
         }
     }
 
@@ -171,7 +171,7 @@ public abstract class ReaderFactory {
             new SecureXmlParserFactory().parse(reader, getCharset(), handler);
         }
         catch (IOException | SecureXmlParserFactory.ParsingException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, this);
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/AbstractDryParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AbstractDryParser.java
@@ -1,10 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.IOException;
-import java.io.Serial;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.digester3.Digester;
 import org.xml.sax.SAXException;
 
@@ -16,6 +11,11 @@ import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.SecureDigester;
 import edu.hm.hafner.analysis.Severity;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A duplication parser template for Digester based parsers.
@@ -78,7 +78,7 @@ public abstract class AbstractDryParser<T> extends IssueParser {
         try (var reader = readerFactory.create(); var issueBuilder = new IssueBuilder()) {
             var result = digester.parse(reader);
             if (result != duplications) { // NOPMD
-                throw new ParsingException("Input stream is not a valid duplications file.");
+                throw new ParsingException(readerFactory, "Input stream is not a valid duplications file.");
             }
 
             issueBuilder.setMessage("Found duplicated code.")
@@ -86,7 +86,7 @@ public abstract class AbstractDryParser<T> extends IssueParser {
             return convertDuplicationsToIssues(duplications, issueBuilder);
         }
         catch (IOException | SAXException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/AjcParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AjcParser.java
@@ -32,8 +32,8 @@ public class AjcParser extends IssueParser {
         try (Stream<String> lines = reader.readStream()) {
             return parse(lines);
         }
-        catch (UncheckedIOException e) {
-            throw new ParsingException(e);
+        catch (UncheckedIOException exception) {
+            throw new ParsingException(exception, reader);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/CcmParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CcmParser.java
@@ -56,13 +56,13 @@ public class CcmParser extends IssueParser {
         try (var reader = ccmXmlFile.create()) {
             Ccm report = digester.parse(reader);
             if (report == null) {
-                throw new ParsingException("Input stream is not a CCM file.");
+                throw new ParsingException(ccmXmlFile, "Input stream is not a CCM file.");
             }
 
             return report;
         }
         catch (IOException | SAXException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, ccmXmlFile);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/CheckStyleParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/CheckStyleParser.java
@@ -68,13 +68,13 @@ public class CheckStyleParser extends IssueParser {
         try (var reader = readerFactory.create()) {
             CheckStyle checkStyle = digester.parse(reader);
             if (checkStyle == null) {
-                throw new ParsingException("Input stream is not a Checkstyle file.");
+                throw new ParsingException(readerFactory, "Input stream is not a Checkstyle file.");
             }
 
             return convert(checkStyle);
         }
         catch (IOException | SAXException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/ClangAnalyzerPlistParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ClangAnalyzerPlistParser.java
@@ -1,8 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.Serial;
-import java.util.ArrayList;
-import java.util.List;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
@@ -21,6 +18,10 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.util.IntegerParser;
 import edu.hm.hafner.analysis.util.XmlElementUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A parser for the clang-analyzer static analysis warnings.
@@ -76,7 +77,7 @@ public class ClangAnalyzerPlistParser extends IssueParser {
             return report;
         }
         catch (XPathExpressionException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/EclipseXmlParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/EclipseXmlParser.java
@@ -83,7 +83,7 @@ public class EclipseXmlParser extends IssueParser {
             return report;
         }
         catch (XPathExpressionException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/EmbeddedEngineerParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/EmbeddedEngineerParser.java
@@ -1,10 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.Serial;
-import java.io.UncheckedIOException;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
-
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.analysis.IssueBuilder;
@@ -14,6 +9,11 @@ import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.util.LookaheadStream;
+
+import java.io.Serial;
+import java.io.UncheckedIOException;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * A parser for the EmbeddedEngineer EA Code Generator tool log files.
@@ -42,7 +42,7 @@ public class EmbeddedEngineerParser extends IssueParser {
             }
         }
         catch (UncheckedIOException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, reader);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/FindBugsParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/FindBugsParser.java
@@ -104,7 +104,7 @@ public class FindBugsParser extends IssueParser {
             }
         }
         catch (SAXException | IOException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
 
         return parse(readerFactory, sources, builder, hashToMessageMapping, categories);
@@ -137,7 +137,7 @@ public class FindBugsParser extends IssueParser {
             }
         }
         catch (DocumentException | IOException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/JcReportParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JcReportParser.java
@@ -89,7 +89,7 @@ public class JcReportParser extends IssueParser {
             return digester.parse(reader);
         }
         catch (IOException | SAXException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonIssueParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonIssueParser.java
@@ -1,8 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.IOException;
-import java.io.Serial;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -13,6 +10,9 @@ import edu.hm.hafner.analysis.IssueParser;
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
+
+import java.io.IOException;
+import java.io.Serial;
 
 /**
  * Base class for parsers that operate on a `*.json` file that contains issues in a JSON data structure.
@@ -35,11 +35,11 @@ public abstract class JsonIssueParser extends IssueParser {
                 parseJsonArray(report, jsonReport, issueBuilder);
             }
             else {
-                throw new ParsingException("Cannot process parsed JSON object '%s'", parsedValue);
+                throw new ParsingException(readerFactory, "Cannot process parsed JSON object '%s'", parsedValue);
             }
         }
         catch (IOException | JSONException | ClassCastException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, readerFactory);
         }
         return report;
     }

--- a/src/main/java/edu/hm/hafner/analysis/parser/JsonParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/JsonParser.java
@@ -1,10 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.IOException;
-import java.io.Serial;
-import java.util.Optional;
-import java.util.stream.StreamSupport;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -14,6 +9,11 @@ import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 /**
  * Parser that reads the 1:1 JSON mapping of the properties of the {@link Issue} bean.
@@ -47,8 +47,8 @@ public class JsonParser extends JsonBaseParser {
             }
             return report;
         }
-        catch (IOException | JSONException e) {
-            throw new ParsingException(e);
+        catch (IOException | JSONException exception) {
+            throw new ParsingException(exception, readerFactory);
         }
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/PmdParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/PmdParser.java
@@ -62,13 +62,13 @@ public class PmdParser extends IssueParser {
         try (var reader = readerFactory.create()) {
             Pmd pmd = digester.parse(reader);
             if (pmd == null) {
-                throw new ParsingException("Input stream is not a PMD file.");
+                throw new ParsingException(readerFactory, "Input stream is not a PMD file.");
             }
 
             return convertIssues(pmd);
         }
         catch (IOException | SAXException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
     }
 
@@ -88,13 +88,13 @@ public class PmdParser extends IssueParser {
         try (var reader = readerFactory.create()) {
             Pmd pmd = digester.parse(reader);
             if (pmd == null) {
-                throw new ParsingException("Input stream is not a PMD file.");
+                throw new ParsingException(readerFactory, "Input stream is not a PMD file.");
             }
 
             return convertErrors(pmd);
         }
         catch (IOException | SAXException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/SimulinkCheckParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/SimulinkCheckParser.java
@@ -1,9 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.IOException;
-import java.io.Serial;
-import java.util.regex.Pattern;
-
 import org.apache.commons.io.input.ReaderInputStream;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -16,6 +12,10 @@ import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
+
+import java.io.IOException;
+import java.io.Serial;
+import java.util.regex.Pattern;
 
 /**
  * A parser for Simulink Check tool by Mathworks results. Used for HTML report files.
@@ -45,7 +45,7 @@ public class SimulinkCheckParser extends IssueParser {
             var systemElements = document.select(REPORT_CONTENT);
             var systemElement = systemElements.first();
             if (systemElement == null) {
-                throw new ParsingException("No system element found");
+                throw new ParsingException(readerFactory, "No system element found");
             }
             var report = new Report();
 
@@ -59,7 +59,7 @@ public class SimulinkCheckParser extends IssueParser {
             return report;
         }
         catch (IOException exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/TaglistParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/TaglistParser.java
@@ -1,6 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.Serial;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
@@ -15,6 +14,8 @@ import edu.hm.hafner.analysis.ReaderFactory;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.util.XmlElementUtil;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+import java.io.Serial;
 
 /**
  * Parser for Taglist Maven Plugin output. During parse, class names are converted into assumed file system names, so
@@ -63,7 +64,7 @@ public class TaglistParser extends IssueParser {
             return report;
         }
         catch (XPathExpressionException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/XmlParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/XmlParser.java
@@ -1,6 +1,5 @@
 package edu.hm.hafner.analysis.parser;
 
-import java.io.Serial;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -20,6 +19,8 @@ import edu.hm.hafner.analysis.util.XmlElementUtil;
 import edu.hm.hafner.util.LineRange;
 import edu.hm.hafner.util.LineRangeList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.Serial;
 
 /**
  * Parser that reads the 1:1 XML mapping of the properties of the {@link Issue} bean.
@@ -103,7 +104,7 @@ public class XmlParser extends IssueParser {
             return report;
         }
         catch (XPathExpressionException e) {
-            throw new ParsingException(e);
+            throw new ParsingException(e, readerFactory);
         }
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/parser/violations/AbstractViolationAdapter.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/violations/AbstractViolationAdapter.java
@@ -1,9 +1,5 @@
 package edu.hm.hafner.analysis.parser.violations;
 
-import java.io.Serial;
-import java.util.Set;
-import java.util.logging.Level;
-
 import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.IssueParser;
@@ -14,6 +10,9 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
+import java.io.Serial;
+import java.util.Set;
+import java.util.logging.Level;
 import se.bjurr.violations.lib.ViolationsLogger;
 import se.bjurr.violations.lib.model.SEVERITY;
 import se.bjurr.violations.lib.model.Violation;
@@ -42,7 +41,7 @@ public abstract class AbstractViolationAdapter extends IssueParser {
             return convertToReport(violations);
         }
         catch (Exception exception) {
-            throw new ParsingException(exception);
+            throw new ParsingException(exception, readerFactory);
         }
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/PmdParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/PmdParserTest.java
@@ -3,6 +3,7 @@ package edu.hm.hafner.analysis.parser;
 import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.ParsingException;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.assertions.SoftAssertions;
@@ -46,6 +47,13 @@ class PmdParserTest extends AbstractParserTest {
                 .hasPackageName("com.avaloq.adt.env.internal.ui.actions")
                 .hasFileName(
                         "C:/Build/Results/jobs/ADT-Base/workspace/com.avaloq.adt.ui/src/main/java/com/avaloq/adt/env/internal/ui/actions/CopyToClipboard.java");
+    }
+
+    @Test
+    void showFileNameWhenReportIsBroken() {
+        assertThatExceptionOfType(ParsingException.class).isThrownBy(
+                        () -> parseInPmdFolder("otherfile.xml"))
+                .withMessageContaining("target/test-classes/edu/hm/hafner/analysis/parser/pmd/otherfile.xml");
     }
 
     @Test


### PR DESCRIPTION
When a file cannot be read, then the name of the file should be shown. This helps to find the root cause for the failure.

Before:
```
edu.hm.hafner.analysis.ParsingException: Input stream is not a PMD file.
	at edu.hm.hafner.analysis.parser.PmdParser.parseIssues(PmdParser.java:65)
	at edu.hm.hafner.analysis.parser.PmdParser.parseReport(PmdParser.java:39)
	at edu.hm.hafner.analysis.IssueParser.parse(IssueParser.java:62)
	at edu.hm.hafner.grading.FileSystemToolParser.readReport(FileSystemToolParser.java:40)
	at edu.hm.hafner.grading.ScoreBuilder.readReport(ScoreBuilder.java:162)
	at edu.hm.hafner.grading.AnalysisScore$AnalysisScoreBuilder.read(AnalysisScore.java:177)
	at edu.hm.hafner.grading.AggregatedScore.grade(AggregatedScore.java:390)
	at edu.hm.hafner.grading.AggregatedScore.gradeAnalysis(AggregatedScore.java:341)
	at edu.hm.hafner.grading.AutoGradingRunner.run(AutoGradingRunner.java:98)
	at edu.hm.hafner.grading.gitlab.GitLabAutoGradingRunner.main(GitLabAutoGradingRunner.java:38)
```

After:
```
edu.hm.hafner.analysis.ParsingException: /Users/hafner/git/warnings-ng-plugin-devenv/analysis-model/target/test-classes/edu/hm/hafner/analysis/parser/pmd/otherfile.xml: Input stream is not a PMD file.
	at edu.hm.hafner.analysis.parser.PmdParser.parseIssues(PmdParser.java:65)
	at edu.hm.hafner.analysis.parser.PmdParser.parseReport(PmdParser.java:39)
	at edu.hm.hafner.analysis.IssueParser.parse(IssueParser.java:62)
	at edu.hm.hafner.analysis.registry.AbstractParserTest.parse(AbstractParserTest.java:173)
	at edu.hm.hafner.analysis.parser.PmdParserTest.parseInPmdFolder(PmdParserTest.java:188)
	at edu.hm.hafner.analysis.parser.PmdParserTest.lambda$showFileNameWhenReportIsBroken$0(PmdParserTest.java:55)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:63)
	at org.assertj.core.api.ThrowableTypeAssert.isThrownBy(ThrowableTypeAssert.java:59)
```