### PR TITLE
Restore serialization to use interfaces again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,20 @@
                   <classQualifiedName>edu.hm.hafner.analysis.parser..*Parser</classQualifiedName>
                   <justification>Parsers are not part of the API.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <regex>true</regex>
+                  <code>java.field.serialVersionUIDUnchanged</code>
+                  <classSimpleName>Issue</classSimpleName>
+                  <justification>We are using the interface which still serialzes correctly.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <regex>true</regex>
+                  <code>java.field.serialVersionUIDUnchanged</code>
+                  <classSimpleName>DuplicationGroup</classSimpleName>
+                  <justification>We are using the interface which still serialzes correctly.</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/src/main/java/edu/hm/hafner/analysis/DuplicationGroup.java
+++ b/src/main/java/edu/hm/hafner/analysis/DuplicationGroup.java
@@ -19,8 +19,8 @@ public final class DuplicationGroup implements Serializable {
     @Serial
     private static final long serialVersionUID = 14L; // release 14.0.0
 
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<Issue> occurrences = new ArrayList<>();
+    @SuppressWarnings("serial")
+    private final List<Issue> occurrences = new ArrayList<>();
     private String codeFragment = StringUtils.EMPTY;
 
     /**

--- a/src/main/java/edu/hm/hafner/analysis/Issue.java
+++ b/src/main/java/edu/hm/hafner/analysis/Issue.java
@@ -185,8 +185,8 @@ public class Issue implements Serializable {
     @Deprecated @CheckForNull @SuppressWarnings("DeprecatedIsStillUsed") // used in readResolve()
     private LineRangeList lineRanges = null;  // replaced by locations since 14.0.0
 
-    @SuppressWarnings("PMD.LooseCoupling")
-    private ArrayList<Location> locations; // fixed
+    @SuppressWarnings("serial")
+    private List<Location> locations; // fixed
 
     private final UUID id;            // fixed
 


### PR DESCRIPTION
Changing the fields to serializable classes breaks the existing serializations.
