### PR TITLE
Fix `MSBuild` parser regression with masked `****` paths in Jenkins logs

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/MsBuildParser.java
@@ -337,7 +337,12 @@ public class MsBuildParser extends LookaheadParser {
         if (fileName.contains("<") || fileName.contains(">") || fileName.contains("|")) {
             return true;
         }
-        return fileName.contains("\"") || fileName.contains("?") || fileName.contains("*");
+
+        if (fileName.contains("\"") || fileName.contains("?")) {
+            return true;
+        }
+
+        return fileName.contains("*") && !fileName.contains("/") && !fileName.contains("\\");
     }
 
     private boolean canResolveRelativeFileName(final String fileName, final String projectDir) {

--- a/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/MsBuildParserTest.java
@@ -1180,6 +1180,35 @@ class MsBuildParserTest extends AbstractParserTest {
                 .hasMessage("ignoring '/OPT:REF' due to '/DEBUG' specification");
     }
 
+    /**
+     * MSBuildParser should keep warnings when Jenkins log masking replaces a directory segment with "****".
+     *
+     * @see <a href="https://github.com/jenkinsci/analysis-model/issues/1476">Issue 1476</a>
+     */
+    @Test
+    void issue1476() {
+        var withoutMask = parseStringContent(
+                "d:\\workspace\\foo\\Bar.cs(26,57): warning CS8625: Example warning text [d:\\workspace\\foo\\foo.csproj]");
+        assertThat(withoutMask).hasSize(1);
+
+        var withMask = parseStringContent(
+                "d:\\****\\workspace\\foo\\Bar.cs(26,57): warning CS8625: Example warning text [d:\\****\\workspace\\foo\\foo.csproj]");
+        assertThat(withMask).hasSize(1);
+
+        var warnings = parseStringContent(
+                "[2025-11-24T09:30:26.235Z]     34>d:\\****\\workspace\\foo\\Bar.cs(26,57): warning CS8625: Example warning text [d:\\****\\workspace\\foo\\foo.csproj]");
+
+        assertThat(warnings).hasSize(1);
+
+        assertThat(warnings.get(0))
+                .hasFileName("D:/****/workspace/foo/Bar.cs")
+                .hasCategory("CS8625")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasMessage("Example warning text")
+                .hasLineStart(26)
+                .hasColumnStart(57);
+    }
+
     @Override
     protected MsBuildParser createParser() {
         return new MsBuildParser();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix `MSBuild` parser regression with masked `****` paths in Jenkins logs

Fixes #1476 
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
