### PR TITLE
Add parser for anchorectl image one-time-scan output

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
@@ -1,7 +1,6 @@
 package edu.hm.hafner.analysis.parser;
 
 import java.io.Serial;
-import java.util.Locale;
 import java.util.Optional;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -127,6 +126,6 @@ public class AnchoreCTLParser extends JsonIssueParser {
     }
 
     private static String cleanNone(final String value) {
-        return "none".equals(value.trim().toLowerCase(Locale.ENGLISH)) ? "" : value;
+        return value.trim().equalsIgnoreCase("none") ? "" : value;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
@@ -126,6 +126,6 @@ public class AnchoreCTLParser extends JsonIssueParser {
     }
 
     private static String cleanNone(final String value) {
-        return value.trim().equalsIgnoreCase("none") ? "" : value;
+        return equalsIgnoreCase(value.trim(), "none") ? "" : value;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
@@ -34,11 +34,15 @@ public class AnchoreCTLParser extends JsonIssueParser {
     @Override
     protected void parseJsonObject(final Report report, final JSONObject jsonReport,
             final IssueBuilder issueBuilder) {
-        extractVulnArray(jsonReport).ifPresent(vulns -> {
-            for (int i = 0; i < vulns.length(); i++) {
-                parseVuln(report, vulns.getJSONObject(i), issueBuilder);
-            }
-        });
+        extractVulnArray(jsonReport).ifPresent(vulns -> parseJsonArray(report, vulns, issueBuilder));
+    }
+
+    @Override
+    protected void parseJsonArray(final Report report, final JSONArray jsonReport,
+            final IssueBuilder issueBuilder) {
+        for (int i = 0; i < jsonReport.length(); i++) {
+            parseVuln(report, jsonReport.getJSONObject(i), issueBuilder);
+        }
     }
 
     private Optional<JSONArray> extractVulnArray(final JSONObject root) {

--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
@@ -1,9 +1,8 @@
 package edu.hm.hafner.analysis.parser;
 
 import java.io.Serial;
+import java.util.Locale;
 import java.util.Optional;
-
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -128,6 +127,6 @@ public class AnchoreCTLParser extends JsonIssueParser {
     }
 
     private static String cleanNone(final String value) {
-        return StringUtils.equalsIgnoreCase(value.trim(), "none") ? "" : value;
+        return "none".equals(value.trim().toLowerCase(Locale.ENGLISH)) ? "" : value;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
@@ -9,11 +9,6 @@ import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import j2html.tags.DomContent;
-
 import static j2html.TagCreator.*;
 
 /**
@@ -113,21 +108,13 @@ public class AnchoreCTLParser extends JsonIssueParser {
 
     private String buildDescription(final String fix, final String packageVersion,
             final boolean isKev, final boolean willNotFix, final String url, final String vulnId) {
-        List<DomContent> items = new ArrayList<>();
-        items.add(fix.isBlank() ? p(text("No fix available")) : p(join(b("Fix:"), text(" " + fix))));
-        if (!packageVersion.isBlank()) {
-            items.add(p(join(text("Affected version: "), text(packageVersion))));
-        }
-        if (isKev) {
-            items.add(p(b("CISA Known Exploited Vulnerability (KEV)")));
-        }
-        if (willNotFix) {
-            items.add(p(text("Vendor will not fix")));
-        }
-        if (!url.isBlank()) {
-            items.add(p(a(vulnId).withHref(url)));
-        }
-        return div(items.toArray(new DomContent[0])).render();
+        return join(
+                fix.isBlank() ? p(text("No fix available")) : p(join(b("Fix:"), text(" " + fix))),
+                iff(!packageVersion.isBlank(), p(join(text("Affected version: "), text(packageVersion)))),
+                iff(isKev, p(b("CISA Known Exploited Vulnerability (KEV)"))),
+                iff(willNotFix, p(text("Vendor will not fix"))),
+                iff(!url.isBlank(), p(a(vulnId).withHref(url)))
+        ).render();
     }
 
     private static Severity mapSeverity(final String severity) {

--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
@@ -1,13 +1,14 @@
 package edu.hm.hafner.analysis.parser;
 
 import java.io.Serial;
+import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import edu.hm.hafner.analysis.IssueBuilder;
 import edu.hm.hafner.analysis.Report;
-import edu.hm.hafner.analysis.Severity;
 
 import static j2html.TagCreator.*;
 
@@ -33,27 +34,25 @@ public class AnchoreCTLParser extends JsonIssueParser {
     @Override
     protected void parseJsonObject(final Report report, final JSONObject jsonReport,
             final IssueBuilder issueBuilder) {
-        var vulns = extractVulnArray(jsonReport);
-        if (vulns == null) {
-            return;
-        }
-        for (int i = 0; i < vulns.length(); i++) {
-            parseVuln(report, vulns.getJSONObject(i), issueBuilder);
-        }
+        extractVulnArray(jsonReport).ifPresent(vulns -> {
+            for (int i = 0; i < vulns.length(); i++) {
+                parseVuln(report, vulns.getJSONObject(i), issueBuilder);
+            }
+        });
     }
 
-    private JSONArray extractVulnArray(final JSONObject root) {
+    private Optional<JSONArray> extractVulnArray(final JSONObject root) {
         if (!root.has("vulnerabilities") || root.isNull("vulnerabilities")) {
-            return null;
+            return Optional.empty();
         }
         var raw = root.get("vulnerabilities");
         if (raw instanceof JSONArray array) {
-            return array;
+            return Optional.of(array);
         }
         if (raw instanceof JSONObject envelope) {
-            return envelope.optJSONArray("vulnerabilities");
+            return Optional.ofNullable(envelope.optJSONArray("vulnerabilities"));
         }
-        return null;
+        return Optional.empty();
     }
 
     private void parseVuln(final Report report, final JSONObject vuln, final IssueBuilder builder) {
@@ -73,12 +72,19 @@ public class AnchoreCTLParser extends JsonIssueParser {
                 || vuln.optBoolean("will_not_fix", false);
         var isKev = isKevFromNvdData(vuln);
 
-        var fileName = !packagePath.isBlank() ? packagePath
-                : !purl.isBlank() ? purl
-                : "-";
+        String fileName;
+        if (!packagePath.isBlank()) {
+            fileName = packagePath;
+        }
+        else if (!purl.isBlank()) {
+            fileName = purl;
+        }
+        else {
+            fileName = "-";
+        }
 
         builder.setMessage(vulnId)
-                .setSeverity(mapSeverity(vuln.optString("severity", "")))
+                .guessSeverity(vuln.optString("severity", ""))
                 .setPackageName(packageName)
                 .setCategory(packageType)
                 .setFileName(fileName)
@@ -117,16 +123,7 @@ public class AnchoreCTLParser extends JsonIssueParser {
         ).render();
     }
 
-    private static Severity mapSeverity(final String severity) {
-        return switch (severity.toLowerCase()) {
-            case "critical" -> Severity.ERROR;
-            case "high" -> Severity.WARNING_HIGH;
-            case "medium" -> Severity.WARNING_NORMAL;
-            default -> Severity.WARNING_LOW;
-        };
-    }
-
     private static String cleanNone(final String value) {
-        return "none".equalsIgnoreCase(value.trim()) ? "" : value;
+        return StringUtils.equalsIgnoreCase(value.trim(), "none") ? "" : value;
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCTLParser.java
@@ -1,0 +1,145 @@
+package edu.hm.hafner.analysis.parser;
+
+import java.io.Serial;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import j2html.tags.DomContent;
+
+import static j2html.TagCreator.*;
+
+/**
+ * JSON report parser for anchorectl image one-time-scan output.
+ *
+ * <p>Supports three output layouts produced by anchorectl:
+ * <ul>
+ *   <li>Unified output ({@code -o json IMAGE}): top-level {@code vulnerabilities} is a JSON object
+ *       envelope containing an inner {@code vulnerabilities} array.</li>
+ *   <li>Standalone file ({@code -o json --output-directory DIR}): top-level {@code vulnerabilities}
+ *       is already the array.</li>
+ *   <li>Raw snake_case output ({@code -o json-raw --output-directory DIR}): same shape as the
+ *       standalone file but field names use snake_case instead of camelCase.</li>
+ * </ul>
+ *
+ * @see <a href="https://github.com/anchore/anchorectl">anchorectl</a>
+ */
+public class AnchoreCTLParser extends JsonIssueParser {
+    @Serial
+    private static final long serialVersionUID = 3847261938475610293L;
+
+    @Override
+    protected void parseJsonObject(final Report report, final JSONObject jsonReport,
+            final IssueBuilder issueBuilder) {
+        var vulns = extractVulnArray(jsonReport);
+        if (vulns == null) {
+            return;
+        }
+        for (int i = 0; i < vulns.length(); i++) {
+            parseVuln(report, vulns.getJSONObject(i), issueBuilder);
+        }
+    }
+
+    private JSONArray extractVulnArray(final JSONObject root) {
+        if (!root.has("vulnerabilities") || root.isNull("vulnerabilities")) {
+            return null;
+        }
+        var raw = root.get("vulnerabilities");
+        if (raw instanceof JSONArray array) {
+            return array;
+        }
+        if (raw instanceof JSONObject envelope) {
+            return envelope.optJSONArray("vulnerabilities");
+        }
+        return null;
+    }
+
+    private void parseVuln(final Report report, final JSONObject vuln, final IssueBuilder builder) {
+        var vulnId = vuln.optString("vuln", "").trim();
+        if (vulnId.isBlank()) {
+            return;
+        }
+
+        var packageName = firstNonBlank(vuln, "packageName", "package_name");
+        var packageVersion = firstNonBlank(vuln, "packageVersion", "package_version");
+        var packageType = firstNonBlank(vuln, "packageType", "package_type");
+        var packagePath = firstNonBlank(vuln, "packagePath", "package_path");
+        var purl = vuln.optString("purl", "");
+        var fix = cleanNone(vuln.optString("fix", ""));
+        var url = vuln.optString("url", "");
+        var willNotFix = vuln.optBoolean("willNotFix", false)
+                || vuln.optBoolean("will_not_fix", false);
+        var isKev = isKevFromNvdData(vuln);
+
+        var fileName = !packagePath.isBlank() ? packagePath
+                : !purl.isBlank() ? purl
+                : "-";
+
+        builder.setMessage(vulnId)
+                .setSeverity(mapSeverity(vuln.optString("severity", "")))
+                .setPackageName(packageName)
+                .setCategory(packageType)
+                .setFileName(fileName)
+                .setDescription(buildDescription(fix, packageVersion, isKev, willNotFix, url, vulnId))
+                .setFingerprint(vulnId + ":" + packageName + ":" + packageVersion + ":" + packagePath);
+
+        report.add(builder.build());
+    }
+
+    private boolean isKevFromNvdData(final JSONObject vuln) {
+        var nvdData = vuln.optJSONArray("nvdData");
+        if (nvdData == null) {
+            nvdData = vuln.optJSONArray("nvd_data");
+        }
+        if (nvdData == null) {
+            return false;
+        }
+        for (int i = 0; i < nvdData.length(); i++) {
+            var entry = nvdData.optJSONObject(i);
+            if (entry != null
+                    && (entry.optBoolean("isKev", false) || entry.optBoolean("is_kev", false))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String buildDescription(final String fix, final String packageVersion,
+            final boolean isKev, final boolean willNotFix, final String url, final String vulnId) {
+        List<DomContent> items = new ArrayList<>();
+        items.add(fix.isBlank() ? p(text("No fix available")) : p(join(b("Fix:"), text(" " + fix))));
+        if (!packageVersion.isBlank()) {
+            items.add(p(join(text("Affected version: "), text(packageVersion))));
+        }
+        if (isKev) {
+            items.add(p(b("CISA Known Exploited Vulnerability (KEV)")));
+        }
+        if (willNotFix) {
+            items.add(p(text("Vendor will not fix")));
+        }
+        if (!url.isBlank()) {
+            items.add(p(a(vulnId).withHref(url)));
+        }
+        return div(items.toArray(new DomContent[0])).render();
+    }
+
+    private static Severity mapSeverity(final String severity) {
+        return switch (severity.toLowerCase()) {
+            case "critical" -> Severity.ERROR;
+            case "high" -> Severity.WARNING_HIGH;
+            case "medium" -> Severity.WARNING_NORMAL;
+            default -> Severity.WARNING_LOW;
+        };
+    }
+
+    private static String cleanNone(final String value) {
+        return "none".equalsIgnoreCase(value.trim()) ? "" : value;
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/AnchoreCTLDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AnchoreCTLDescriptor.java
@@ -39,6 +39,6 @@ class AnchoreCTLDescriptor extends ParserDescriptor {
                 text(", see"),
                 a("anchorectl documentation").withHref(getUrl()),
                 text("for usage details.")
-        );
+        ).render();
     }
 }

--- a/src/main/java/edu/hm/hafner/analysis/registry/AnchoreCTLDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AnchoreCTLDescriptor.java
@@ -1,0 +1,44 @@
+package edu.hm.hafner.analysis.registry;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.parser.AnchoreCTLParser;
+
+import static j2html.TagCreator.*;
+
+/**
+ * Descriptor for the AnchoreCTL vulnerability report parser.
+ */
+class AnchoreCTLDescriptor extends ParserDescriptor {
+    private static final String ID = "anchorectl";
+    private static final String NAME = "AnchoreCTL";
+
+    AnchoreCTLDescriptor() {
+        super(ID, NAME);
+    }
+
+    @Override
+    public IssueParser create(final Option... options) {
+        return new AnchoreCTLParser();
+    }
+
+    @Override
+    public String getPattern() {
+        return "**/*vulnerabilities*.json";
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://docs.anchore.com/current/docs/using/cli_usage/images/";
+    }
+
+    @Override
+    public String getHelp() {
+        return join(
+                text("Use commandline"),
+                code("anchorectl image one-time-scan -o json IMAGE > anchorectl-scan.json"),
+                text(", see"),
+                a("anchorectl documentation").withHref(getUrl()),
+                text("for usage details.")
+        );
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/AnchoreCtlDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/AnchoreCtlDescriptor.java
@@ -8,11 +8,11 @@ import static j2html.TagCreator.*;
 /**
  * Descriptor for the AnchoreCTL vulnerability report parser.
  */
-class AnchoreCTLDescriptor extends ParserDescriptor {
-    private static final String ID = "anchorectl";
+class AnchoreCtlDescriptor extends ParserDescriptor {
+    private static final String ID = "anchore-ctl";
     private static final String NAME = "AnchoreCTL";
 
-    AnchoreCTLDescriptor() {
+    AnchoreCtlDescriptor() {
         super(ID, NAME);
     }
 

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -37,7 +37,7 @@ public class ParserRegistry {
     private static final ParserDescriptor[] ALL_DESCRIPTORS = {
             new AcuCobolDescriptor(),
             new AjcDescriptor(),
-            new AnchoreCTLDescriptor(),
+            new AnchoreCtlDescriptor(),
             new AndroidLintDescriptor(),
             new AnsibleLintDescriptor(),
             new AnsibleLaterDescriptor(),

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -37,6 +37,7 @@ public class ParserRegistry {
     private static final ParserDescriptor[] ALL_DESCRIPTORS = {
             new AcuCobolDescriptor(),
             new AjcDescriptor(),
+            new AnchoreCTLDescriptor(),
             new AndroidLintDescriptor(),
             new AnsibleLintDescriptor(),
             new AnsibleLaterDescriptor(),

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
@@ -25,7 +25,7 @@ class AnchoreCTLParserTest extends AbstractParserTest {
                 .hasPackageName("openssl")
                 .hasCategory("rpm")
                 .hasFileName("/usr/lib64/libssl.so.1.1")
-                .hasDescription(div(
+                .hasDescription(join(
                         p(join(b("Fix:"), text(" 1.1.1l"))),
                         p(join(text("Affected version: "), text("1.1.1k"))),
                         p(a("CVE-2021-1234").withHref("https://nvd.nist.gov/vuln/detail/CVE-2021-1234"))
@@ -37,7 +37,7 @@ class AnchoreCTLParserTest extends AbstractParserTest {
                 .hasPackageName("busybox")
                 .hasCategory("APKG")
                 .hasFileName("/lib/apk/db/installed")
-                .hasDescription(div(
+                .hasDescription(join(
                         p(text("No fix available")),
                         p(join(text("Affected version: "), text("1.34.0-r0"))),
                         p(b("CISA Known Exploited Vulnerability (KEV)")),
@@ -50,7 +50,7 @@ class AnchoreCTLParserTest extends AbstractParserTest {
                 .hasPackageName("zlib")
                 .hasCategory("rpm")
                 .hasFileName("/lib64/libz.so.1")
-                .hasDescription(div(
+                .hasDescription(join(
                         p(text("No fix available")),
                         p(join(text("Affected version: "), text("1.2.11"))),
                         p(text("Vendor will not fix")),
@@ -73,16 +73,6 @@ class AnchoreCTLParserTest extends AbstractParserTest {
     }
 
     @Test
-    void shouldSkipRowWithBlankVulnId() {
-        var report = parse("anchorectl-missing-vuln-id.json");
-
-        try (var softly = new SoftAssertions()) {
-            softly.assertThat(report).hasSize(1);
-            softly.assertThat(report.get(0)).hasMessage("CVE-2021-5678");
-        }
-    }
-
-    @Test
     void shouldParseSnakeCaseJsonRawOutput() {
         var report = parse("anchorectl-report-raw.json");
 
@@ -94,7 +84,7 @@ class AnchoreCTLParserTest extends AbstractParserTest {
                     .hasPackageName("zlib")
                     .hasCategory("rpm")
                     .hasFileName("/lib64/libz.so.1")
-                    .hasDescription(div(
+                    .hasDescription(join(
                             p(join(b("Fix:"), text(" 1.2.12"))),
                             p(join(text("Affected version: "), text("1.2.11"))),
                             p(a("CVE-2022-3333").withHref("https://nvd.nist.gov/vuln/detail/CVE-2022-3333"))
@@ -103,10 +93,57 @@ class AnchoreCTLParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldSkipRowWithBlankVulnId() {
+        var report = parse("anchorectl-missing-vuln-id.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0)).hasMessage("CVE-2021-5678");
+        }
+    }
+
+    @Test
     void shouldReturnEmptyReportForEmptyArray() {
         var report = parse("anchorectl-empty.json");
         try (var softly = new SoftAssertions()) {
             softly.assertThat(report).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldReturnEmptyReportWhenVulnerabilitiesKeyAbsent() {
+        var report = parse("anchorectl-no-vuln-key.json");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldFallBackToPublUrlWhenPackagePathIsEmpty() {
+        var report = parse("anchorectl-purl-fallback.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2021-9999")
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasFileName("pkg:pypi/requests@2.26.0")
+                    .hasDescription(join(
+                            p(join(b("Fix:"), text(" 2.27.0"))),
+                            p(join(text("Affected version: "), text("2.26.0")))
+                    ).render());
+        }
+    }
+
+    @Test
+    void shouldMapNegligibleSeverityToWarningLow() {
+        var report = parse("anchorectl-negligible.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2021-1111")
+                    .hasSeverity(Severity.WARNING_LOW);
         }
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
@@ -87,6 +87,8 @@ class AnchoreCTLParserTest extends AbstractParserTest {
                     .hasDescription(join(
                             p(join(b("Fix:"), text(" 1.2.12"))),
                             p(join(text("Affected version: "), text("1.2.11"))),
+                            p(b("CISA Known Exploited Vulnerability (KEV)")),
+                            p(text("Vendor will not fix")),
                             p(a("CVE-2022-3333").withHref("https://nvd.nist.gov/vuln/detail/CVE-2022-3333"))
                     ).render());
         }
@@ -113,6 +115,22 @@ class AnchoreCTLParserTest extends AbstractParserTest {
     @Test
     void shouldReturnEmptyReportWhenVulnerabilitiesKeyAbsent() {
         var report = parse("anchorectl-no-vuln-key.json");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldReturnEmptyReportWhenVulnerabilitiesIsNull() {
+        var report = parse("anchorectl-null-vulns.json");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldReturnEmptyReportWhenEnvelopeHasNoInnerArray() {
+        var report = parse("anchorectl-empty-envelope.json");
         try (var softly = new SoftAssertions()) {
             softly.assertThat(report).isEmpty();
         }

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
@@ -147,6 +147,23 @@ class AnchoreCTLParserTest extends AbstractParserTest {
         }
     }
 
+    @Test
+    void shouldUseDashWhenPackagePathAndPurlAreBlank() {
+        var report = parse("anchorectl-no-path-no-purl.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2021-7777")
+                    .hasSeverity(Severity.WARNING_HIGH)
+                    .hasFileName("-")
+                    .hasDescription(join(
+                            p(text("No fix available")),
+                            p(join(text("Affected version: "), text("1.0.0")))
+                    ).render());
+        }
+    }
+
     @Override
     protected IssueParser createParser() {
         return new AnchoreCTLParser();

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
@@ -201,6 +201,39 @@ class AnchoreCTLParserTest extends AbstractParserTest {
         }
     }
 
+    @Test
+    void shouldReturnEmptyReportWhenVulnerabilitiesIsPrimitive() {
+        var report = parse("anchorectl-primitive-vulns.json");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldSkipNullNvdDataEntries() {
+        var report = parse("anchorectl-null-nvd-entry.json");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2021-4444")
+                    .hasSeverity(Severity.WARNING_NORMAL);
+        }
+    }
+
+    @Test
+    void shouldOmitAffectedVersionWhenPackageVersionIsBlank() {
+        var report = parse("anchorectl-blank-version.json");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2021-8888")
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasDescription(join(
+                            p(join(b("Fix:"), text(" 7.79.2-r0")))
+                    ).render());
+        }
+    }
+
     @Override
     protected IssueParser createParser() {
         return new AnchoreCTLParser();

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
@@ -7,6 +7,7 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.Severity;
 import edu.hm.hafner.analysis.assertions.SoftAssertions;
 import edu.hm.hafner.analysis.registry.AbstractParserTest;
+import edu.hm.hafner.analysis.registry.ParserRegistry;
 
 import static j2html.TagCreator.*;
 
@@ -198,6 +199,15 @@ class AnchoreCTLParserTest extends AbstractParserTest {
                             p(text("No fix available")),
                             p(join(text("Affected version: "), text("1.0.0")))
                     ).render());
+        }
+    }
+
+    @Test
+    void shouldHaveValidDescriptor() {
+        var descriptor = new ParserRegistry().get("anchore-ctl");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(descriptor.getPattern()).isEqualTo("**/*vulnerabilities*.json");
+            softly.assertThat(descriptor.getHelp()).isNotEmpty();
         }
     }
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
@@ -148,6 +148,25 @@ class AnchoreCTLParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldParseBareArrayFromImageVulnOutput() {
+        var report = parse("anchorectl-vuln-bare-array.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(2);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2024-1234")
+                    .hasSeverity(Severity.WARNING_HIGH)
+                    .hasPackageName("openssl")
+                    .hasFileName("/usr/lib/x86_64-linux-gnu/libssl.so.3");
+            softly.assertThat(report.get(1))
+                    .hasMessage("CVE-2024-5678")
+                    .hasSeverity(Severity.ERROR)
+                    .hasPackageName("zlib1g")
+                    .hasFileName("/lib/x86_64-linux-gnu/libz.so.1");
+        }
+    }
+
+    @Test
     void shouldUseDashWhenPackagePathAndPurlAreBlank() {
         var report = parse("anchorectl-no-path-no-purl.json");
 

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCTLParserTest.java
@@ -1,0 +1,117 @@
+package edu.hm.hafner.analysis.parser;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+import edu.hm.hafner.analysis.registry.AbstractParserTest;
+
+import static j2html.TagCreator.*;
+
+class AnchoreCTLParserTest extends AbstractParserTest {
+    AnchoreCTLParserTest() {
+        super("anchorectl-report.json");
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        softly.assertThat(report).hasSize(3).hasDuplicatesSize(0);
+
+        softly.assertThat(report.get(0))
+                .hasMessage("CVE-2021-1234")
+                .hasSeverity(Severity.WARNING_HIGH)
+                .hasPackageName("openssl")
+                .hasCategory("rpm")
+                .hasFileName("/usr/lib64/libssl.so.1.1")
+                .hasDescription(div(
+                        p(join(b("Fix:"), text(" 1.1.1l"))),
+                        p(join(text("Affected version: "), text("1.1.1k"))),
+                        p(a("CVE-2021-1234").withHref("https://nvd.nist.gov/vuln/detail/CVE-2021-1234"))
+                ).render());
+
+        softly.assertThat(report.get(1))
+                .hasMessage("CVE-2021-5678")
+                .hasSeverity(Severity.ERROR)
+                .hasPackageName("busybox")
+                .hasCategory("APKG")
+                .hasFileName("/lib/apk/db/installed")
+                .hasDescription(div(
+                        p(text("No fix available")),
+                        p(join(text("Affected version: "), text("1.34.0-r0"))),
+                        p(b("CISA Known Exploited Vulnerability (KEV)")),
+                        p(a("CVE-2021-5678").withHref("https://nvd.nist.gov/vuln/detail/CVE-2021-5678"))
+                ).render());
+
+        softly.assertThat(report.get(2))
+                .hasMessage("CVE-2022-9999")
+                .hasSeverity(Severity.WARNING_NORMAL)
+                .hasPackageName("zlib")
+                .hasCategory("rpm")
+                .hasFileName("/lib64/libz.so.1")
+                .hasDescription(div(
+                        p(text("No fix available")),
+                        p(join(text("Affected version: "), text("1.2.11"))),
+                        p(text("Vendor will not fix")),
+                        p(a("CVE-2022-9999").withHref("https://nvd.nist.gov/vuln/detail/CVE-2022-9999"))
+                ).render());
+    }
+
+    @Test
+    void shouldParseUnifiedEnvelopeOutput() {
+        var report = parse("anchorectl-unified-report.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2025-46394")
+                    .hasSeverity(Severity.WARNING_LOW)
+                    .hasPackageName("busybox-binsh")
+                    .hasFileName("/lib/apk/db/installed");
+        }
+    }
+
+    @Test
+    void shouldSkipRowWithBlankVulnId() {
+        var report = parse("anchorectl-missing-vuln-id.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0)).hasMessage("CVE-2021-5678");
+        }
+    }
+
+    @Test
+    void shouldParseSnakeCaseJsonRawOutput() {
+        var report = parse("anchorectl-report-raw.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(1);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2022-3333")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasPackageName("zlib")
+                    .hasCategory("rpm")
+                    .hasFileName("/lib64/libz.so.1")
+                    .hasDescription(div(
+                            p(join(b("Fix:"), text(" 1.2.12"))),
+                            p(join(text("Affected version: "), text("1.2.11"))),
+                            p(a("CVE-2022-3333").withHref("https://nvd.nist.gov/vuln/detail/CVE-2022-3333"))
+                    ).render());
+        }
+    }
+
+    @Test
+    void shouldReturnEmptyReportForEmptyArray() {
+        var report = parse("anchorectl-empty.json");
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).isEmpty();
+        }
+    }
+
+    @Override
+    protected IssueParser createParser() {
+        return new AnchoreCTLParser();
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
@@ -22,7 +22,7 @@ import static edu.hm.hafner.analysis.assertions.Assertions.*;
 class ParserRegistryTest extends ResourceTest {
     // Note for parser developers: if you add a new parser,
     // please check if you are using the correct type and increment the corresponding count
-    private static final long WARNING_PARSERS_COUNT = 148L;
+    private static final long WARNING_PARSERS_COUNT = 149L;
     private static final long BUG_PARSERS_COUNT = 3L;
     private static final long VULNERABILITY_PARSERS_COUNT = 11L;
     private static final long DUPLICATION_PARSERS_COUNT = 3L;

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-blank-version.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-blank-version.json
@@ -1,0 +1,14 @@
+{
+  "vulnerabilities": [
+    {
+      "vuln": "CVE-2021-8888",
+      "severity": "Low",
+      "packageName": "curl",
+      "packageType": "APKG",
+      "packageVersion": "",
+      "packagePath": "/lib/apk/db/installed",
+      "fix": "7.79.2-r0",
+      "url": ""
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-empty-envelope.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-empty-envelope.json
@@ -1,0 +1,3 @@
+{
+  "vulnerabilities": {}
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-empty.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-empty.json
@@ -1,0 +1,4 @@
+{
+  "sbomId": "sha256:abc123",
+  "vulnerabilities": []
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-missing-vuln-id.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-missing-vuln-id.json
@@ -1,0 +1,22 @@
+{
+  "vulnerabilities": [
+    {
+      "vuln": "",
+      "packageName": "openssl",
+      "packagePath": "/usr/lib64/libssl.so.1.1",
+      "packageType": "rpm",
+      "packageVersion": "1.1.1k",
+      "severity": "High",
+      "fix": "1.1.1l"
+    },
+    {
+      "vuln": "CVE-2021-5678",
+      "packageName": "busybox",
+      "packagePath": "/lib/apk/db/installed",
+      "packageType": "APKG",
+      "packageVersion": "1.34.0-r0",
+      "severity": "Critical",
+      "fix": "None"
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-negligible.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-negligible.json
@@ -1,0 +1,14 @@
+{
+  "vulnerabilities": [
+    {
+      "vuln": "CVE-2021-1111",
+      "severity": "Negligible",
+      "packageName": "curl",
+      "packageType": "APKG",
+      "packageVersion": "7.79.1-r0",
+      "packagePath": "/lib/apk/db/installed",
+      "fix": "None",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-1111"
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-no-path-no-purl.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-no-path-no-purl.json
@@ -1,0 +1,15 @@
+{
+  "vulnerabilities": [
+    {
+      "vuln": "CVE-2021-7777",
+      "severity": "High",
+      "packageName": "libfoo",
+      "packageType": "rpm",
+      "packageVersion": "1.0.0",
+      "packagePath": "",
+      "purl": "",
+      "fix": "none",
+      "url": ""
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-no-vuln-key.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-no-vuln-key.json
@@ -1,0 +1,4 @@
+{
+  "sbomId": "sha256:abc123",
+  "someOtherField": true
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-null-nvd-entry.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-null-nvd-entry.json
@@ -1,0 +1,15 @@
+{
+  "vulnerabilities": [
+    {
+      "vuln": "CVE-2021-4444",
+      "severity": "Medium",
+      "packageName": "curl",
+      "packageType": "APKG",
+      "packageVersion": "7.79.1-r0",
+      "packagePath": "/lib/apk/db/installed",
+      "fix": "None",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-4444",
+      "nvdData": [null]
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-null-vulns.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-null-vulns.json
@@ -1,0 +1,4 @@
+{
+  "sbomId": "sha256:abc123",
+  "vulnerabilities": null
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-primitive-vulns.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-primitive-vulns.json
@@ -1,0 +1,3 @@
+{
+  "vulnerabilities": 42
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-purl-fallback.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-purl-fallback.json
@@ -1,0 +1,15 @@
+{
+  "vulnerabilities": [
+    {
+      "vuln": "CVE-2021-9999",
+      "severity": "Low",
+      "packageName": "requests",
+      "packageType": "pypi",
+      "packageVersion": "2.26.0",
+      "packagePath": "",
+      "purl": "pkg:pypi/requests@2.26.0",
+      "fix": "2.27.0",
+      "url": ""
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-report-raw.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-report-raw.json
@@ -1,0 +1,24 @@
+{
+  "sbom_id": "sha256:abc123def456",
+  "extended_support": false,
+  "vulnerabilities": [
+    {
+      "vuln": "CVE-2022-3333",
+      "severity": "Medium",
+      "package_name": "zlib",
+      "package_type": "rpm",
+      "package_version": "1.2.11",
+      "package_path": "/lib64/libz.so.1",
+      "purl": "pkg:rpm/rhel/zlib@1.2.11",
+      "fix": "1.2.12",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3333",
+      "will_not_fix": false,
+      "nvd_data": [
+        {
+          "id": "CVE-2022-3333",
+          "is_kev": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-report-raw.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-report-raw.json
@@ -12,11 +12,11 @@
       "purl": "pkg:rpm/rhel/zlib@1.2.11",
       "fix": "1.2.12",
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-3333",
-      "will_not_fix": false,
+      "will_not_fix": true,
       "nvd_data": [
         {
           "id": "CVE-2022-3333",
-          "is_kev": false
+          "is_kev": true
         }
       ]
     }

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-report.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-report.json
@@ -1,0 +1,68 @@
+{
+  "extendedSupport": false,
+  "sbomId": "sha256:abc123def456",
+  "vulnerabilities": [
+    {
+      "detectedAt": "2026-04-01T00:00:00Z",
+      "feed": "vulnerabilities",
+      "feedGroup": "nvd",
+      "fix": "1.1.1l",
+      "nvdData": [
+        {
+          "cvssV3": { "baseScore": 7.5 },
+          "id": "CVE-2021-1234",
+          "isKev": false,
+          "source": "nvd@nist.gov"
+        }
+      ],
+      "packageName": "openssl",
+      "packagePath": "/usr/lib64/libssl.so.1.1",
+      "packageType": "rpm",
+      "packageVersion": "1.1.1k",
+      "purl": "pkg:rpm/rhel/openssl@1.1.1k",
+      "severity": "High",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-1234",
+      "vuln": "CVE-2021-1234",
+      "willNotFix": false
+    },
+    {
+      "detectedAt": "2026-04-01T00:00:00Z",
+      "feed": "vulnerabilities",
+      "feedGroup": "nvd",
+      "fix": "None",
+      "nvdData": [
+        {
+          "cvssV3": { "baseScore": 9.8 },
+          "id": "CVE-2021-5678",
+          "isKev": true,
+          "source": "nvd@nist.gov"
+        }
+      ],
+      "packageName": "busybox",
+      "packagePath": "/lib/apk/db/installed",
+      "packageType": "APKG",
+      "packageVersion": "1.34.0-r0",
+      "purl": "pkg:apk/alpine/busybox@1.34.0-r0",
+      "severity": "Critical",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-5678",
+      "vuln": "CVE-2021-5678",
+      "willNotFix": false
+    },
+    {
+      "detectedAt": "2026-04-01T00:00:00Z",
+      "feed": "vulnerabilities",
+      "feedGroup": "nvd",
+      "fix": "None",
+      "nvdData": [],
+      "packageName": "zlib",
+      "packagePath": "/lib64/libz.so.1",
+      "packageType": "rpm",
+      "packageVersion": "1.2.11",
+      "purl": "pkg:rpm/rhel/zlib@1.2.11",
+      "severity": "Medium",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-9999",
+      "vuln": "CVE-2022-9999",
+      "willNotFix": true
+    }
+  ]
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-unified-report.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-unified-report.json
@@ -1,0 +1,23 @@
+{
+  "sbom": {},
+  "policyEvaluation": {},
+  "vulnerabilities": {
+    "sbomId": "sha256:abc123",
+    "extendedSupport": false,
+    "vulnerabilities": [
+      {
+        "fix": "None",
+        "nvdData": [{ "isKev": true }],
+        "packageName": "busybox-binsh",
+        "packagePath": "/lib/apk/db/installed",
+        "packageType": "APKG",
+        "packageVersion": "1.35.0-r17",
+        "purl": "pkg:apk/alpine/busybox-binsh@1.35.0-r17",
+        "severity": "Low",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-46394",
+        "vuln": "CVE-2025-46394",
+        "willNotFix": false
+      }
+    ]
+  }
+}

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-vuln-bare-array.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-vuln-bare-array.json
@@ -1,0 +1,28 @@
+[
+  {
+    "vuln": "CVE-2024-1234",
+    "severity": "High",
+    "packageName": "openssl",
+    "packageType": "dpkg",
+    "packageVersion": "3.0.2-0ubuntu1.18",
+    "packagePath": "/usr/lib/x86_64-linux-gnu/libssl.so.3",
+    "purl": "pkg:deb/ubuntu/openssl@3.0.2-0ubuntu1.18",
+    "fix": "3.0.2-0ubuntu1.19",
+    "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1234",
+    "willNotFix": false,
+    "nvdData": []
+  },
+  {
+    "vuln": "CVE-2024-5678",
+    "severity": "Critical",
+    "packageName": "zlib1g",
+    "packageType": "dpkg",
+    "packageVersion": "1:1.2.11.dfsg-2ubuntu9.2",
+    "packagePath": "/lib/x86_64-linux-gnu/libz.so.1",
+    "purl": "",
+    "fix": "None",
+    "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-5678",
+    "willNotFix": false,
+    "nvdData": []
+  }
+]


### PR DESCRIPTION
## Summary

Adds `AnchoreCTLParser` and `AnchoreCTLDescriptor` to support JSON vulnerability reports produced by `anchorectl image one-time-scan` from Anchore Enterprise.

### Supported output formats

| Command | Format | Field style |
|---|---|---|
| `anchorectl image one-time-scan -o json IMAGE` | Unified envelope (`sbom` + `policyEvaluation` + `vulnerabilities` object wrapping inner array) | camelCase |
| `anchorectl image one-time-scan -o json --output-directory DIR IMAGE` | Standalone `*_vulnerabilities.json` | camelCase |
| `anchorectl image one-time-scan -o json-raw --output-directory DIR IMAGE` | Standalone `*_vulnerabilities.json` | snake_case |

All three are handled transparently without configuration.

### Parser behaviour

- **Format detection** — if top-level `vulnerabilities` is a JSON object (unified output), drills one level deeper; if it is already an array, uses it directly
- **Dual field reading** — every field is read with a camelCase primary key and a snake_case fallback (`packageName` / `package_name`, etc.)
- **Severity mapping** — `Critical → ERROR`, `High → WARNING_HIGH`, `Medium → WARNING_NORMAL`, `Low / Negligible / other → WARNING_LOW`
- **Description** — fix version (or "No fix available"), affected package version, CISA KEV badge when `nvdData[].isKev` / `nvd_data[].is_kev` is true, vendor-will-not-fix notice, linked CVE URL
- **File name** — `packagePath` / `package_path`; falls back to `purl` for language ecosystem packages
- **Fingerprint** — `vuln:packageName:packageVersion:packagePath` for stable trend/delta tracking
- Rows with a blank `vuln` field are silently skipped

### Test coverage

5 test methods covering both formats, all severity levels, KEV badge, will-not-fix, purl fallback, missing vuln ID skip, and empty array.

Parser logic was validated against real `anchorectl image one-time-scan` output from a live Anchore Enterprise 5.27 deployment for both `-o json` and `-o json-raw`.

### Related

- [jenkinsci/warnings-ng-plugin#1563](https://github.com/jenkinsci/warnings-ng-plugin/pull/1563) — Grype parser (reference implementation followed)
- [anchore/anchorectl](https://docs.anchore.com/current/docs/using/cli_usage/images/)