### PR TITLE
Support anchorectl app version vuln list output in AnchoreCtlParser

### DIFF
--- a/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCtlParser.java
+++ b/src/main/java/edu/hm/hafner/analysis/parser/AnchoreCtlParser.java
@@ -12,16 +12,22 @@ import java.util.Optional;
 import static j2html.TagCreator.*;
 
 /**
- * JSON report parser for anchorectl image one-time-scan output.
+ * JSON report parser for anchorectl vulnerability output.
  *
- * <p>Supports three output layouts produced by anchorectl:
+ * <p>Supports the output layouts produced by anchorectl:
  * <ul>
- *   <li>Unified output ({@code -o json IMAGE}): top-level {@code vulnerabilities} is a JSON object
- *       envelope containing an inner {@code vulnerabilities} array.</li>
- *   <li>Standalone file ({@code -o json --output-directory DIR}): top-level {@code vulnerabilities}
- *       is already the array.</li>
- *   <li>Raw snake_case output ({@code -o json-raw --output-directory DIR}): same shape as the
- *       standalone file but field names use snake_case instead of camelCase.</li>
+ *   <li>Unified output ({@code image one-time-scan -o json IMAGE}): top-level {@code vulnerabilities}
+ *       is a JSON object envelope containing an inner {@code vulnerabilities} array.</li>
+ *   <li>Standalone file ({@code image one-time-scan -o json --output-directory DIR}): top-level
+ *       {@code vulnerabilities} is already the array.</li>
+ *   <li>Raw snake_case output ({@code image one-time-scan -o json-raw --output-directory DIR}): same
+ *       shape as the standalone file but field names use snake_case instead of camelCase.</li>
+ *   <li>Bare array ({@code image vuln -o json}): the top-level JSON value is itself the array of
+ *       vulnerability objects, camelCase or snake_case.</li>
+ *   <li>App/BYOS-SBOM feature ({@code app version vuln list -o json[-raw]}): a bare array with a
+ *       distinct field vocabulary ({@code vulnerabilityId}/{@code vulnerability_id} instead of
+ *       {@code vuln}, {@code fixState}/{@code fix_state} plus {@code fixVersions}/{@code fix_versions}
+ *       instead of {@code fix}, a top-level {@code kev} boolean instead of {@code nvdData[].isKev}).</li>
  * </ul>
  *
  * @see <a href="https://github.com/anchore/anchorectl">anchorectl</a>
@@ -59,7 +65,9 @@ public class AnchoreCtlParser extends JsonIssueParser {
     }
 
     private void parseVulnerability(final Report report, final JSONObject vulnerability, final IssueBuilder builder) {
-        var vulnerabilityId = vulnerability.optString("vuln", "").trim();
+        // "vuln" on the image-scan endpoints; "vulnerabilityId"/"vulnerability_id" on the
+        // App/BYOS-SBOM endpoint (anchorectl app version vuln list).
+        var vulnerabilityId = firstNonBlank(vulnerability, "vuln", "vulnerabilityId", "vulnerability_id").trim();
         if (vulnerabilityId.isBlank()) {
             return;
         }
@@ -68,9 +76,16 @@ public class AnchoreCtlParser extends JsonIssueParser {
         var purl = vulnerability.optString("purl", "");
 
         var fix = cleanNone(vulnerability.optString("fix", ""));
+        if (fix.isBlank()) {
+            fix = firstFixVersion(vulnerability);
+        }
         var url = vulnerability.optString("url", "");
-        var willNotFix = vulnerability.optBoolean("willNotFix") || vulnerability.optBoolean("will_not_fix");
-        var isKev = isKevFromNvdData(vulnerability);
+        var fixState = firstNonBlank(vulnerability, "fixState", "fix_state");
+        var willNotFix = vulnerability.optBoolean("willNotFix") || vulnerability.optBoolean("will_not_fix")
+                || equalsIgnoreCase(fixState, "wont_fix");
+        // Image-scan endpoints: isKev lives inside nvdData[].isKev / nvd_data[].is_kev.
+        // App/BYOS-SBOM endpoint: top-level "kev" boolean.
+        var isKev = vulnerability.optBoolean("kev") || isKevFromNvdData(vulnerability);
 
         var packageVersion = firstNonBlank(vulnerability, "packageVersion", "package_version");
         builder.setMessage(vulnerabilityId)
@@ -82,6 +97,17 @@ public class AnchoreCtlParser extends JsonIssueParser {
                 .setFingerprint(vulnerabilityId + ":" + firstNonBlank(vulnerability, "packageName", "package_name") + ":" + packageVersion + ":" + packagePath);
 
         report.add(builder.build());
+    }
+
+    private String firstFixVersion(final JSONObject vulnerability) {
+        var fixVersions = vulnerability.optJSONArray("fixVersions");
+        if (fixVersions == null) {
+            fixVersions = vulnerability.optJSONArray("fix_versions");
+        }
+        if (fixVersions == null || fixVersions.isEmpty()) {
+            return "";
+        }
+        return cleanNone(fixVersions.optString(0, ""));
     }
 
     private String extractFileName(final String packagePath, final String purl) {

--- a/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCtlParserTest.java
+++ b/src/test/java/edu/hm/hafner/analysis/parser/AnchoreCtlParserTest.java
@@ -203,6 +203,62 @@ class AnchoreCtlParserTest extends AbstractParserTest {
     }
 
     @Test
+    void shouldParseAppVulnListCamelCase() {
+        var report = parse("anchorectl-app-vuln-list.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(2);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2026-8927")
+                    .hasSeverity(Severity.ERROR)
+                    .hasPackageName("libcurl4t64")
+                    .hasCategory("deb")
+                    .hasFileName("pkg:deb/debian/libcurl4t64@8.14.1-2%2Bdeb13u4?arch=amd64&distro=debian-13&upstream=curl")
+                    .hasDescription(join(
+                            p(text("No fix available")),
+                            p(join(text("Affected version: "), text("8.14.1-2+deb13u4"))),
+                            p(text("Vendor will not fix"))
+                    ).render());
+            softly.assertThat(report.get(1))
+                    .hasMessage("CVE-2026-42533")
+                    .hasSeverity(Severity.WARNING_HIGH)
+                    .hasPackageName("nginx")
+                    .hasDescription(join(
+                            p(join(b("Fix:"), text(" 1.31.4-1~trixie"))),
+                            p(join(text("Affected version: "), text("1.31.3-1~trixie"))),
+                            p(b("CISA Known Exploited Vulnerability (KEV)"))
+                    ).render());
+        }
+    }
+
+    @Test
+    void shouldParseAppVulnListSnakeCase() {
+        var report = parse("anchorectl-app-vuln-list-raw.json");
+
+        try (var softly = new SoftAssertions()) {
+            softly.assertThat(report).hasSize(2);
+            softly.assertThat(report.get(0))
+                    .hasMessage("CVE-2025-60876")
+                    .hasSeverity(Severity.WARNING_NORMAL)
+                    .hasPackageName("ssl_client")
+                    .hasCategory("apk")
+                    .hasDescription(join(
+                            p(text("No fix available")),
+                            p(join(text("Affected version: "), text("1.36.1-r31")))
+                    ).render());
+            softly.assertThat(report.get(1))
+                    .hasMessage("CVE-2026-8376")
+                    .hasSeverity(Severity.ERROR)
+                    .hasPackageName("perl-base")
+                    .hasDescription(join(
+                            p(text("No fix available")),
+                            p(join(text("Affected version: "), text("5.40.1-6"))),
+                            p(text("Vendor will not fix"))
+                    ).render());
+        }
+    }
+
+    @Test
     void shouldHaveValidDescriptor() {
         var descriptor = new ParserRegistry().get("anchore-ctl");
         try (var softly = new SoftAssertions()) {

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-app-vuln-list-raw.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-app-vuln-list-raw.json
@@ -1,0 +1,24 @@
+[
+  {
+    "vulnerability_id": "CVE-2025-60876",
+    "severity": "medium",
+    "package_name": "ssl_client",
+    "package_version": "1.36.1-r31",
+    "package_type": "apk",
+    "purl": "pkg:apk/alpine/ssl_client@1.36.1-r31?arch=x86_64&distro=alpine-3.20.10&upstream=busybox",
+    "fix_state": "unknown",
+    "fix_versions": [],
+    "kev": false
+  },
+  {
+    "vulnerability_id": "CVE-2026-8376",
+    "severity": "critical",
+    "package_name": "perl-base",
+    "package_version": "5.40.1-6",
+    "package_type": "deb",
+    "purl": "pkg:deb/debian/perl-base@5.40.1-6",
+    "fix_state": "wont_fix",
+    "fix_versions": [],
+    "kev": false
+  }
+]

--- a/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-app-vuln-list.json
+++ b/src/test/resources/edu/hm/hafner/analysis/parser/anchorectl-app-vuln-list.json
@@ -1,0 +1,24 @@
+[
+  {
+    "vulnerabilityId": "CVE-2026-8927",
+    "severity": "critical",
+    "packageName": "libcurl4t64",
+    "packageVersion": "8.14.1-2+deb13u4",
+    "packageType": "deb",
+    "purl": "pkg:deb/debian/libcurl4t64@8.14.1-2%2Bdeb13u4?arch=amd64&distro=debian-13&upstream=curl",
+    "fixState": "wont_fix",
+    "fixVersions": [],
+    "kev": false
+  },
+  {
+    "vulnerabilityId": "CVE-2026-42533",
+    "severity": "high",
+    "packageName": "nginx",
+    "packageVersion": "1.31.3-1~trixie",
+    "packageType": "deb",
+    "purl": "pkg:deb/debian/nginx@1.31.3-1~trixie",
+    "fixState": "not_fixed",
+    "fixVersions": ["1.31.4-1~trixie"],
+    "kev": true
+  }
+]


### PR DESCRIPTION
## Summary

Extends `AnchoreCtlParser` (added in #1511) to also support `anchorectl app version vuln list`, the vulnerability-listing endpoint for Anchore Enterprise 6's App/BYOS-SBOM feature. This endpoint uses a different field vocabulary than the image-scan endpoints the parser already supports:

| Concept | Image-scan endpoints | App/BYOS-SBOM endpoint |
|---|---|---|
| Vulnerability ID | `vuln` | `vulnerabilityId` / `vulnerability_id` |
| Fix info | `fix` (version string or "None") | `fixState`/`fix_state` ("wont_fix", "not_fixed", ...) + `fixVersions`/`fix_versions` array |
| KEV flag | `nvdData[].isKev` / `nvd_data[].is_kev` | top-level `kev` boolean |

Both are bare top-level JSON arrays, so no change was needed to the array/object dispatch logic added for `anchorectl image vuln` bare-array output.

All new field lookups are fallbacks: the image-scan field names are always checked first, so existing output layouts (unified envelope, standalone file, snake_case raw, bare array) are unaffected. Ran the full existing `AnchoreCtlParserTest` suite plus the project's full test suite (2099 tests) with no failures.

## Test plan

- [x] All existing `AnchoreCtlParserTest` cases pass unchanged (image-scan formats unaffected)
- [x] New `shouldParseAppVulnListCamelCase` / `shouldParseAppVulnListSnakeCase` tests cover the App/BYOS-SBOM format, including will-not-fix, has-fix-version, and KEV cases
- [x] Full project test suite (`mvn test`) passes: 2099 tests, 0 failures, 0 errors