### PR TITLE
[JENKINS-64612] Skip clang-tidy warnings in Gcc parser and vice versaa

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/ClangTidyParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/ClangTidyParser.java
@@ -41,12 +41,19 @@ public class ClangTidyParser extends LookaheadParser {
             priority = Severity.WARNING_NORMAL;
         }
 
+        // Reject GCC warnings that have [-W...] format
+        // GCC warnings should be handled by Gcc4CompilerParser
+        var category = matcher.group(7);
+        if (category.startsWith("-W")) {
+            return Optional.empty();
+        }
+
         return builder.setFileName(matcher.group(2))
                 .setSeverity(priority)
                 .setLineStart(matcher.group(3))
                 .setColumnStart(matcher.group(4))
                 .setType(StringUtils.capitalize(matcher.group(5)))
-                .setCategory(matcher.group(7))
+                .setCategory(category)
                 .setMessage(matcher.group(6))
                 .buildOptional();
     }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/gcc-clang-tidy-mixed.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/gcc-clang-tidy-mixed.txt
@@ -1,0 +1,14 @@
+# GCC warnings with [-W...] should be matched by Gcc4CompilerParser
+main.cpp:10:5: warning: unused variable 'x' [-Wunused-variable]
+test.cpp:20:10: warning: comparison between signed and unsigned [-Wsign-compare]
+
+# Clang-tidy warnings with [check-name] should NOT be matched by Gcc4CompilerParser
+src/main.cpp:1:8: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+/src/main.cpp:10:20: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+/path/to/project/src/test2.cpp:83:20: warning: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [clang-diagnostic-sign-conversion]
+/path/to/project/src/test2.cpp:25:15: warning: suggest braces around initialization of subobject [clang-diagnostic-missing-braces]
+/path with space/to/project/src/path_with_space.cpp:24:5: warning: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
+
+# More GCC warnings with [-W...] should be matched
+foo.cpp:30:12: error: undefined reference to 'bar' [-Wundefined]
+bar.cpp:15:1: warning: control reaches end of non-void function [-Wreturn-type]


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
[JENKINS-64612](https://issues.jenkins.io/browse/JENKINS-64612)

clang-tidy warnigns are reported as gcc warnings
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
