### PR TITLE
Add a parser for `Black` (Python code formatter) output

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/BlackParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/BlackParser.java
@@ -34,8 +34,7 @@ public class BlackParser extends LookaheadParser {
 
     @Override
     protected boolean isLineInteresting(final String line) {
-        return line.startsWith("error: cannot format") || line.startsWith("would reformat")
-                || line.startsWith("reformatted");
+        return line.contains("format");
     }
 
     @Override

--- a/src/main/java/edu/hm/hafner/analysis/parser/BlackParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/BlackParser.java
@@ -1,0 +1,65 @@
+package edu.hm.hafner.analysis.parser;
+
+import java.io.Serial;
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+import edu.hm.hafner.analysis.Issue;
+import edu.hm.hafner.analysis.IssueBuilder;
+import edu.hm.hafner.analysis.LookaheadParser;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.util.LookaheadStream;
+
+/**
+ * A parser for Black (Python code formatter) output.
+ *
+ * @author Akash Manna
+ * @see <a href="https://black.readthedocs.io/">Black documentation</a>
+ * @see <a href="https://github.com/psf/black">Black on GitHub</a>
+ */
+public class BlackParser extends LookaheadParser {
+    @Serial
+    private static final long serialVersionUID = -8266015919240804585L;
+
+    private static final String BLACK_WARNING_PATTERN =
+            "(?:error: cannot format (?<file>.+): Cannot parse: (?<line>\\d+):(?<col>\\d+): (?<msg>.+)"
+            + "|(?<action>would reformat|reformatted) (?<rfile>.+))";
+
+    /**
+     * Creates a new instance of {@link BlackParser}.
+     */
+    public BlackParser() {
+        super(BLACK_WARNING_PATTERN);
+    }
+
+    @Override
+    protected boolean isLineInteresting(final String line) {
+        return line.startsWith("error: cannot format") || line.startsWith("would reformat")
+                || line.startsWith("reformatted");
+    }
+
+    @Override
+    protected Optional<Issue> createIssue(final Matcher matcher, final LookaheadStream lookahead,
+            final IssueBuilder builder) {
+        if (matcher.group("file") != null) {
+            return builder
+                    .setFileName(matcher.group("file"))
+                    .setLineStart(matcher.group("line"))
+                    .setColumnStart(matcher.group("col"))
+                    .setMessage(matcher.group("msg"))
+                    .setCategory("syntax-error")
+                    .setSeverity(Severity.ERROR)
+                    .buildOptional();
+        }
+        else {
+            var action = matcher.group("action");
+            var fileName = matcher.group("rfile");
+            return builder
+                    .setFileName(fileName)
+                    .setMessage("\"" + fileName + "\" " + action + " by black")
+                    .setCategory("formatting")
+                    .setSeverity(Severity.WARNING_NORMAL)
+                    .buildOptional();
+        }
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/BlackDescriptor.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/BlackDescriptor.java
@@ -1,0 +1,50 @@
+package edu.hm.hafner.analysis.registry;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.Report.IssueType;
+import edu.hm.hafner.analysis.parser.BlackParser;
+
+/**
+ * A descriptor for Black Python code formatter reports.
+ *
+ * @author Akash Manna
+ */
+class BlackDescriptor extends ParserDescriptor {
+    private static final String ID = "black";
+    private static final String NAME = "Black";
+
+    BlackDescriptor() {
+        super(ID, NAME);
+    }
+
+    @Override
+    public IssueType getType() {
+        return IssueType.WARNING;
+    }
+
+    @Override
+    public IssueParser create(final Option... options) {
+        return new BlackParser();
+    }
+
+    @Override
+    public String getPattern() {
+        return "**/black-report.txt";
+    }
+
+    @Override
+    public String getHelp() {
+        return "Use commandline <code>black --check . 2&gt;&amp;1 | tee black-report.txt</code> to capture output.<br/>"
+                + "See <a href='https://black.readthedocs.io/'>Black documentation</a> for usage details.";
+    }
+
+    @Override
+    public String getUrl() {
+        return "https://github.com/psf/black";
+    }
+
+    @Override
+    public String getIconUrl() {
+        return "https://raw.githubusercontent.com/psf/black/main/docs/_static/logo2-readme.png";
+    }
+}

--- a/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
+++ b/src/main/java/edu/hm/hafner/analysis/registry/ParserRegistry.java
@@ -44,6 +44,7 @@ public class ParserRegistry {
             new AquaScannerDescriptor(),
             new ArmccCompilerDescriptor(),
             new BanditDescriptor(),
+            new BlackDescriptor(),
             new BluePearlDescriptor(),
             new BrakemanDescriptor(),
             new BuckminsterDescriptor(),

--- a/src/test/java/edu/hm/hafner/analysis/parser/BlackParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/BlackParserTest.java
@@ -1,0 +1,173 @@
+package edu.hm.hafner.analysis.parser;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.analysis.IssueParser;
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.analysis.Severity;
+import edu.hm.hafner.analysis.assertions.SoftAssertions;
+import edu.hm.hafner.analysis.registry.AbstractParserTest;
+import edu.hm.hafner.analysis.registry.ParserRegistry;
+
+import static edu.hm.hafner.analysis.assertions.Assertions.*;
+
+/**
+ * Tests the class {@link BlackParser}.
+ *
+ * @author Akash Manna
+ */
+class BlackParserTest extends AbstractParserTest {
+    BlackParserTest() {
+        super("black-report.txt");
+    }
+
+    @Override
+    protected void assertThatIssuesArePresent(final Report report, final SoftAssertions softly) {
+        assertThat(report).hasSize(5);
+        assertThatReportHasSeverities(report, 2, 0, 3, 0);
+
+        // First issue: syntax error in src/main.py
+        softly.assertThat(report.get(0))
+                .hasFileName("src/main.py")
+                .hasLineStart(5)
+                .hasColumnStart(1)
+                .hasMessage("invalid syntax")
+                .hasCategory("syntax-error")
+                .hasSeverity(Severity.ERROR);
+
+        // Second issue: syntax error in tests/test_utils.py
+        softly.assertThat(report.get(1))
+                .hasFileName("tests/test_utils.py")
+                .hasLineStart(12)
+                .hasColumnStart(5)
+                .hasMessage("expected an indented block after function definition on line 11")
+                .hasCategory("syntax-error")
+                .hasSeverity(Severity.ERROR);
+
+        // Third issue: would reformat src/utils.py
+        softly.assertThat(report.get(2))
+                .hasFileName("src/utils.py")
+                .hasMessage("\"src/utils.py\" would reformat by black")
+                .hasCategory("formatting")
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        // Fourth issue: would reformat src/models.py
+        softly.assertThat(report.get(3))
+                .hasFileName("src/models.py")
+                .hasMessage("\"src/models.py\" would reformat by black")
+                .hasCategory("formatting")
+                .hasSeverity(Severity.WARNING_NORMAL);
+
+        // Fifth issue: reformatted src/config.py
+        softly.assertThat(report.get(4))
+                .hasFileName("src/config.py")
+                .hasMessage("\"src/config.py\" reformatted by black")
+                .hasCategory("formatting")
+                .hasSeverity(Severity.WARNING_NORMAL);
+    }
+
+    @Override
+    protected IssueParser createParser() {
+        return new BlackParser();
+    }
+
+    /** Verifies that a report with no issues produces an empty result. */
+    @Test
+    void shouldHandleNoIssues() {
+        var report = parse("black-report-no-issues.txt");
+
+        assertThat(report).isEmpty();
+    }
+
+    /** Verifies that an empty input produces an empty result. */
+    @Test
+    void shouldHandleEmptyInput() {
+        var report = parseStringContent("");
+
+        assertThat(report).isEmpty();
+    }
+
+    /** Verifies parsing of a single syntax error from inline content. */
+    @Test
+    void shouldParseSingleSyntaxError() {
+        var report = parseStringContent(
+                "error: cannot format app.py: Cannot parse: 10:3: invalid syntax\n");
+
+        assertThat(report).hasSize(1);
+        assertThat(report.get(0))
+                .hasFileName("app.py")
+                .hasLineStart(10)
+                .hasColumnStart(3)
+                .hasMessage("invalid syntax")
+                .hasCategory("syntax-error")
+                .hasSeverity(Severity.ERROR);
+    }
+
+    /** Verifies parsing of a "would reformat" line from inline content. */
+    @Test
+    void shouldParseWouldReformatNotice() {
+        var report = parseStringContent("would reformat my_module.py\n");
+
+        assertThat(report).hasSize(1);
+        assertThat(report.get(0))
+                .hasFileName("my_module.py")
+                .hasMessage("\"my_module.py\" would reformat by black")
+                .hasCategory("formatting")
+                .hasSeverity(Severity.WARNING_NORMAL);
+    }
+
+    /** Verifies parsing of a "reformatted" line from inline content. */
+    @Test
+    void shouldParseReformattedNotice() {
+        var report = parseStringContent("reformatted path/to/file.py\n");
+
+        assertThat(report).hasSize(1);
+        assertThat(report.get(0))
+                .hasFileName("path/to/file.py")
+                .hasMessage("\"path/to/file.py\" reformatted by black")
+                .hasCategory("formatting")
+                .hasSeverity(Severity.WARNING_NORMAL);
+    }
+
+    /** Verifies that summary and emoji lines are ignored (not parsed). */
+    @Test
+    void shouldIgnoreSummaryLines() {
+        var report = parseStringContent(
+                """
+                Oh no!
+                💥 💔 💥
+                2 files would be reformatted, 1 file would be left unchanged.
+                All done! ✨ 🍰 ✨
+                """);
+
+        assertThat(report).isEmpty();
+    }
+
+    /** Verifies handling of file paths with spaces and nested directories. */
+    @Test
+    void shouldHandleNestedPathWithSyntaxError() {
+        var report = parseStringContent(
+                "error: cannot format src/sub/module.py: Cannot parse: 42:10: unexpected EOF while parsing\n");
+
+        assertThat(report).hasSize(1);
+        assertThat(report.get(0))
+                .hasFileName("src/sub/module.py")
+                .hasLineStart(42)
+                .hasColumnStart(10)
+                .hasMessage("unexpected EOF while parsing")
+                .hasCategory("syntax-error")
+                .hasSeverity(Severity.ERROR);
+    }
+
+    /** Verifies that the descriptor metadata is correctly registered. */
+    @Test
+    void shouldProvideDescriptorMetadata() {
+        var descriptor = new ParserRegistry().get("black");
+
+        assertThat(descriptor.getPattern()).isEqualTo("**/black-report.txt");
+        assertThat(descriptor.getHelp()).contains("black --check");
+        assertThat(descriptor.getUrl()).isEqualTo("https://github.com/psf/black");
+        assertThat(descriptor.hasHelp()).isTrue();
+        assertThat(descriptor.hasUrl()).isTrue();
+    }
+}

--- a/src/test/java/edu/hm/hafner/analysis/parser/BlackParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/BlackParserTest.java
@@ -167,6 +167,7 @@ class BlackParserTest extends AbstractParserTest {
         assertThat(descriptor.getPattern()).isEqualTo("**/black-report.txt");
         assertThat(descriptor.getHelp()).contains("black --check");
         assertThat(descriptor.getUrl()).isEqualTo("https://github.com/psf/black");
+        assertThat(descriptor.getIconUrl()).isEqualTo("https://raw.githubusercontent.com/psf/black/main/docs/_static/logo2-readme.png");
         assertThat(descriptor.hasHelp()).isTrue();
         assertThat(descriptor.hasUrl()).isTrue();
     }

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParserRegistryTest.java
@@ -22,7 +22,7 @@ import static edu.hm.hafner.analysis.assertions.Assertions.*;
 class ParserRegistryTest extends ResourceTest {
     // Note for parser developers: if you add a new parser,
     // please check if you are using the correct type and increment the corresponding count
-    private static final long WARNING_PARSERS_COUNT = 156L;
+    private static final long WARNING_PARSERS_COUNT = 157L;
     private static final long BUG_PARSERS_COUNT = 3L;
     private static final long VULNERABILITY_PARSERS_COUNT = 21L;
     private static final long DUPLICATION_PARSERS_COUNT = 3L;
@@ -77,6 +77,10 @@ class ParserRegistryTest extends ResourceTest {
         assertThat(parserRegistry.get("swagger-lint"))
                 .hasId("swagger-lint")
                 .hasName("Swagger Lint")
+                .hasType(IssueType.WARNING);
+        assertThat(parserRegistry.get("black"))
+                .hasId("black")
+                .hasName("Black")
                 .hasType(IssueType.WARNING);
         assertThat(parserRegistry.contains(SPOTBUGS)).isTrue();
         assertThat(parserRegistry.contains("nothing")).isFalse();

--- a/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/registry/ParsersTest.java
@@ -907,6 +907,12 @@ class ParsersTest extends ResourceTest {
         findIssuesOfTool(6, "ruff", "ruff.json");
     }
 
+    /** Runs the Black parser on an output file that contains 5 issues. */
+    @Test
+    void shouldFindAllBlackIssues() {
+        findIssuesOfTool(5, "black", "black-report.txt");
+    }
+
     /** Runs the MarkdownLint parser on an output file that contains 4 issues. */
     @Test
     void shouldFindAllMarkdownLintIssues() {

--- a/src/test/resources/edu/hm/hafner/analysis/parser/black-report-no-issues.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/black-report-no-issues.txt
@@ -1,0 +1,2 @@
+All done! ✨ 🍰 ✨
+5 files left unchanged.

--- a/src/test/resources/edu/hm/hafner/analysis/parser/black-report.txt
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/black-report.txt
@@ -1,0 +1,8 @@
+error: cannot format src/main.py: Cannot parse: 5:1: invalid syntax
+error: cannot format tests/test_utils.py: Cannot parse: 12:5: expected an indented block after function definition on line 11
+would reformat src/utils.py
+would reformat src/models.py
+reformatted src/config.py
+Oh no!
+💥 💔 💥
+2 files would be reformatted, 1 file would be left unchanged, 2 files would fail to reformat.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Add a parser for `Black` `(Python code formatter)` output

See : https://black.readthedocs.io/en/stable/
See : https://github.com/psf/black
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
